### PR TITLE
Added a createOnClickOverride function to BrowserId

### DIFF
--- a/yesod-auth/Yesod/Auth/BrowserId.hs
+++ b/yesod-auth/Yesod/Auth/BrowserId.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RecordWildCards #-}
 module Yesod.Auth.BrowserId
     ( authBrowserId
-    , createOnClick
+    , createOnClick, createOnClickOverride
     , def
     , BrowserIdSettings
     , bisAudience
@@ -107,14 +107,16 @@ $newline never
 
 -- | Generates a function to handle on-click events, and returns that function
 -- name.
-createOnClick :: BrowserIdSettings
+createOnClickOverride :: BrowserIdSettings
               -> (Route Auth -> Route master)
+              -> Maybe (Route master)
               -> WidgetT master IO Text
-createOnClick BrowserIdSettings {..} toMaster = do
+createOnClickOverride BrowserIdSettings {..} toMaster mOnRegistration = do
     unless bisLazyLoad $ addScriptRemote browserIdJs
     onclick <- newIdent
     render <- getUrlRender
-    let login = toJSON $ getPath $ render (toMaster LoginR)
+    let login = toJSON $ getPath $ render loginRoute -- (toMaster LoginR)
+        loginRoute = maybe (toMaster LoginR) id mOnRegistration
     toWidget [julius|
         function #{rawJS onclick}() {
             if (navigator.id) {
@@ -152,3 +154,10 @@ createOnClick BrowserIdSettings {..} toMaster = do
     getPath t = fromMaybe t $ do
         uri <- parseURI $ T.unpack t
         return $ T.pack $ uriPath uri
+
+-- | Generates a function to handle on-click events, and returns that function
+-- name.
+createOnClick :: BrowserIdSettings
+              -> (Route Auth -> Route master)
+              -> WidgetT master IO Text
+createOnClick bidSettings toMaster = createOnClickOverride bidSettings toMaster Nothing

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.2.6
+version:         1.2.7
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
When a user registers a new persona account, we should allow library users to choose the route that the new user gets redirected to in case they want to explain the Persona/BrowserId flow or do something else..  This should have no effect on any other parts of the library.
