### PR TITLE
Auth.Email: modern buttons, use translation RegisterLong

### DIFF
--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -250,8 +250,11 @@ $newline never
                 <input type="password" name="password">
         <tr>
             <td colspan="2">
-                <input type="submit" value=_{Msg.LoginViaEmail}>
-                <a href="@{tm registerR}">I don't have an account
+                <button type=submit .btn .btn-success>
+                    _{Msg.LoginViaEmail}
+                &nbsp;
+                <a href="@{tm registerR}" .btn .btn-default>
+                    _{Msg.RegisterLong}
 |]
   where
     dispatch "GET" ["register"] = getRegisterR >>= sendResponse


### PR DESCRIPTION
The Email Auth plugin is not up to date, here I propose:
- to use the translated message for account creation (instead of hardconding: "I don't have an account").
- nice and homogeneous stylized buttons (thanks to Bootstrap CSS).

Test and in production. Any remark?
