### PR TITLE
yesod-core does not build with blaze-html 0.4.1.1

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -60,7 +60,7 @@ library
                    , monad-control             >= 0.2      && < 0.3
                    , enumerator                >= 0.4.7    && < 0.5
                    , cookie                    >= 0.3      && < 0.4
-                   , blaze-html                >= 0.4      && < 0.5
+                   , blaze-html                >= 0.4.1.3  && < 0.5
                    , http-types                >= 0.6.5    && < 0.7
                    , case-insensitive          >= 0.2      && < 0.4
                    , parsec                    >= 2        && < 3.2


### PR DESCRIPTION
[14 of 17] Compiling Yesod.Internal.Core ( Yesod/Internal/Core.hs, dist-ghc/build/Yesod/Internal/Core.o )

Yesod/Internal/Core.hs:55:60:
    Module `Text.Blaze' does not export`unsafeLazyByteString'
