### PR TITLE
Update Socks dependency to fix build error

### DIFF
--- a/yesod-platform/yesod-platform.cabal
+++ b/yesod-platform/yesod-platform.cabal
@@ -1,5 +1,5 @@
 name:            yesod-platform
-version:         1.2.4.2
+version:         1.2.4.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -104,7 +104,7 @@ library
                  , silently == 1.2.4.1
                  , simple-sendfile == 0.2.12
                  , skein == 1.0.6
-                 , socks == 0.5.1
+                 , socks == 0.5.3
                  , stringsearch == 0.3.6.4
                  , system-fileio == 0.3.11
                  , system-filepath == 0.4.7


### PR DESCRIPTION
Socks 0.5.1 does not build on my machine, 0.5.3 fixes the ambiguous identifier `sClose` imported from `Network` and `Network.Sockets`.
