### PR TITLE
OpenID Extension Fields

### DIFF
--- a/yesod-auth/Yesod/Auth/OpenId.hs
+++ b/yesod-auth/Yesod/Auth/OpenId.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Yesod.Auth.OpenId
     ( authOpenId
+    , authOpenIdExtended
     , forwardUrl
     ) where
 
@@ -26,7 +27,10 @@ forwardUrl :: AuthRoute
 forwardUrl = PluginR "openid" ["forward"]
 
 authOpenId :: YesodAuth m => AuthPlugin m
-authOpenId =
+authOpenId = authOpenIdExtended []
+
+authOpenIdExtended :: YesodAuth m => [(Text, Text)] -> AuthPlugin m
+authOpenIdExtended extensionFields =
     AuthPlugin "openid" dispatch login
   where
     complete = PluginR "openid" ["complete"]
@@ -57,7 +61,7 @@ authOpenId =
                 render <- getUrlRender
                 toMaster <- getRouteToMaster
                 let complete' = render $ toMaster complete
-                res <- runAttemptT $ OpenId.getForwardUrl oid complete' Nothing []
+                res <- runAttemptT $ OpenId.getForwardUrl oid complete' Nothing extensionFields 
                 attempt
                   (\err -> do
                         setMessage $ toHtml $ show err
@@ -87,5 +91,5 @@ completeHelper gets' = do
             setMessage $ toHtml $ show err
             redirect RedirectTemporary $ toMaster LoginR
         let onSuccess (OpenId.Identifier ident, _) =
-                setCreds True $ Creds "openid" ident []
+                setCreds True $ Creds "openid" ident gets'
         attempt onFailure onSuccess res


### PR DESCRIPTION
I've exposed a second function in Yesod.Auth.OpenId that takes a list of OpenID extension fields as a parameter, which are passed straight through to Web.Authenticate.OpenId.

I wanted this so that I could use attribute exchange with Google to retrieve a user's email address. The other half to this work is a change to the Creds that are returned. `credsExtra` is now filled with all the OpenId response pairs. I originally had this list filtered down to 'openid.ext.*', but I think that prefix is google-specific.
