### PR TITLE
Add support for multiple cookies in yesod-test

### DIFF
--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -35,6 +35,9 @@ library
                    , blaze-markup              >= 0.5.1    && < 0.6
                    , pool-conduit
                    , monad-control
+                   , time
+                   , blaze-builder
+                   , cookie
 
     exposed-modules: Yesod.Test
                      Yesod.Test.CssQuery


### PR DESCRIPTION
Hi,

This commit adds support for multiple Set-Cookie headers.  I need this because my yesod app sets a cookie inside a handler, and when combined with the session cookie this creates two Set-Cookie headers.

While I was there editing the code, I added support for path and expires.  I did test the path checking of cookies.  The expire checks could probably be removed, they don't really make sense for testing.
