### PR TITLE
pre-baked Route Auth value

### DIFF
--- a/yesod-auth/Yesod/Auth/BrowserId.hs
+++ b/yesod-auth/Yesod/Auth/BrowserId.hs
@@ -32,6 +32,7 @@ pid = "browserid"
 forwardUrl :: AuthRoute
 forwardUrl = PluginR pid []
 
+complete :: AuthRoute
 complete = forwardUrl
 
 -- | A settings type for various configuration options relevant to BrowserID.


### PR DESCRIPTION
Added `forwardUrl` alias for `PluginR "browserid" []` as in other plugins
(e.g. GoogleEmail2 and OpenID).
