### PR TITLE
yesod-auth: change returned Creds identifier to "googleemail".

### DIFF
--- a/yesod-auth/Yesod/Auth/GoogleEmail.hs
+++ b/yesod-auth/Yesod/Auth/GoogleEmail.hs
@@ -31,17 +31,20 @@ import qualified Yesod.Auth.Message as Msg
 import qualified Data.Text as T
 import Control.Exception.Lifted (try, SomeException)
 
+pid :: Text
+pid = "googleemail"
+
 forwardUrl :: AuthRoute
-forwardUrl = PluginR "googleemail" ["forward"]
+forwardUrl = PluginR pid ["forward"]
 
 googleIdent :: Text
 googleIdent = "https://www.google.com/accounts/o8/id"
 
 authGoogleEmail :: YesodAuth m => AuthPlugin m
 authGoogleEmail =
-    AuthPlugin "googleemail" dispatch login
+    AuthPlugin pid dispatch login
   where
-    complete = PluginR "googleemail" ["complete"]
+    complete = PluginR pid ["complete"]
     login tm =
         [whamlet|<a href=@{tm forwardUrl}>_{Msg.LoginGoogle}|]
     dispatch "GET" ["forward"] = do
@@ -86,7 +89,7 @@ completeHelper gets' = do
                 let OpenId.Identifier ident = OpenId.oirOpLocal oir
                 memail <- lookupGetParam "openid.ext1.value.email"
                 case (memail, "https://www.google.com/accounts/o8/id" `T.isPrefixOf` ident) of
-                    (Just email, True) -> setCreds True $ Creds "openid" email []
+                    (Just email, True) -> setCreds True $ Creds pid email []
                     (_, False) -> do
                         setMessage "Only Google login is supported"
                         redirect $ toMaster LoginR


### PR DESCRIPTION
I'm tracking which authentication plugin was used for logging in users, and found that the authGoogleEmail plugin returns "openid" in it's Creds value after a successful login.  I've changed this to "googleemail" to match the convention that other auth plugins follow.

Here's an overview of what all the auth modules are currently using:

<table>
<tr>
<th>module</th>
<th>AuthPlugin</th>
<th>returned Creds</th>
</tr>
<tr>
<td>BrowserId</td>
<td>"browserid"</td>
<td>"browserid"</td>
</tr>
<tr>
<td>Dummy</td>
<td>"dummy"</td>
<td>"dummy"</td>
</tr>
<tr>
<td>GoogleEmail</td>
<td>"googleemail"</td>
<td>"openid"</td>
</tr>
<tr>
<td>HashDB</td>
<td>"hashdb"</td>
<td>"hashdb"</td>
</tr>
<tr>
<td>OpenId</td>
<td>"openid"</td>
<td>"openid"</td>
</tr>
<tr>
<td>Rpxnow</td>
<td>"rpxnow"</td>
<td>"rpxnow"</td>
</tr>
</table>
