### PR TITLE
Changed description of hsenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ If you aren't building from an application, remove the `./` and create a new dir
 
 
 
-## hsenv (Linux only)
+## hsenv (Linux and Mac OS X)
 
-[hsenv](http://hackage.haskell.org/package/hsenv) prevents your custom build of Yesod from interfering with your currently installed cabal packages:
+[hsenv](https://github.com/tmhedberg/hsenv) prevents your custom build of Yesod from interfering with your currently installed cabal packages:
 
 * hsenv creates an isolated environment like cabal-dev
 * hsenv works at the shell level, so every shell must activate the hsenv


### PR DESCRIPTION
- `hsenv` works on Mac OS X also (at least Lion and Mountain lion).
- supplied link to forked, working version of `hsenv` at https://github.com/tmhedberg/hsenv
