### PR TITLE
Fix starting field number

### DIFF
--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -182,7 +182,7 @@ runFormGeneric :: Monad m
                -> [Text]
                -> Maybe (Env, FileEnv)
                -> m (a, Enctype)
-runFormGeneric form site langs env = evalRWST form (env, site, langs) (IntSingle 1)
+runFormGeneric form site langs env = evalRWST form (env, site, langs) (IntSingle 0)
 
 -- | This function is used to both initially render a form and to later extract
 -- results from it. Note that, due to CSRF protection and a few other issues,


### PR DESCRIPTION
This commit makes starts the counter as `IntSingle 0` instead of `IntSingle 1`. This is needed because `newFormIdent` yield the incremented state value. Meaning: right now, all of my forms start at f2 instead of f1. This commit will make them start at f1 like I would expect them to.
