### PR TITLE
Added .ghci to scaffold projects

### DIFF
--- a/scaffold.hs
+++ b/scaffold.hs
@@ -100,6 +100,7 @@ scaffold = do
 
     writeFile' ("config/" ++ project ++ ".hs") $(codegen "test_hs")
     writeFile' (project ++ ".cabal") $ if backendS == "m" then $(codegen "mini-cabal") else $(codegen "cabal")
+    writeFile' ".ghci" $(codegen "dotghci")
     writeFile' "LICENSE" $(codegen "LICENSE")
     writeFile' (sitearg ++ ".hs") $ if backendS == "m" then $(codegen "mini-sitearg_hs") else $(codegen "sitearg_hs")
     writeFile' "Controller.hs" $ if backendS == "m" then $(codegen "mini-Controller_hs") else $(codegen "Controller_hs")

--- a/scaffold/dotghci.cg
+++ b/scaffold/dotghci.cg
@@ -1,0 +1,2 @@
+:set -i.:config:dist/build/autogen
+


### PR DESCRIPTION
Hi Michael,

I have added a .ghci to yesod scaffold created object. This is needed to use the ghci out of the box, for example together with the emacs haskell-mode, because the config dir is not in the default search path.

I've also added the file where cabal creates its dynamic files to the source search path.

Regards
Markus

Commit Message: added a .ghci to scaffold created projects to expand the search path to config dir
