### PR TITLE
Protect touch call in test action with #ifndef WINDOWS macro

### DIFF
--- a/yesod/main.hs
+++ b/yesod/main.hs
@@ -38,7 +38,9 @@ main = do
 #endif
         "devel":rest -> devel isDev rest
         "test":_ -> do
+#ifndef WINDOWS
             touch
+#endif
             rawSystem' cmd ["configure", "--enable-tests", "-flibrary-only"]
             rawSystem' cmd ["build"]
             rawSystem' cmd ["test"]


### PR DESCRIPTION
Trying to build yesod under windows but it was failing with:
main.hs:41:13 Not in scope: 'touch'
