### PR TITLE
Switching to Data.Default.Class in yesod-bin.

### DIFF
--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -69,7 +69,7 @@ import           Data.Conduit.Network                  (HostPreference (HostIPv4
 import           Network                               (withSocketsDo)
 #if MIN_VERSION_http_conduit(2, 0, 0)
 import           Network.HTTP.Conduit                  (conduitManagerSettings, newManager)
-import           Data.Default                          (def)
+import           Data.Default.Class                    (def)
 #else
 import           Network.HTTP.Conduit                  (def, newManager)
 #endif

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -89,7 +89,7 @@ executable             yesod
                      , transformers
                      , warp               >= 1.3.7.5
                      , wai                >= 1.4
-                     , data-default
+                     , data-default-class
 
     ghc-options:       -Wall -threaded
     main-is:           main.hs


### PR DESCRIPTION
Hello! I'm new to Yesod and was trying to build from Hackage today and encountered an issue that required me to do some patching. I figured I'd submit this pull request to bring it to your attention.

I was trying to build yesod-bin (along with http-request-proxy, I'm submitting a similar pull request there) today and noticed breakages when compiling due to a change in http-client from Data.Default to Data.Default.Class in this commit:

https://github.com/snoyberg/http-client/commit/c9fc8fe33af902b9c3904295188d3e0f710bd0c9

I'm not sure if Data.Default.Class or Data.Default is the intended choice for the framework, but I thought I'd bring this to your attention. As of now I can't build yesod-bin or http-reverse-client because of this issue when pulling them from Hackage. This is a pretty minor change, and I'm not 100% sure of the reason why the upstream change was made, so feel free to take it or leave it for your own purposes. Thanks for your time!
