### PR TITLE
Reinstate HashDB, with compatible security enhancement

### DIFF
--- a/yesod-auth/Yesod/Auth/HashDB.hs
+++ b/yesod-auth/Yesod/Auth/HashDB.hs
@@ -128,9 +128,8 @@ import Yesod.Core
 import Control.Applicative         ((<$>), (<*>))
 import Data.Typeable
 
-import qualified Data.ByteString.Lazy.Char8 as BL (pack)
 import qualified Data.ByteString.Char8 as BS (pack, unpack)
-import Data.Digest.Pure.SHA        (sha1, showDigest)
+import qualified Crypto.Hash as CH (SHA1, Digest, hash)
 import Data.Text                   (Text, pack, unpack, append)
 import Data.Maybe                  (fromMaybe)
 import Crypto.PasswordStore        (makePassword, verifyPassword,
@@ -193,8 +192,8 @@ class HashDBUser user where
 saltedHash :: Text              -- ^ Salt
            -> Text              -- ^ Password
            -> Text
-saltedHash salt = 
-  pack . showDigest . sha1 . BL.pack . unpack . append salt
+saltedHash salt pw =
+  pack $ show (CH.hash $ BS.pack $ unpack $ append salt pw :: CH.Digest CH.SHA1)
 
 -- | Calculate a new-style password hash using "Crypto.PasswordStore".
 passwordHash :: MonadIO m => Int -> Text -> m Text

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -55,7 +55,6 @@ library
                    , resourcet
                    , safe
                    , time
-                   , SHA
 
     exposed-modules: Yesod.Auth
                      Yesod.Auth.BrowserId


### PR DESCRIPTION
I would like to propose reinstating HashDB, but with this security enhancement to fix https://github.com/yesodweb/yesod/issues/668.  It now uses Crypto.PasswordStore, but falls back to the old hash algorithm for verification if it finds database entries of the old format.  It also provides an upgrade path which can be used on the database entries alone to strengthen them, avoiding the main security problem of the old algorithm (that a single round of SHA is too fast).

I am aware of yesod-auth-bcrypt, but it is not compatible with existing databases, and at the moment does not compile with the latest Yesod Platform.  I have put my efforts into this one because it is vitally important to me to have compatibility, plus a suitable upgrade path for existing databases.

You will see I've added my name as the maintainer - I am happy to do that, since I have to have this module for a real application!
