### PR TITLE
This fixes all warnings in the generated code

### DIFF
--- a/yesod/scaffold/config/Settings.hs.cg
+++ b/yesod/scaffold/config/Settings.hs.cg
@@ -32,7 +32,7 @@ import Yesod (liftIO, MonadControlIO, addWidget, addCassius, addJulius, addLuciu
 import Data.Monoid (mempty, mappend)
 import System.Directory (doesFileExist)
 import Prelude hiding (concat)
-import Data.Text (Text, snoc, append, pack, concat)
+import Data.Text (Text)
 import Data.Object
 import qualified Data.Object.Yaml as YAML
 import Control.Monad (join)

--- a/yesod/scaffold/sitearg.hs.cg
+++ b/yesod/scaffold/sitearg.hs.cg
@@ -16,7 +16,6 @@ module ~sitearg~
     ) where
 
 import Yesod
-import Yesod.Form (defaultFormMessage)
 import Yesod.Static
 import Yesod.Auth
 import Yesod.Auth.OpenId
@@ -27,7 +26,6 @@ import qualified Data.ByteString.Lazy as L
 import Database.Persist.GenericSql
 import Settings (hamletFile, cassiusFile, luciusFile, juliusFile, widgetFile)
 import Model
-import StaticFiles
 import Data.Maybe (isJust)
 import Control.Monad (join, unless)
 import Network.Mail.Mime


### PR DESCRIPTION
```
[3 of 7] Compiling Settings         ( config/Settings.hs, dist/build/muspy/muspy-tmp/Settings.o )

config/Settings.hs:36:1:
    Warning: The import of `concat, append, pack, snoc'
             from module `Data.Text' is redundant
[4 of 7] Compiling Muspy            ( Muspy.hs, dist/build/muspy/muspy-tmp/Muspy.o )

Muspy.hs:19:1:
    Warning: The import of `Yesod.Form' is redundant
               except perhaps to import instances from `Yesod.Form'
             To import instances alone, use: import Yesod.Form()

Muspy.hs:30:1:
    Warning: The import of `StaticFiles' is redundant
               except perhaps to import instances from `StaticFiles'
             To import instances alone, use: import StaticFiles()
```
