### PR TITLE
Add checkboxesField{,List} fields (based on multiSelectField{,List})

### DIFF
--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -403,12 +403,11 @@ checkboxesField ioptlist = (multiSelectField ioptlist)
             opts <- fmap olOptions $ handlerToWidget ioptlist
             let optselected (Left _) _ = False
                 optselected (Right vals) opt = (optionInternalValue opt) `elem` vals
-            let selOpts = map (id &&& (optselected val)) opts
             [whamlet|
                 <span ##{theId}>
-                    $forall (opt, optsel) <- selOpts
+                    $forall opt <- opts
                         <label>
-                            <input type=checkbox name=#{name} value=#{optionExternalValue opt} *{attrs} :optsel:checked>
+                            <input type=checkbox name=#{name} value=#{optionExternalValue opt} *{attrs} :optselected val opt:checked>
                             #{optionDisplay opt}
                 |]
     }


### PR DESCRIPTION
Issue #602 

I think we should have the choice between select tags and input type=checkbox tags for a multiple selection field in a form. Here I've made an adaptation based on multiSelectField{,List), it only change the view implementation (see code below).

I was wondering why isn't there already this implementation? Is there any suggestion about this? We may factorize some helpers function to avoid duplicating code (like selOpts).

PS: the field was renamed, the multiplicities of checkbox(es) is already implied, no need for 'multiple'.
