### PR TITLE
Defer error handling of runInputForm to user code.

### DIFF
--- a/yesod-form/Yesod/Form/Input.hs
+++ b/yesod-form/Yesod/Form/Input.hs
@@ -72,5 +72,15 @@ runInputPost (FormInput f) = do
     l <- languages
     emx <- f m l env fenv
     case emx of
+        Left errs -> invalidArgs $ errs []
+        Right x -> return x
+
+runInputPostResult :: MonadHandler m => FormInput m a -> m (FormResult a)
+runInputPostResult (FormInput f) = do
+    (env, fenv) <- liftM (toMap *** toMap) runRequestBody
+    m <- getYesod
+    l <- languages
+    emx <- f m l env fenv
+    case emx of
         Left errs -> return $ FormFailure (errs [])
-        Right x -> return (FormSuccess x)
+        Right x   -> return $ FormSuccess x


### PR DESCRIPTION
Input forms are handy because they leave the user complete control of the markup, which is often necessary.
One thing makes them unusable though, and that's the error handling. Redirecting to an error page (invalidArgs) is something users will never accept, as opposed to displaying an error message above the form and letting the user try again.
This is a first attempt at enabling this. I'm very happy to get feedback and improve this, considering that I'm a beginner at Yesod, and that I'm aware this is a ridiculously simple solution (and may need to be propagated to runInputGet).
I'm also aware it breaks backwards compatibility for those unhappy few who have used runInputPost before. Please consider this a start to the discussion.
