### PR TITLE
yesod-bin/Devel.hs : Relax requirements on location of Application.hs.

### DIFF
--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -416,7 +416,7 @@ checkCabalFile gpd = case D.condLibrary gpd of
            unless (null unlisted) $ do
                 putStrLn "WARNING: the following source files are not listed in exposed-modules or other-modules:"
                 mapM_ putStrLn unlisted
-           when (D.fromString "Application" `notElem` D.exposedModules dLib) $
+           when ("Application" `notElem` (map (last . D.components) $ D.exposedModules dLib)) $
                 putStrLn "WARNING: no exposed module Application"
            return (hsSourceDirs, dLib)
 


### PR DESCRIPTION
I often move Application.hs to MyApp/Application.hs (and change the
module name as needed) which would result in yesod-bin printing a
warning about a missing Application.hs.

The code should now accept any file named Application.hs (either in
the top level source directory or somewhere in the tree.

I realise this may be a little controvertial, but I'm happy to discuss it further.
