### PR TITLE
Remove deprecated RepHtml content type in yesod-auth

### DIFF
--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -110,7 +110,7 @@ class (Yesod master, PathPiece (AuthId master), RenderMessage master FormMessage
     authPlugins :: master -> [AuthPlugin master]
 
     -- | What to show on the login page.
-    loginHandler :: AuthHandler master RepHtml
+    loginHandler :: AuthHandler master Html
     loginHandler = do
         tp <- getRouteToParent
         lift $ authLayout $ do
@@ -340,7 +340,7 @@ setUltDestReferer' = lift $ do
     master <- getYesod
     when (redirectToReferer master) setUltDestReferer
 
-getLoginR :: AuthHandler master RepHtml
+getLoginR :: AuthHandler master Html
 getLoginR = setUltDestReferer' >> loginHandler
 
 getLogoutR :: AuthHandler master ()


### PR DESCRIPTION
Hi, I noticed these warnings while compiling yesod-auth today.
