### PR TITLE
Added optionsPersistKey to Fields

### DIFF
--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -87,6 +87,8 @@ import Control.Applicative ((<$>), (<|>))
 
 import Data.Attoparsec.Text (Parser, char, string, digit, skipSpace, endOfInput, parseOnly)
 
+import Yesod.Persist.Core
+
 defaultFormMessage :: FormMessage -> Text
 defaultFormMessage = englishFormMessage
 


### PR DESCRIPTION
There is no immediately obvious way to use optionsPersist with selectField. The function optionsPersistKey makes this possible. Example of use:
areq (selectField $ optionsPersistKey [] [Asc UserIdent] userIdent) "User" Nothing
