### PR TITLE
newsfeed/atom: Wrap the name of the author in a name element.

### DIFF
--- a/yesod-newsfeed/Yesod/AtomFeed.hs
+++ b/yesod-newsfeed/Yesod/AtomFeed.hs
@@ -62,7 +62,7 @@ template Feed {..} render =
         : Element "link" (Map.singleton "href" $ render feedLinkHome) []
         : Element "updated" Map.empty [NodeContent $ formatW3 feedUpdated]
         : Element "id" Map.empty [NodeContent $ render feedLinkHome]
-        : Element "author" Map.empty [NodeContent feedAuthor]
+        : Element "author" Map.empty [NodeElement $ Element "name" Map.empty [NodeContent feedAuthor]]
         : map (flip entryTemplate render) feedEntries
 
 entryTemplate :: FeedEntry url -> (url -> Text) -> Element


### PR DESCRIPTION
This fixes an validation error (http://validator.w3.org/feed).

According to http://tools.ietf.org/html/rfc4287 the atom:author
element contains a person construct, that is it contains at least the
name element.

No further elements of the person construct are added, as there is no
representation for them in the current Feed type.
