### PR TITLE
Removed bytestring pkg version upper bound from yesod-auth-oauth

### DIFF
--- a/yesod-auth-oauth/yesod-auth-oauth.cabal
+++ b/yesod-auth-oauth/yesod-auth-oauth.cabal
@@ -21,7 +21,7 @@ library
     else
         build-depends:   base                >= 4         && < 4.3
     build-depends:   authenticate-oauth      >= 1.4       && < 1.5
-                   , bytestring              >= 0.9.1.4   && < 0.10
+                   , bytestring              >= 0.9.1.4   
                    , yesod-core              >= 1.1       && < 1.2
                    , yesod-auth              >= 1.1       && < 1.2
                    , text                    >= 0.7       && < 0.12


### PR DESCRIPTION
This way it matches the bytestring depend. of yesod-core and it doesn't force cabal into downloading version < 0.10
