### PR TITLE
importing Prelude into Model.hs so basic types can be used (Int, etc)

### DIFF
--- a/yesod-bin/hsfiles/mysql.hsfiles
+++ b/yesod-bin/hsfiles/mysql.hsfiles
@@ -365,6 +365,7 @@ import Yesod
 import Data.Text (Text)
 import Database.Persist.Quasi
 import Data.Typeable (Typeable)
+import Prelude
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities

--- a/yesod-bin/hsfiles/postgres-fay.hsfiles
+++ b/yesod-bin/hsfiles/postgres-fay.hsfiles
@@ -397,6 +397,7 @@ import Yesod
 import Data.Text (Text)
 import Database.Persist.Quasi
 import Data.Typeable (Typeable)
+import Prelude
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities

--- a/yesod-bin/hsfiles/postgres.hsfiles
+++ b/yesod-bin/hsfiles/postgres.hsfiles
@@ -365,6 +365,7 @@ import Yesod
 import Data.Text (Text)
 import Database.Persist.Quasi
 import Data.Typeable (Typeable)
+import Prelude
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities

--- a/yesod-bin/hsfiles/sqlite.hsfiles
+++ b/yesod-bin/hsfiles/sqlite.hsfiles
@@ -365,6 +365,7 @@ import Yesod
 import Data.Text (Text)
 import Database.Persist.Quasi
 import Data.Typeable (Typeable)
+import Prelude
 
 -- You can define all of your database entities in the entities file.
 -- You can find more information on persistent and how to declare entities


### PR DESCRIPTION
In a default scaffolded app, adding (for example) an age to User in config/models will give an error:

`config/models`

```
User
    ident Text
    password      Text   Maybe
    age   Int 
    UniqueUser ident
    deriving Typeable
```

```
Model.hs:13:7:
    Not in scope: type constructor or class `Int'
    Perhaps you meant `Ints' (imported from Yesod)
    In the result of the splice:
      $(persistFileWith lowerCaseSettings "config/models")
    To see what the splice expanded to, use -ddump-splices
    In the second argument of `share', namely
      `$(persistFileWith lowerCaseSettings "config/models")'
    In the expression:
      share
        [mkPersist sqlOnlySettings, mkMigrate "migrateAll"]
        ($(persistFileWith lowerCaseSettings "config/models"))
```

Int, being a basic type.. seems like it should be naively available.. and users following alongish with the Yesod Book (but within a scaffolded app) for Persistent will immediately run into errors when they add the `age` for `Person`
