### PR TITLE
Bump pwstore-fast version to 2.2, and allow compatible 2.x versions.

### DIFF
--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -42,7 +42,7 @@ library
                    , SHA                     >= 1.4.1.3   && < 1.5
                    , http-enumerator         >= 0.6       && < 0.7
                    , aeson                   >= 0.3.2.2   && < 0.4
-                   , pwstore-fast            >= 2.1       && < 2.2
+                   , pwstore-fast            >= 2.2       && < 3
 
     exposed-modules: Yesod.Auth
                      Yesod.Auth.BrowserId


### PR DESCRIPTION
The way pwstore-fast does versions, all 2.x releases are guaranteed to
be API-compatible with past 2.x releases, so this will not result in
breakage. Version 2.2 squashes some laziness, and uses less memory,
but is otherwise identical to 2.1.
