### PR TITLE
EntityField data instances export for HashDB.User

### DIFF
--- a/yesod-auth/Yesod/Auth/HashDB.hs
+++ b/yesod-auth/Yesod/Auth/HashDB.hs
@@ -69,6 +69,7 @@ module Yesod.Auth.HashDB
     , User
     , UserGeneric (..)
     , UserId
+    , EntityField (..)
     , migrateUsers
     ) where
 


### PR DESCRIPTION
Makes easy to use User model outside of yesod-auth
