### PR TITLE
Session cookie domain

### DIFF
--- a/yesod-core/Yesod/Internal/Core.hs
+++ b/yesod-core/Yesod/Internal/Core.hs
@@ -274,6 +274,12 @@ class RenderRoute a => Yesod a where
     cookiePath :: a -> S8.ByteString
     cookiePath _ = "/"
 
+    -- | The domain value to set for cookies. By default, the
+    -- domain is not set, meaning cookies will be sent only to
+    -- the current domain.
+    cookieDomain :: a -> Maybe S8.ByteString
+    cookieDomain _ = Nothing
+
     -- | Maximum allowed length of the request body, in bytes.
     maximumContentLength :: a -> Maybe (Route a) -> Int
     maximumContentLength _ _ = 2 * 1024 * 1024 -- 2 megabytes
@@ -742,7 +748,7 @@ saveClientSession key timeout master _ now _ sess = do
         , setCookieValue = sessionVal iv
         , setCookiePath = Just (cookiePath master)
         , setCookieExpires = Just expires
-        , setCookieDomain = Nothing
+        , setCookieDomain = cookieDomain master
         , setCookieHttpOnly = True
         }]
   where


### PR DESCRIPTION
We already have a `cookiePath` option.  This patch adds a `cookieDomain` option.  It's useful when having many subdomains.

@snoyberg, I'd like to backport this patch to the Yesod 0.10 series as `yesod-core 0.10.3`, would you mind if I did so?
