### PR TITLE
Change doubleField type from text to number

### DIFF
--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -121,7 +121,7 @@ doubleField = Field
 
     , fieldView = \theId name attrs val isReq -> toWidget [hamlet|
 $newline never
-<input id="#{theId}" name="#{name}" *{attrs} type="text" :isReq:required="" value="#{showVal val}">
+<input id="#{theId}" name="#{name}" *{attrs} type="number" :isReq:required="" value="#{showVal val}">
 |]
     , fieldEnctype = UrlEncoded
     }


### PR DESCRIPTION
With type number we are able to use some of HTML5 attributes.
