### PR TITLE
Add support for reloading in GHCi

### DIFF
--- a/yesod-bin/hsfiles/mongo.hsfiles
+++ b/yesod-bin/hsfiles/mongo.hsfiles
@@ -7987,3 +7987,52 @@ main = do
         yesodSpec foundation $ do
             homeSpecs
 
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+{-# START_FILE DevelMain.hs #-}
+-- | Development version to be run inside GHCi.
+
+module DevelMain where
+
+import Application (getApplicationDev)
+
+import Control.Exception (finally)
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+
+-- | Start or restart the server.
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tid_1
+    case mtidStore of
+      Nothing -> do
+          done <- newEmptyMVar
+          _done_0 <- newStore done
+          tid <- start done
+          tidRef <- newIORef tid
+          _tid_1 <- newStore tidRef
+          return ()
+      Just tidStore -> do
+          tidRef <- readStore tidStore
+          tid <- readIORef tidRef
+          done <- readStore (Store done_0)
+          killThread tid
+          takeMVar done
+          newTid <- start done
+          writeIORef tidRef newTid
+  where tid_1 = 1
+        done_0 = 0
+
+-- | Start the server in a separate thread.
+start :: MVar () -- ^ Written to when the thread is killed.
+      -> IO ThreadId
+start done = do
+    (port,app) <- getApplicationDev
+    forkIO (finally (runSettings (setPort port defaultSettings) app)
+                    (putMVar done ()))

--- a/yesod-bin/hsfiles/mysql.hsfiles
+++ b/yesod-bin/hsfiles/mysql.hsfiles
@@ -8015,3 +8015,52 @@ main = do
         yesodSpec foundation $ do
             homeSpecs
 
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+{-# START_FILE DevelMain.hs #-}
+-- | Development version to be run inside GHCi.
+
+module DevelMain where
+
+import Application (getApplicationDev)
+
+import Control.Exception (finally)
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+
+-- | Start or restart the server.
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tid_1
+    case mtidStore of
+      Nothing -> do
+          done <- newEmptyMVar
+          _done_0 <- newStore done
+          tid <- start done
+          tidRef <- newIORef tid
+          _tid_1 <- newStore tidRef
+          return ()
+      Just tidStore -> do
+          tidRef <- readStore tidStore
+          tid <- readIORef tidRef
+          done <- readStore (Store done_0)
+          killThread tid
+          takeMVar done
+          newTid <- start done
+          writeIORef tidRef newTid
+  where tid_1 = 1
+        done_0 = 0
+
+-- | Start the server in a separate thread.
+start :: MVar () -- ^ Written to when the thread is killed.
+      -> IO ThreadId
+start done = do
+    (port,app) <- getApplicationDev
+    forkIO (finally (runSettings (setPort port defaultSettings) app)
+                    (putMVar done ()))

--- a/yesod-bin/hsfiles/postgres-fay.hsfiles
+++ b/yesod-bin/hsfiles/postgres-fay.hsfiles
@@ -8101,3 +8101,52 @@ main = do
         yesodSpec foundation $ do
             homeSpecs
 
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+{-# START_FILE DevelMain.hs #-}
+-- | Development version to be run inside GHCi.
+
+module DevelMain where
+
+import Application (getApplicationDev)
+
+import Control.Exception (finally)
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+
+-- | Start or restart the server.
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tid_1
+    case mtidStore of
+      Nothing -> do
+          done <- newEmptyMVar
+          _done_0 <- newStore done
+          tid <- start done
+          tidRef <- newIORef tid
+          _tid_1 <- newStore tidRef
+          return ()
+      Just tidStore -> do
+          tidRef <- readStore tidStore
+          tid <- readIORef tidRef
+          done <- readStore (Store done_0)
+          killThread tid
+          takeMVar done
+          newTid <- start done
+          writeIORef tidRef newTid
+  where tid_1 = 1
+        done_0 = 0
+
+-- | Start the server in a separate thread.
+start :: MVar () -- ^ Written to when the thread is killed.
+      -> IO ThreadId
+start done = do
+    (port,app) <- getApplicationDev
+    forkIO (finally (runSettings (setPort port defaultSettings) app)
+                    (putMVar done ()))

--- a/yesod-bin/hsfiles/postgres.hsfiles
+++ b/yesod-bin/hsfiles/postgres.hsfiles
@@ -7989,3 +7989,52 @@ main = do
         yesodSpec foundation $ do
             homeSpecs
 
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+{-# START_FILE DevelMain.hs #-}
+-- | Development version to be run inside GHCi.
+
+module DevelMain where
+
+import Application (getApplicationDev)
+
+import Control.Exception (finally)
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+
+-- | Start or restart the server.
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tid_1
+    case mtidStore of
+      Nothing -> do
+          done <- newEmptyMVar
+          _done_0 <- newStore done
+          tid <- start done
+          tidRef <- newIORef tid
+          _tid_1 <- newStore tidRef
+          return ()
+      Just tidStore -> do
+          tidRef <- readStore tidStore
+          tid <- readIORef tidRef
+          done <- readStore (Store done_0)
+          killThread tid
+          takeMVar done
+          newTid <- start done
+          writeIORef tidRef newTid
+  where tid_1 = 1
+        done_0 = 0
+
+-- | Start the server in a separate thread.
+start :: MVar () -- ^ Written to when the thread is killed.
+      -> IO ThreadId
+start done = do
+    (port,app) <- getApplicationDev
+    forkIO (finally (runSettings (setPort port defaultSettings) app)
+                    (putMVar done ()))

--- a/yesod-bin/hsfiles/simple.hsfiles
+++ b/yesod-bin/hsfiles/simple.hsfiles
@@ -7840,3 +7840,52 @@ main = do
         yesodSpec foundation $ do
             homeSpecs
 
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+{-# START_FILE DevelMain.hs #-}
+-- | Development version to be run inside GHCi.
+
+module DevelMain where
+
+import Application (getApplicationDev)
+
+import Control.Exception (finally)
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+
+-- | Start or restart the server.
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tid_1
+    case mtidStore of
+      Nothing -> do
+          done <- newEmptyMVar
+          _done_0 <- newStore done
+          tid <- start done
+          tidRef <- newIORef tid
+          _tid_1 <- newStore tidRef
+          return ()
+      Just tidStore -> do
+          tidRef <- readStore tidStore
+          tid <- readIORef tidRef
+          done <- readStore (Store done_0)
+          killThread tid
+          takeMVar done
+          newTid <- start done
+          writeIORef tidRef newTid
+  where tid_1 = 1
+        done_0 = 0
+
+-- | Start the server in a separate thread.
+start :: MVar () -- ^ Written to when the thread is killed.
+      -> IO ThreadId
+start done = do
+    (port,app) <- getApplicationDev
+    forkIO (finally (runSettings (setPort port defaultSettings) app)
+                    (putMVar done ()))

--- a/yesod-bin/hsfiles/sqlite.hsfiles
+++ b/yesod-bin/hsfiles/sqlite.hsfiles
@@ -7985,3 +7985,53 @@ main = do
         yesodSpec foundation $ do
             homeSpecs
 
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+
+{-# START_FILE DevelMain.hs #-}
+-- | Development version to be run inside GHCi.
+
+module DevelMain where
+
+import Application (getApplicationDev)
+
+import Control.Exception (finally)
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+
+-- | Start or restart the server.
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tid_1
+    case mtidStore of
+      Nothing -> do
+          done <- newEmptyMVar
+          _done_0 <- newStore done
+          tid <- start done
+          tidRef <- newIORef tid
+          _tid_1 <- newStore tidRef
+          return ()
+      Just tidStore -> do
+          tidRef <- readStore tidStore
+          tid <- readIORef tidRef
+          done <- readStore (Store done_0)
+          killThread tid
+          takeMVar done
+          newTid <- start done
+          writeIORef tidRef newTid
+  where tid_1 = 1
+        done_0 = 0
+
+-- | Start the server in a separate thread.
+start :: MVar () -- ^ Written to when the thread is killed.
+      -> IO ThreadId
+start done = do
+    (port,app) <- getApplicationDev
+    forkIO (finally (runSettings (setPort port defaultSettings) app)
+                    (putMVar done ()))


### PR DESCRIPTION
This adds two files:
- A `.dir-locals.el` file which will be automatically picked up by Emacs and set the right indentation level (`4`) and if the user is using the haskell-mode auto-restart command, it will use GHCi to do so.
- Adds the necessary `DevelMain` file.

I've made about four new Yesod projects so far since first trying the approach [here](https://github.com/chrisdone/ghci-reload-demo#safer-way) and more or less the code is always the same module below which I now tend to copy/paste. This indicates to me that it might be a good time to add it to the scaffold maker. 

While the update in-place of the handler (documented [here](https://github.com/chrisdone/ghci-reload-demo#ides-role)) on can often work, more complicated sites with initializations tends to cause GHCi panics, so I'm including in this patch the conservative kill-thread-and-start-thread approach. For small sites there's no speed difference.

May've missed something, this is the first time I've looked at this scaffold stuff, but I've tested that it generates the right files and content: 

```
$ dist/build/yesod/yesod init
…
Project name: x
…
$ ls x/.dir-locals.el x/DevelMain.hs 
x/DevelMain.hs  x/.dir-locals.el
```
