### PR TITLE
Fix imports in mongodb scaffolded site

### DIFF
--- a/yesod-bin/hsfiles/mongo.hsfiles
+++ b/yesod-bin/hsfiles/mongo.hsfiles
@@ -352,6 +352,8 @@ import Database.Persist.MongoDB hiding (master)
 import Language.Haskell.TH.Syntax
 import Data.Typeable (Typeable)
 
+import Prelude
+
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities
 -- at:


### PR DESCRIPTION
The .cabal file specifies NoImplicitPrelude but model.hs requires Bool. This means that the scaffolded site won't compile.
