### PR TITLE
static: make Entry a setting type

### DIFF
--- a/yesod-static/Yesod/EmbeddedStatic/Types.hs
+++ b/yesod-static/Yesod/EmbeddedStatic/Types.hs
@@ -1,9 +1,18 @@
+{-# LANGUAGE TemplateHaskell, QuasiQuotes, OverloadedStrings #-}
 module Yesod.EmbeddedStatic.Types(
     Location
-  , Entry(..)
   , Generator
+  -- ** Entry
+  , Entry
+  , ebHaskellName
+  , ebLocation
+  , ebMimeType
+  , ebProductionContent
+  , ebDevelReload
+  , ebDevelExtraFiles
 ) where
 
+import Data.Default
 import Language.Haskell.TH
 import Network.Mime (MimeType)
 import qualified Data.ByteString.Lazy as BL
@@ -13,6 +22,9 @@ import qualified Data.ByteString.Lazy as BL
 type Location = String
 
 -- | A single resource embedded into the executable at compile time.
+--
+-- This data type is a settings type.  For more information, see
+-- <http://www.yesodweb.com/book/settings-types>.
 data Entry = Entry {
     ebHaskellName :: Maybe Name
         -- ^ An optional haskell name. If the name is present, a variable
@@ -40,6 +52,16 @@ data Entry = Entry {
         --   taking as input the list of path pieces and optionally returning a mime type
         --   and content.
 }
+
+-- | When using 'def', you must fill in at least 'ebLocation'.
+instance Default Entry where
+    def = Entry { ebHaskellName = Nothing
+                , ebLocation = "xxxx"
+                , ebMimeType = "application/octet-stream"
+                , ebProductionContent = return BL.empty
+                , ebDevelReload = [| return BL.empty |]
+                , ebDevelExtraFiles = Nothing
+                }
 
 -- | An embedded generator is executed at compile time to produce the entries to embed.
 type Generator = Q [Entry]

--- a/yesod-static/test/EmbedTestGenerator.hs
+++ b/yesod-static/test/EmbedTestGenerator.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell, QuasiQuotes, OverloadedStrings #-}
 module EmbedTestGenerator (testGen) where
 
+import Data.Default
 import Network.Mime (MimeType)
 import Yesod.EmbeddedStatic.Types
 import Yesod.EmbeddedStatic.Generators (pathToName)
@@ -13,7 +14,7 @@ import qualified Data.ByteString.Lazy as BL
 e1, e2, e3, e4 :: Entry
 
 -- Basic entry
-e1 = Entry
+e1 = def
         { ebHaskellName = Just $ pathToName "e1"
         , ebLocation = "e1"
         , ebMimeType = "text/plain"
@@ -23,7 +24,7 @@ e1 = Entry
         }
 
 -- Test simulated directory in location
-e2 = Entry
+e2 = def
         { ebHaskellName = Just $ pathToName "e2"
         , ebLocation = "dir/e2"
         , ebMimeType = "abcdef"
@@ -33,7 +34,7 @@ e2 = Entry
         }
 
 -- Test empty haskell name
-e3 = Entry
+e3 = def
         { ebHaskellName = Nothing
         , ebLocation = "xxxx/e3"
         , ebMimeType = "yyy"
@@ -48,7 +49,7 @@ devExtra ["dir", "dev2"] = return $ Just ("mime2", "dev2 content")
 devExtra _ = return Nothing
 
 -- Entry with devel extra files
-e4 = Entry
+e4 = def
         { ebHaskellName = Just $ pathToName "e4"
         , ebLocation = "e4"
         , ebMimeType = "text/plain"


### PR DESCRIPTION
In the future we might want to add new features to the Entry.  One nice extension would be source maps http://www.html5rocks.com/en/tutorials/developertools/sourcemaps/ but this will need a new field in the Entry.  So before making a release with the embedded static, switch the Entry to a settings type.
