### PR TITLE
Add -XDeriveDataTypeable to .ghci sqlite pragmas 

### DIFF
--- a/yesod-bin/hsfiles/sqlite.hsfiles
+++ b/yesod-bin/hsfiles/sqlite.hsfiles
@@ -1,6 +1,6 @@
 {-# START_FILE .ghci #-}
 :set -i.:config:dist/build/autogen
-:set -XCPP -XTemplateHaskell -XQuasiQuotes -XTypeFamilies -XFlexibleContexts -XGADTs -XOverloadedStrings -XMultiParamTypeClasses -XGeneralizedNewtypeDeriving -XEmptyDataDecls
+:set -XCPP -XTemplateHaskell -XQuasiQuotes -XTypeFamilies -XFlexibleContexts -XGADTs -XOverloadedStrings -XMultiParamTypeClasses -XGeneralizedNewtypeDeriving -XEmptyDataDecls -XDeriveDataTypeable
 
 {-# START_FILE .gitignore #-}
 dist*


### PR DESCRIPTION
Hi, I noticed that Models.hs won't load in ghci unless this is added to the project .ghci (for sqlite sites generated by scaffolding).
