### PR TITLE
Strictly evaluate arguments of setSession* and deleteSession.

### DIFF
--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE BangPatterns               #-}
 ---------------------------------------------------------
 --
 -- Module        : Yesod.Handler
@@ -718,13 +719,11 @@ setSessionBS :: MonadHandler m
              => Text
              -> S.ByteString
              -> m ()
-setSessionBS k bs =
-    liftIO (evaluate $ k `seq` bs) >>= modify . modSession . Map.insert k
+setSessionBS !k !bs = modify . modSession $ Map.insert k bs
 
 -- | Unsets a session variable. See 'setSession'.
 deleteSession :: MonadHandler m => Text -> m ()
-deleteSession k =
-    liftIO (evaluate k) >>= modify . modSession . Map.delete
+deleteSession !k = modify . modSession $ Map.delete k
 
 -- | Clear all session variables.
 --


### PR DESCRIPTION
It seems that passing _|_ to these functions leads to a big explosion
inside Yesod [1].  This commit makes these functions evaluate their
arguments on the spot in order to avoid these confusing errors in the future.

[1] https://github.com/prowdsponsor/mangopay/commit/aae5d92f9b3

Ping @JPMoresmau.
