### PR TITLE
mkRenderRouteInstance with context

### DIFF
--- a/yesod-routes/Yesod/Routes/TH/RenderRoute.hs
+++ b/yesod-routes/Yesod/Routes/TH/RenderRoute.hs
@@ -2,6 +2,7 @@
 module Yesod.Routes.TH.RenderRoute
     ( -- ** RenderRoute
       mkRenderRouteInstance
+    , mkRenderRouteInstance'
     , mkRouteCons
     , mkRenderRouteClauses
     ) where
@@ -89,12 +90,19 @@ mkRenderRouteClauses =
 
 -- | Generate the 'RenderRoute' instance.
 --
--- This includes both the 'Route' associated type and the 'renderRoute' method.
--- This function uses both 'mkRouteCons' and 'mkRenderRouteClasses'.
+-- This includes both the 'Route' associated type and the
+-- 'renderRoute' method.  This function uses both 'mkRouteCons' and
+-- 'mkRenderRouteClasses'.
 mkRenderRouteInstance :: Type -> [Resource Type] -> Q Dec
-mkRenderRouteInstance typ ress = do
+mkRenderRouteInstance = mkRenderRouteInstance' []
+
+-- | A more general version of 'mkRenderRouteInstance' which takes an
+-- additional context.
+
+mkRenderRouteInstance' :: Cxt -> Type -> [Resource Type] -> Q Dec
+mkRenderRouteInstance' cxt typ ress = do
     cls <- mkRenderRouteClauses ress
-    return $ InstanceD [] (ConT ''RenderRoute `AppT` typ)
+    return $ InstanceD cxt (ConT ''RenderRoute `AppT` typ)
         [ DataInstD [] ''Route [typ] (mkRouteCons ress) clazzes
         , FunD (mkName "renderRoute") cls
         ]


### PR DESCRIPTION
Exporting a version of mkRenderRouteInstance which takes a context will simplyfy some of the
code that I am writing in yesod-adim. This single commit does the trick. I would be happy if it is merged
