### PR TITLE
Enabling wai-handler-devel again in Yesod for GHC 7 now that hint has been ported.

### DIFF
--- a/Yesod.hs
+++ b/Yesod.hs
@@ -62,7 +62,7 @@ import Yesod.Json
 import Yesod.Persist
 import Network.Wai (Application)
 import Network.Wai.Middleware.Debug
-#if !GHC7 && !PRODUCTION
+#if !PRODUCTION
 import Network.Wai.Handler.DevelServer (runQuit)
 #endif
 import Control.Monad.Trans.Class (lift)
@@ -106,9 +106,7 @@ develServer :: Int -- ^ port number
             -> String -- ^ module name holding the code
             -> String -- ^ name of function providing a with-application
             -> IO ()
-#if GHC7
-develServer = error "Unfortunately, the hint package has not yet been ported to GHC 7, and therefore wai-handler-devel has not either. Once this situation is addressed, a new version of Yesod will be released."
-#else
+
 develServer port modu func = do
     mapM_ putStrLn
         [ "Starting your server process. Code changes will be automatically"
@@ -117,7 +115,7 @@ develServer port modu func = do
         , ""
         ]
     runQuit port modu func determineHamletDeps
-#endif
+
 #endif
 
 data TempType = Hamlet | Cassius | Julius | Widget

--- a/yesod.cabal
+++ b/yesod.cabal
@@ -23,15 +23,15 @@ flag production
     Default:     False
 
 library
+    if flag(production)
+        cpp-options: -DPRODUCTION
+    else
+        build-depends: wai-handler-devel   >= 0.2      && < 0.3
     if flag(ghc7)
         build-depends:   base                  >= 4.3      && < 5
         cpp-options:     -DGHC7
     else
         build-depends:   base                  >= 4        && < 4.3
-        if flag(production)
-            cpp-options: -DPRODUCTION
-        else
-            build-depends: wai-handler-devel   >= 0.2      && < 0.3
     build-depends:   yesod-core                >= 0.7      && < 0.8
                    , yesod-auth                >= 0.3      && < 0.4
                    , yesod-json                >= 0.0      && < 0.1


### PR DESCRIPTION
I've tested hint's functionality with GHC 7 and Yesod and it seems to be working fine.
