### PR TITLE
yesod-json: add an upper bound on aeson dependency

### DIFF
--- a/yesod-json/yesod-json.cabal
+++ b/yesod-json/yesod-json.cabal
@@ -15,7 +15,7 @@ description:     Generate content for Yesod using the aeson package.
 library
     build-depends:   base                 >= 4        && < 5
                    , yesod-core           >= 0.9      && < 0.10
-                   , aeson                >= 0.3
+                   , aeson                >= 0.3      && < 0.5
                    , text                 >= 0.8      && < 0.12
                    , shakespeare-js       >= 0.10     && < 0.11
                    , vector               >= 0.9


### PR DESCRIPTION
aeson 0.5 no longer uses blaze-builder during encoding
https://github.com/bos/aeson/commit/672a797, and hence its API has
changed incompatibly.

Fixes GH-189.
