### PR TITLE
Code fix for issue #306

### DIFF
--- a/yesod-default/Yesod/Default/Main.hs
+++ b/yesod-default/Yesod/Default/Main.hs
@@ -92,6 +92,6 @@ defaultDevelApp load getApp = do
     conf   <- load
     logger <- defaultDevelopmentLogger
     let p = appPort conf
-    logString logger $ "Devel application launched, listening on port " ++ show p
+    logString logger $ "Devel application launched at " ++ (show $ appRoot conf) ++ ", listening on port " ++ show p
     app <- getApp conf logger
     return (p, app)


### PR DESCRIPTION
Now if approot in settings file is not supplied, there will be a redundancy of having a port both in generated approot (http(s):// host / port) and in the end of the file. But I guess it's not worth splitting appRoot content to find out what's inside and based on that include/exclude message part with port. 
