### PR TITLE
yesod-static: Correctly add the "etag" param to TH-generated routes.

### DIFF
--- a/yesod-static/Yesod/Static.hs
+++ b/yesod-static/Yesod/Static.hs
@@ -307,7 +307,7 @@ mkStaticFilesList fp fs routeConName makeHash = do
         pack' <- [|pack|]
         qs <- if makeHash
                     then do hash <- qRunIO $ base64md5File $ pathFromRawPieces fp f
-                            [|[(pack $(lift hash), mempty)]|]
+                            [|[("etag" :: Text, pack $(lift hash))]|]
                     else return $ ListE []
         return
             [ SigD routeName $ ConT route


### PR DESCRIPTION
The wai-app-static package expects the etag parameter to be
passed in the form of

```
  /...?etag=XXXX
```

but yesod-static was passing

```
  /...?XXXX
```

This commit fixes this bug.

@gregwebs With this fix and currently released `wai-app-static` I already get the desired behaviour.  In the end it was a simple bug but I was able to see it only after you taught me about the `etag` parameter =).
