### PR TITLE
Request to add a ToTypedContent to the response tyvar of Handler for yesodMiddleware.

### DIFF
--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -266,7 +266,7 @@ class RenderRoute site => Yesod site where
     -- Default: the 'defaultYesodMiddleware' function.
     --
     -- Since: 1.1.6
-    yesodMiddleware :: HandlerT site IO res -> HandlerT site IO res
+    yesodMiddleware :: ToTypedContent res => HandlerT site IO res -> HandlerT site IO res
     yesodMiddleware = defaultYesodMiddleware
 
 -- | Default implementation of 'yesodMiddleware'. Adds the response header


### PR DESCRIPTION
The yesodMiddleware would be a lot more useful if there was a way to interact with the response. I looked at where the middleware was run, and the Handler has a ToTypeContent constraint on it, so I don't see the harm of adding one, and the gain is very large.

Without this contraint or something similar I am forced to use Wai middleware. Not ideal.
