### PR TITLE
Add some minimal interaction to add-handler command

### DIFF
--- a/yesod-bin/AddHandler.hs
+++ b/yesod-bin/AddHandler.hs
@@ -22,20 +22,28 @@ addHandler = do
             [] -> error "No cabal file found"
             _ -> error "Too many cabal files found"
 
-    putStr "Name of route (without trailing R): "
-    hFlush stdout
-    name <- getLine
-    case name of
-        [] -> error "Please provide a name"
-        c:_
-            | isLower c -> error "Name must start with an upper case letter"
-            | otherwise -> return ()
+    let routeInput = do
+        putStr "Name of route (without trailing R): "
+        hFlush stdout
+        name <- getLine
+        case name of
+            [] -> error "No name entered. Quitting ..."
+            c:_
+                | isLower c -> do
+                    putStrLn "Name must start with an upper case letter"
+                    routeInput
+                | otherwise -> do
+                    -- Check that the handler file doesn't already exist
+                    let handlerFile = concat ["Handler/", name, ".hs"]
+                    exists <- doesFileExist handlerFile
+                    if exists
+                        then do
+                            putStrLn $ "File already exists: " ++ show handlerFile
+                            putStrLn "Try another name or leave blank to exit"
+                            routeInput
+                        else return (name, handlerFile)
 
-    -- Check that the handler file doesn't already exist
-    let handlerFile = concat ["Handler/", name, ".hs"]
-    exists <- doesFileExist handlerFile
-    when exists $ error $ "File already exists: " ++ show handlerFile
-
+    (name, handlerFile) <- routeInput
     putStr "Enter route pattern (ex: /entry/#EntryId): "
     hFlush stdout
     pattern <- getLine


### PR DESCRIPTION
Adding some interaction for route name input of yesod-bin's `add-handler` command.
Slightly related to recent fix https://github.com/yesodweb/yesod/commit/cfb96fd316e3b983bbb235891b991226832eb4b1 ,
