### PR TITLE
Prevent caching of redirects

### DIFF
--- a/yesod-core/Yesod/Handler.hs
+++ b/yesod-core/Yesod/Handler.hs
@@ -526,7 +526,7 @@ runHandler handler mrender sroute tomr master sub upload log' =
                     [ Header "Cache-Control" "no-cache, must-revalidate"
                     , Header "Expires" "Thu, 01 Jan 1970 05:05:05 GMT"
                     ]
-                hs = (if status == H.movedPermanently301 then disable_caching else [])
+                hs = (if status /= H.movedPermanently301 then disable_caching else [])
                       ++ Header "Location" (encodeUtf8 loc) : appEndo headers []
             return $ YARPlain
                 status hs typePlain emptyContent


### PR DESCRIPTION
Ran into a problem accessing my site on a recent version of icecat (the FSF firefox fork).  It's very aggressive about caching, and was caching the redirect from a protected route to the login page, such that trying to get back to that protected route once logged in would put me back at the login page.  This seems to fix it, by telling the browser not to cache redirects, which should be correct for most redirects that are decided dynamically.
