### PR TITLE
missing import in Yesod/Helpers/Static.hs

### DIFF
--- a/Yesod/Helpers/Static.hs
+++ b/Yesod/Helpers/Static.hs
@@ -44,6 +44,7 @@ import Data.Maybe (fromMaybe)
 
 import Yesod hiding (lift)
 import Data.List (intercalate)
+import Language.Haskell.TH
 import Language.Haskell.TH.Syntax
 import Web.Routes
 


### PR DESCRIPTION
added import for Language.Haskell.TH in Yesod/Helpers/Static.hs
