### PR TITLE
Add feed functions to generate feeds with external links

### DIFF
--- a/yesod-newsfeed/Yesod/AtomFeed.hs
+++ b/yesod-newsfeed/Yesod/AtomFeed.hs
@@ -20,6 +20,7 @@
 -- | Generation of Atom newsfeeds.
 module Yesod.AtomFeed
     ( atomFeed
+    , atomFeedText
     , atomLink
     , RepAtom (..)
     , module Yesod.FeedTypes
@@ -46,6 +47,11 @@ atomFeed :: MonadHandler m => Feed (Route (HandlerSite m)) -> m RepAtom
 atomFeed feed = do
     render <- getUrlRender
     return $ RepAtom $ toContent $ renderLBS def $ template feed render
+
+-- | Same as @'atomFeed'@ but for @'Feed Text'@. Useful for cases where you are
+--   generating a feed of external links.
+atomFeedText :: MonadHandler m => Feed Text -> m RepAtom
+atomFeedText feed = return $ RepAtom $ toContent $ renderLBS def $ template feed id
 
 template :: Feed url -> (url -> Text) -> Document
 template Feed {..} render =

--- a/yesod-newsfeed/Yesod/Feed.hs
+++ b/yesod-newsfeed/Yesod/Feed.hs
@@ -17,6 +17,7 @@
 -------------------------------------------------------------------------------
 module Yesod.Feed
     ( newsFeed
+    , newsFeedText
     , module Yesod.FeedTypes
     ) where
 
@@ -29,3 +30,10 @@ newsFeed :: MonadHandler m => Feed (Route (HandlerSite m)) -> m TypedContent
 newsFeed f = selectRep $ do
     provideRep $ atomFeed f
     provideRep $ rssFeed f
+
+-- | Same as @'newsFeed'@ but for @'Feed Text'@. Useful for cases where you are
+--   generating a feed of external links.
+newsFeedText :: MonadHandler m => Feed Text -> m TypedContent
+newsFeedText f = selectRep $ do
+    provideRep $ atomFeedText f
+    provideRep $ rssFeedText f

--- a/yesod-newsfeed/Yesod/RssFeed.hs
+++ b/yesod-newsfeed/Yesod/RssFeed.hs
@@ -16,6 +16,7 @@
 -------------------------------------------------------------------------------
 module Yesod.RssFeed
     ( rssFeed
+    , rssFeedText
     , rssLink
     , RepRss (..)
     , module Yesod.FeedTypes
@@ -43,6 +44,11 @@ rssFeed :: MonadHandler m => Feed (Route (HandlerSite m)) -> m RepRss
 rssFeed feed = do
     render <- getUrlRender
     return $ RepRss $ toContent $ renderLBS def $ template feed render
+
+-- | Same as @'rssFeed'@ but for @'Feed Text'@. Useful for cases where you are
+--   generating a feed of external links.
+rssFeedText :: MonadHandler m => Feed Text -> m RepRss
+rssFeedText feed = return $ RepRss $ toContent $ renderLBS def $ template feed id
 
 template :: Feed url -> (url -> Text) -> Document
 template Feed {..} render =


### PR DESCRIPTION
We ran into a situation yesterday where we needed to generate a feed of
external links (so `Text`, not `Route m`). The Feed types are parameterized, so
they support it, but the generation functions require routes and use
`getUrlRenderer` to render them.

The simplest fix was to duplicate the generation functions as versions that
take `Feed Text` and use `id` as the renderer.

Another option could be to use a type class, but I thought this easy,
backwards-compatible addition was a good start.

_Note_: I just pulled these changes in from some in-project hacks but don't
have the time to compile/test this PR right now. I'm hoping that travis builds
PRs so I may not have to; if that's not the case, I'll report back later when I
do get the time to ensure there are no typos here, etc.
