### PR TITLE
Make requireAuth and requireAuthId class methods for YesodAuth class

### DIFF
--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -163,16 +163,6 @@ class (Yesod master, PathPiece (AuthId master), RenderMessage master FormMessage
         => HandlerT master IO (Maybe (AuthId master))
     maybeAuthId = defaultMaybeAuthId
 
-    -- | Similar to 'maybeAuthId', but redirects to a login page if user is not
-    -- authenticated.
-    --
-    -- Since 1.1.0
-    requireAuthId :: YesodAuthPersist master => HandlerT master IO (AuthId master)
-    requireAuthId = maybeAuthId >>= maybe redirectLogin return
-
-    requireAuth :: YesodAuthPersist master => HandlerT master IO (Entity (AuthEntity master))
-    requireAuth = maybeAuth >>= maybe redirectLogin return
-
 credsKey :: Text
 credsKey = "_ID"
 
@@ -386,6 +376,15 @@ type YesodAuthPersist master =
 -- Since 1.2.0
 type AuthEntity master = KeyEntity (AuthId master)
 
+-- | Similar to 'maybeAuthId', but redirects to a login page if user is not
+-- authenticated.
+--
+-- Since 1.1.0
+requireAuthId :: YesodAuthPersist master => HandlerT master IO (AuthId master)
+requireAuthId = maybeAuthId >>= maybe redirectLogin return
+
+requireAuth :: YesodAuthPersist master => HandlerT master IO (Entity (AuthEntity master))
+requireAuth = maybeAuth >>= maybe redirectLogin return
 
 redirectLogin :: Yesod master => HandlerT master IO a
 redirectLogin = do

--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -163,6 +163,16 @@ class (Yesod master, PathPiece (AuthId master), RenderMessage master FormMessage
         => HandlerT master IO (Maybe (AuthId master))
     maybeAuthId = defaultMaybeAuthId
 
+    -- | Similar to 'maybeAuthId', but redirects to a login page if user is not
+    -- authenticated.
+    --
+    -- Since 1.1.0
+    requireAuthId :: YesodAuthPersist master => HandlerT master IO (AuthId master)
+    requireAuthId = maybeAuthId >>= maybe redirectLogin return
+
+    requireAuth :: YesodAuthPersist master => HandlerT master IO (Entity (AuthEntity master))
+    requireAuth = maybeAuth >>= maybe redirectLogin return
+
 credsKey :: Text
 credsKey = "_ID"
 
@@ -376,15 +386,6 @@ type YesodAuthPersist master =
 -- Since 1.2.0
 type AuthEntity master = KeyEntity (AuthId master)
 
--- | Similar to 'maybeAuthId', but redirects to a login page if user is not
--- authenticated.
---
--- Since 1.1.0
-requireAuthId :: YesodAuthPersist master => HandlerT master IO (AuthId master)
-requireAuthId = maybeAuthId >>= maybe redirectLogin return
-
-requireAuth :: YesodAuthPersist master => HandlerT master IO (Entity (AuthEntity master))
-requireAuth = maybeAuth >>= maybe redirectLogin return
 
 redirectLogin :: Yesod master => HandlerT master IO a
 redirectLogin = do

--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -26,10 +26,10 @@ module Yesod.Auth
     , loginErrorMessage
     , loginErrorMessageI
       -- * User functions
+    , requireAuth
     , defaultMaybeAuthId
     , maybeAuth
     , requireAuthId
-    , requireAuth
       -- * Exception
     , AuthException (..)
       -- * Helper
@@ -145,7 +145,8 @@ class (Yesod master, PathPiece (AuthId master), RenderMessage master FormMessage
     -- session. This can be overridden to allow authentication via other means,
     -- such as checking for a special token in a request header. This is
     -- especially useful for creating an API to be accessed via some means
-    -- other than a browser.
+    -- other than a browser or creating additional site specific requirements
+    -- for when the authentication system.
     --
     -- Since 1.2.0
     maybeAuthId :: HandlerT master IO (Maybe (AuthId master))
@@ -383,6 +384,14 @@ type AuthEntity master = KeyEntity (AuthId master)
 requireAuthId :: YesodAuthPersist master => HandlerT master IO (AuthId master)
 requireAuthId = maybeAuthId >>= maybe redirectLogin return
 
+-- | Similar to 'maybeAuth', but redirects to a login page if user is not
+-- authenticated.
+--
+-- If we think of 'requireAuth' in declarative terms, it says "the user must
+-- be authenticated to run this handler."  In other words, it acts as an entry
+-- point for the authentication system, guarding the handler it is called in,
+-- and ensuring that all of the authentication requirements are met.  To customize
+-- these requirements, override 'maybeAuthId'.
 requireAuth :: YesodAuthPersist master => HandlerT master IO (Entity (AuthEntity master))
 requireAuth = maybeAuth >>= maybe redirectLogin return
 


### PR DESCRIPTION
As an effort to be more constructive, I am making this pull request.

The idea is to create a simple "entry point" for users of the Auth system.  

Thesis: If we think of `requireAuth` in declarative terms, it should be saying "the user needs to be authenticated to run this Handler."  In other words, it should work like something of a guard for the Handler it gets used in.

Moving `requireAuth` to the `YesodAuth` type class gives us some flexibility.  Instead of each Yesod-using-developer having to make a class like:

    class YesodAuth master => MyAuth master where
        requireAuthentication :: Handler (AuthId master)

in order add "arbitrary" (site specific) requirements, we can just override the default method in the YesodAuth class.  More importantly, if the user uses the `MyAuth` pattern, the site specific requirements will **not** be picked up by generic framework code that calls `requireAuth`.

The name `requireAuth` is too good for the framework to take it, and not allow customization.