### PR TITLE
Faster session date handling (partially solves #415)

### DIFF
--- a/yesod-core/Yesod/Internal/Session.hs
+++ b/yesod-core/Yesod/Internal/Session.hs
@@ -1,6 +1,8 @@
 module Yesod.Internal.Session
     ( encodeClientSession
     , decodeClientSession
+    , clientSessionDateCacher
+    , ClientSessionDateCache(..)
     , BackendSession
     , SaveSession
     , SessionBackend(..)
@@ -12,58 +14,96 @@ import Data.Int (Int64)
 import Data.Serialize
 import Data.Time
 import Data.ByteString (ByteString)
-import Control.Monad (guard)
+import Control.Concurrent (forkIO, killThread, threadDelay)
+import Control.Monad (forever, guard)
 import Data.Text (Text, pack, unpack)
 import Control.Arrow (first)
 import Control.Applicative ((<$>))
 
 import qualified Data.ByteString.Char8 as S8
+import qualified Data.IORef as I
 import qualified Network.Wai as W
 
 type BackendSession = [(Text, S8.ByteString)]
 
 type SaveSession = BackendSession    -- ^ The session contents after running the handler
-                -> UTCTime           -- ^ current time
                 -> IO [Header]
 
 newtype SessionBackend master = SessionBackend
     { sbLoadSession :: master
                     -> W.Request
-                    -> UTCTime
                     -> IO (BackendSession, SaveSession) -- ^ Return the session data and a function to save the session
     }
 
 encodeClientSession :: CS.Key
                     -> CS.IV
-                    -> UTCTime -- ^ expire time
+                    -> ClientSessionDateCache  -- ^ expire time
                     -> ByteString -- ^ remote host
                     -> [(Text, ByteString)] -- ^ session
                     -> ByteString -- ^ cookie value
-encodeClientSession key iv expire rhost session' =
-    CS.encrypt key iv $ encode $ SessionCookie expire rhost session'
+encodeClientSession key iv date rhost session' =
+    CS.encrypt key iv $ encode $ SessionCookie expires rhost session'
+      where expires = Right (csdcExpiresSerialized date)
 
 decodeClientSession :: CS.Key
-                    -> UTCTime -- ^ current time
+                    -> ClientSessionDateCache  -- ^ current time
                     -> ByteString -- ^ remote host field
                     -> ByteString -- ^ cookie value
                     -> Maybe [(Text, ByteString)]
-decodeClientSession key now rhost encrypted = do
+decodeClientSession key date rhost encrypted = do
     decrypted <- CS.decrypt key encrypted
-    SessionCookie expire rhost' session' <-
+    SessionCookie (Left expire) rhost' session' <-
         either (const Nothing) Just $ decode decrypted
-    guard $ expire > now
+    guard $ expire > csdcNow date
     guard $ rhost' == rhost
     return session'
 
-data SessionCookie = SessionCookie UTCTime ByteString [(Text, ByteString)]
+data SessionCookie = SessionCookie (Either UTCTime ByteString) ByteString [(Text, ByteString)]
     deriving (Show, Read)
 instance Serialize SessionCookie where
-    put (SessionCookie a b c) = putTime a >> put b >> put (map (first unpack) c)
+    put (SessionCookie a b c) = do
+        either putTime putByteString a
+        put b
+        put (map (first unpack) c)
     get = do
         a <- getTime
         b <- get
         c <- map (first pack) <$> get
-        return $ SessionCookie a b c
+        return $ SessionCookie (Left a) b c
+
+
+----------------------------------------------------------------------
+
+
+-- Mostly copied from Kazu's date-cache, but with modifications
+-- that better suit our needs.
+--
+-- The cached date is updated every 10s, we don't need second
+-- resolution for session expiration times.
+
+data ClientSessionDateCache =
+  ClientSessionDateCache {
+    csdcNow               :: !UTCTime
+  , csdcExpires           :: !UTCTime
+  , csdcExpiresSerialized :: !ByteString
+  } deriving (Eq, Show)
+
+clientSessionDateCacher ::
+     NominalDiffTime -- ^ Inactive session valitity.
+  -> IO (IO ClientSessionDateCache, IO ())
+clientSessionDateCacher validity = do
+    ref <- getUpdated >>= I.newIORef
+    tid <- forkIO $ forever (doUpdate ref)
+    return $! (I.readIORef ref, killThread tid)
+  where
+    getUpdated = do
+      now <- getCurrentTime
+      let expires  = validity `addUTCTime` now
+          expiresS = runPut (putTime expires)
+      return $! ClientSessionDateCache now expires expiresS
+    doUpdate ref = do
+      threadDelay 10000000 -- 10s
+      I.writeIORef ref =<< getUpdated
 
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
The first commit, 065e33a3d13e4bfacd47d073f94206430d88f9ed, breaks the cookie format.  Other than that, I feel it should be accepted.

The second commit, b2a9beba3cdd9e4df4f772af89fa991369e86013, is somewhat more controversial.  We'll need a major version bump of yesod-core.  It's also a bit complicated.
