### PR TITLE
Use clientsession 0.9.* on Yesod 1.2.

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -56,7 +56,7 @@ library
                    , shakespeare-i18n      >= 1.0      && < 1.1
                    , blaze-builder         >= 0.2.1.4  && < 0.4
                    , transformers          >= 0.2.2    && < 0.4
-                   , clientsession         >= 0.8      && < 0.9
+                   , clientsession         >= 0.9      && < 0.10
                    , random                >= 1.0.0.2  && < 1.1
                    , cereal                >= 0.3      && < 0.4
                    , old-locale            >= 1.0.0.2  && < 1.1


### PR DESCRIPTION
`clientsession >= 0.9` uses `skein == 1.0.*` which includes Skein v1.3 up from Skein v1.1.  I'm not sure if we should upgrade the `clientsession` dependency on Yesod 1.1 as well since that will break all current sessions on a stable branch of Yesod.  Also, Yesod 1.2's release is already on the horizon.  Therefore I didn't update the stable branch.
