### PR TITLE
import (<>) from Data.Monoid with GHC >= 7.0.4

### DIFF
--- a/yesod/scaffold/Import.hs.cg
+++ b/yesod/scaffold/Import.hs.cg
@@ -15,7 +15,11 @@ module Import
 import Prelude hiding (writeFile, readFile, head, tail, init, last)
 import Yesod   hiding (Route(..))
 import Foundation
+#if __GLASGOW_HASKELL__ < 704
 import Data.Monoid (Monoid (mappend, mempty, mconcat))
+#else
+import Data.Monoid (Monoid (mappend, mempty, mconcat), (<>))
+#endif
 import Control.Applicative ((<$>), (<*>), pure)
 import Data.Text (Text)
 import Settings.StaticFiles


### PR DESCRIPTION
Import.hs defines its own (<>) if your GHC is too old to have (<>) in Data.Monoid, but unfortunately it never imports (<>) even with recent GHC. So with >7.0.4 you perversely get no (<>). This patch should fix this.
