### PR TITLE
jqueryDayField: do nothing if <input type=date> supported

### DIFF
--- a/yesod-form/Yesod/Form/Jquery.hs
+++ b/yesod-form/Yesod/Form/Jquery.hs
@@ -86,13 +86,18 @@ jqueryDayField jds = Field
         addScript' urlJqueryUiJs
         addStylesheet' urlJqueryUiCss
         addJulius [JULIUS|
-$(function(){$("##{theId}").datepicker({
-    dateFormat:'yy-mm-dd',
-    changeMonth:#{jsBool $ jdsChangeMonth jds},
-    changeYear:#{jsBool $ jdsChangeYear jds},
-    numberOfMonths:#{mos $ jdsNumberOfMonths jds},
-    yearRange:"#{jdsYearRange jds}"
-})});
+$(function(){
+    var i = $("##{theId}");
+    if (i.attr("type") != "date") {
+        i.datepicker({
+            dateFormat:'yy-mm-dd',
+            changeMonth:#{jsBool $ jdsChangeMonth jds},
+            changeYear:#{jsBool $ jdsChangeYear jds},
+            numberOfMonths:#{mos $ jdsNumberOfMonths jds},
+            yearRange:"#{jdsYearRange jds}"
+        });
+    }
+});
 |]
     }
   where


### PR DESCRIPTION
On iOS 5, for example, `<input type=date>` throws up a native date picker, so there's no reason to show the jquery-ui datepicker.

This is not perfect, because the jquery-ui JavaScript and CSS are still loaded, and the `JqueryDaySettings` are not turned into attributes on the `<input>`, but it's a start.
