### PR TITLE
yesod-bin.cabal grant developers rtsopts

### DIFF
--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -95,7 +95,7 @@ executable             yesod
                      , data-default-class
                      , streaming-commons
 
-    ghc-options:       -Wall -threaded
+    ghc-options:       -Wall -threaded -rtsopts
     main-is:           main.hs
     other-modules:     Scaffolding.Scaffolder
                        Devel


### PR DESCRIPTION
Sometimes yesod (yesod-bin) needs a stack space boost. Large projects can suffer stack overflows during development rebuilds.
