### PR TITLE
add appPort setting

### DIFF
--- a/scaffold/Settings_hs.cg
+++ b/scaffold/Settings_hs.cg
@@ -19,6 +19,7 @@ module Settings
     , approot
     , staticroot
     , staticdir
+    , appPort
     ) where
 
 import qualified Text.Hamlet as H
@@ -42,10 +43,13 @@ approot =
 -- You probably want to change this. If your domain name was "yesod.com",
 -- you would probably want it to be:
 -- > "http://yesod.com"
-  "http://localhost:3000"
+  "http://localhost:" ++ show appPort
 #else
-  "http://localhost:3000"
+  "http://localhost:" ++ show appPort
 #endif
+
+appPort :: Int
+appPort = 3000
 
 -- | The location of static files on your system. This is a file system
 -- path. The default value works properly with your scaffolded site.

--- a/scaffold/test_hs.cg
+++ b/scaffold/test_hs.cg
@@ -10,11 +10,11 @@ import Controller (with~sitearg~)
 import System.IO (hPutStrLn, stderr)
 import Network.Wai.Middleware.Debug (debug)
 import Network.Wai.Handler.Warp (run)
+import Settings (appPort)
 
 main :: IO ()
 main = do
-    let port = 3000
-    hPutStrLn stderr $ "Application launched, listening on port " ++ show port
-    with~sitearg~ $ run port . debug
+    hPutStrLn stderr $ "Application launched, listening on port " ++ show appPort
+    with~sitearg~ $ run appPort . debug
 #endif
 


### PR DESCRIPTION
I tried running the fulltest, but I get this, which looks unrelated:

```
Yesod/Auth.hs:233:10:
    Not in scope: type constructor or class `Message'
cabal: Error: some packages failed to install:
yesod-0.8.2 depends on yesod-auth-0.5.0 which failed to install.
yesod-auth-0.5.0 failed during the building phase. The exception was:
ExitFailure 1
```
