### PR TITLE
requireAuthId does not need YesodAuthPersist master

### DIFF
--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -56,7 +56,6 @@ import Data.Monoid (Endo)
 import Network.HTTP.Conduit (Manager)
 
 import qualified Network.Wai as W
-import Text.Hamlet (shamlet)
 
 import Yesod.Core
 import Yesod.Persist
@@ -419,7 +418,7 @@ type AuthEntity master = KeyEntity (AuthId master)
 -- authenticated.
 --
 -- Since 1.1.0
-requireAuthId :: YesodAuthPersist master => HandlerT master IO (AuthId master)
+requireAuthId :: YesodAuth master => HandlerT master IO (AuthId master)
 requireAuthId = maybeAuthId >>= maybe redirectLogin return
 
 -- | Similar to 'maybeAuth', but redirects to a login page if user is not


### PR DESCRIPTION
Hi,

requireAuthId does not do any database access, so a YesodAuth constraint should be enough.

Also removed unused import.

Cheers
