### PR TITLE
Configuration of robots.txt via config/robots.txt

### DIFF
--- a/yesod-default/Yesod/Default/Handlers.hs
+++ b/yesod-default/Yesod/Default/Handlers.hs
@@ -5,10 +5,10 @@ module Yesod.Default.Handlers
     ) where
 
 import Yesod.Handler (GHandler, sendFile)
-import Yesod.Content (RepPlain(..), ToContent(..))
+import Yesod.Content (RepPlain(..))
 
 getFaviconR :: GHandler s m ()
 getFaviconR = sendFile "image/x-icon" "config/favicon.ico"
 
 getRobotsR :: GHandler s m RepPlain
-getRobotsR = return $ RepPlain $ toContent ("User-agent: *" :: String)
+getRobotsR = sendFile "text/plain" "config/robots.txt"

--- a/yesod/Scaffolding/Scaffolder.hs
+++ b/yesod/Scaffolding/Scaffolder.hs
@@ -189,5 +189,9 @@ scaffold = do
         $(runIO (S.readFile "scaffold/config/favicon.ico.cg") >>= \bs -> do
             pack <- [|S.pack|]
             return $ pack `AppE` LitE (StringL $ S.unpack bs))
+
+    S.writeFile (dir ++ "/config/robots.txt")
+        $(runIO (S.readFile "scaffold/config/robots.txt.cg") >>= \bs -> do
+            [|S.pack $(return $ LitE $ StringL $ S.unpack bs)|])
     
     puts $(codegenDir "input" "done")

--- a/yesod/scaffold/config/robots.txt.cg
+++ b/yesod/scaffold/config/robots.txt.cg
@@ -1,0 +1,1 @@
+User-agent: *


### PR DESCRIPTION
Hi,

I found it a bit annoying and not intuitive to write my own RobotsR Handler even if I only want to add a few chars. With this change we have one more configuration file, but I think it makes things more clear.

What do you think?
