### PR TITLE
Add cabal-dev/ to scaffolded .gitignore

### DIFF
--- a/yesod-bin/hsfiles/mongo.hsfiles
+++ b/yesod-bin/hsfiles/mongo.hsfiles
@@ -10,6 +10,7 @@ config/client_session_key.aes
 *.o
 *.sqlite3
 .hsenv*
+cabal-dev/
 yesod-devel/
 
 {-# START_FILE Application.hs #-}

--- a/yesod-bin/hsfiles/mysql.hsfiles
+++ b/yesod-bin/hsfiles/mysql.hsfiles
@@ -10,6 +10,7 @@ config/client_session_key.aes
 *.o
 *.sqlite3
 .hsenv*
+cabal-dev/
 yesod-devel/
 
 {-# START_FILE Application.hs #-}

--- a/yesod-bin/hsfiles/postgres-fay.hsfiles
+++ b/yesod-bin/hsfiles/postgres-fay.hsfiles
@@ -11,6 +11,7 @@ config/client_session_key.aes
 *.sqlite3
 fay/Language/Fay/Yesod.hs
 .hsenv*
+cabal-dev/
 yesod-devel/
 
 {-# START_FILE Application.hs #-}

--- a/yesod-bin/hsfiles/postgres.hsfiles
+++ b/yesod-bin/hsfiles/postgres.hsfiles
@@ -10,6 +10,7 @@ config/client_session_key.aes
 *.o
 *.sqlite3
 .hsenv*
+cabal-dev/
 yesod-devel/
 
 {-# START_FILE Application.hs #-}

--- a/yesod-bin/hsfiles/simple.hsfiles
+++ b/yesod-bin/hsfiles/simple.hsfiles
@@ -10,6 +10,7 @@ config/client_session_key.aes
 *.o
 *.sqlite3
 .hsenv*
+cabal-dev/
 yesod-devel/
 
 {-# START_FILE Application.hs #-}

--- a/yesod-bin/hsfiles/sqlite.hsfiles
+++ b/yesod-bin/hsfiles/sqlite.hsfiles
@@ -10,6 +10,7 @@ config/client_session_key.aes
 *.o
 *.sqlite3
 .hsenv*
+cabal-dev/
 yesod-devel/
 
 {-# START_FILE Application.hs #-}


### PR DESCRIPTION
Since `yesod init` already mentions using `cabal-dev`, it may be useful to add the cabal-dev directory to default .gitignore generated with the scaffolded site.
