### PR TITLE
Update to cryptohash-cryptoapi

### DIFF
--- a/yesod-static/Yesod/Static.hs
+++ b/yesod-static/Yesod/Static.hs
@@ -73,7 +73,7 @@ import Language.Haskell.TH
 import Language.Haskell.TH.Syntax as TH
 
 import Crypto.Conduit (hashFile, sinkHash)
-import Crypto.Hash.MD5 (MD5)
+import Crypto.Hash.CryptoAPI (MD5)
 import Control.Monad.Trans.State
 
 import qualified Data.ByteString.Base64

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -38,7 +38,7 @@ library
                    , unix-compat           >= 0.2
                    , conduit               >= 0.5
                    , crypto-conduit        >= 0.4
-                   , cryptohash            >= 0.6.1
+                   , cryptohash-cryptoapi  >= 0.1.0
                    , system-filepath       >= 0.4.6    && < 0.5
                    , system-fileio         >= 0.3
                    , data-default
@@ -71,7 +71,7 @@ test-suite tests
                    , unix-compat
                    , conduit
                    , crypto-conduit
-                   , cryptohash
+                   , cryptohash-cryptoapi
                    , system-filepath
                    , system-fileio
                    , data-default


### PR DESCRIPTION
Crypto.Hash.MD5 no longer exports the MD5 type, switch to
cryptohash-cryptoapi.
