### PR TITLE
Generating hsfiles file with the --hsfiles switch in yesod init

### DIFF
--- a/yesod-bin/HsFile.hs
+++ b/yesod-bin/HsFile.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE TupleSections, OverloadedStrings #-}
+module HsFile (mkHsFile) where
+import Text.ProjectTemplate (createTemplate)
+import Data.Conduit
+import Data.Conduit.Binary (sourceFile, conduitFile, sinkHandle) 
+import qualified Data.Conduit.List as CL
+import Data.List (partition)
+import Prelude hiding (FilePath)
+import Filesystem.Path.CurrentOS (decodeString, encodeString)
+import Filesystem.Path 
+    ( FilePath, append, (</>), splitDirectories, filename
+    , addExtension)
+import qualified Data.ByteString as BS
+import Control.Monad.IO.Class (liftIO)
+import Control.Applicative ( (<$>) )
+import System.Directory 
+    ( getDirectoryContents, doesDirectoryExist
+    , getCurrentDirectory, getTemporaryDirectory
+    , copyFile, removeFile)
+import System.IO (hClose, openBinaryFile ,IOMode(WriteMode))
+import Data.Void (Void)
+
+-- meh
+doesDirectoryExistGood = doesDirectoryExist.encodeString
+getDirectoryContentsGood fp =
+    map decodeString <$> getDirectoryContents (encodeString fp)
+
+-- Lists all the contents of a dir, including the files in subdirs
+getAllDirContents :: FilePath -> IO [FilePath]
+getAllDirContents dirname = do
+    exists <- doesDirectoryExistGood dirname
+    if exists
+        then do
+            contents <- getDirectoryContentsGood dirname
+            let c = filter (\f -> f /= ".." && f /= ".") contents
+            otherDirs <- mapM (doesDirectoryExistGood.append dirname) c
+            let zippedDirs = zip c otherDirs
+                filesAndDirs = (\(l1, l2) -> (fst $ unzip l1, fst $ unzip l2)) $
+                                    partition (not.snd) zippedDirs
+            dirs <- mapM getAllDirContents 
+                        (map (append dirname) (snd filesAndDirs))
+            return $ map (append dirname) (fst filesAndDirs) ++ (concat dirs)
+        else return []
+
+-- The final file should be dumped to a tmp directory
+-- The name of the file is the same as the current directory name
+destinationPath :: IO FilePath
+destinationPath = do
+    curdir <- getCurrentDirectory
+    tmpdir <- getTemporaryDirectory
+    exists <- doesDirectoryExist tmpdir
+    let file = addExtension (filename $ decodeString curdir) "hsfiles"
+        dir = decodeString $ if exists then tmpdir else ".."
+    return $ dir </> file
+
+-- This is it
+mkHsFile :: IO ()
+mkHsFile = do
+    hsfile <- destinationPath
+    infiles <- getAllDirContents "."
+    runResourceT $ CL.sourceList infiles 
+        $$ readIt
+        =$ createTemplate 
+        =$ sinkFileAndMoveIt (encodeString hsfile)
+
+-- Reads a filepath from upstream and dumps a pair of 
+readIt :: ConduitM FilePath (FilePath, ResourceT IO BS.ByteString) (ResourceT IO) ()
+readIt = awaitForever $ \i -> do bs <- liftIO $ BS.readFile (encodeString i)
+                                 yield (i, return bs)
+
+-- Move the file from the temporary directory after the sink is finished
+sinkFileAndMoveIt :: MonadResource m => String -> ConduitM BS.ByteString Void m ()
+sinkFileAndMoveIt fp = 
+    bracketP (openBinaryFile fp WriteMode) leGrandFinale sinkHandle
+    where curDirFp = encodeString $ decodeString "." </> filename (decodeString fp)
+          leGrandFinale h = do hClose h
+                               copyFile fp curDirFp
+                               removeFile fp 
+

--- a/yesod-bin/main.hs
+++ b/yesod-bin/main.hs
@@ -22,6 +22,7 @@ import           Options.Applicative.Types (ReadM (ReadM))
 
 #ifndef WINDOWS
 import           Build                  (touch)
+import           HsFile                 (mkHsFile)
 
 touch' :: IO ()
 touch' = touch
@@ -45,7 +46,7 @@ data Options = Options
                }
   deriving (Show, Eq)
 
-data Command = Init { _initBare :: Bool }
+data Command = Init { _initBare, _initHsFiles :: Bool }
              | Configure
              | Build { buildExtraArgs   :: [String] }
              | Touch
@@ -92,7 +93,7 @@ main = do
                                              ] optParser'
   let cabal xs = rawSystem' (cabalCommand o) xs
   case optCommand o of
-    Init bare               -> scaffold bare
+    Init bare hsfiles       -> if hsfiles then mkHsFile else scaffold bare
     Configure               -> cabal ["configure"]
     Build es                -> touch' >> cabal ("build":es)
     Touch                   -> touch'
@@ -113,7 +114,8 @@ optParser = Options
         <$> flag Cabal CabalDev ( long "dev"     <> short 'd' <> help "use cabal-dev" )
         <*> switch              ( long "verbose" <> short 'v' <> help "More verbose output" )
         <*> subparser ( command "init"
-                            (info (Init <$> (switch (long "bare" <> help "Create files in current folder")))
+                            (info (Init <$> (switch (long "bare" <> help "Create files in current folder"))
+                                        <*> (switch (long "hsfiles" <> help "Create a hsfiles file for the current folder")))
                             (progDesc "Scaffold a new site"))
                       <> command "configure" (info (pure Configure)
                             (progDesc "Configure a project for building"))

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -1,5 +1,5 @@
 name:            yesod-bin
-version:         1.2.3.4
+version:         1.2.3.5
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -87,6 +87,7 @@ executable             yesod
                      , transformers
                      , warp               >= 1.3.7.5
                      , wai                >= 1.4
+                     , void               >= 0.6
 
     ghc-options:       -Wall -threaded
     main-is:           main.hs
@@ -98,6 +99,7 @@ executable             yesod
                        AddHandler
                        Paths_yesod_bin
                        Options
+                       HsFile
 
 source-repository head
   type:     git


### PR DESCRIPTION
This patch creates a new file "HsFile.hs" in yesod-bin, and adjusts main.hs to allow the --hsfiles flag in yesod init. 
The HsFile module goes through all the files in the current directory and subdirectory and returns a list of FilePath that is consumed by the createTemplate, this is my first try with conduits so the code is prone to heavy adjustments.

I made some simple tests with some folders and yesod init managed to reproduce them well.
