### PR TITLE
Facebook logout support and access token.

### DIFF
--- a/yesod-auth/Yesod/Auth/Facebook.hs
+++ b/yesod-auth/Yesod/Auth/Facebook.hs
@@ -4,6 +4,7 @@
 module Yesod.Auth.Facebook
     ( authFacebook
     , facebookLogin
+    , facebookUrl
     , facebookLogout
     , getFacebookAccessToken
     ) where
@@ -30,6 +31,12 @@ import qualified Yesod.Auth.Message as Msg
 -- | Route for login using this authentication plugin.
 facebookLogin :: AuthRoute
 facebookLogin = PluginR "facebook" ["forward"]
+
+-- | This is just a synonym of 'facebookLogin'.  Deprecated since
+-- @yesod-auth 0.7.8@, please use 'facebookLogin' instead.
+facebookUrl :: AuthRoute
+facebookUrl = facebookLogin
+{-# DEPRECATED facebookUrl "Please use facebookLogin instead." #-}
 
 -- | Route for logout using this authentication plugin.  Per
 -- Facebook's policies

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         0.8
+version:         0.7.8
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
This patch renames "facebookUrl" to "facebookLogin" and adds
"facebookLogout".  The latter logs out the user from Facebook as
well to comply with Facebook's policies.

As a bonus, we also save the user's access token into their
session and export "getFacebookAccessToken".  Besides being
useful for the application, this is necessary for the new logout
action.

This patch also bumps the version to 0.8 since we have renamed
"facebookUrl".
