### PR TITLE
Test additions

### DIFF
--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -52,7 +52,7 @@ module Yesod.Test (
 
   -- * Assertions
   assertEqual, assertHeader, assertNoHeader, statusIs, bodyEquals, bodyContains,
-  htmlAllContain, htmlCount,
+  htmlAllContain, htmlAnyContain, htmlCount,
 
   -- * Utils for debugging tests
   printBody, printMatches,


### PR DESCRIPTION
The new function htmlAnyContain is a variation on the existing htmlAllContain, but passes if any of the matched elements contain the search string.

For  example, it could be used to verify that there is an "Edit Profile" link on the page somewhere: 

``` haskell
htmlAnyContain "a" "Edit Profile"
```

There is some overlap with the htmlCount function, however htmlAnyContain could be used when we want to assert that some quantity of an element exist on a page, but the number of them is not known, or we are not really concerned about the number as long as it is non-zero:

``` haskell
htmlAnyContain "a" "Like this Post"
```
