### PR TITLE
`required' attribute for nicHtmlField (textarea tag)

### DIFF
--- a/yesod-form/Yesod/Form/Nic.hs
+++ b/yesod-form/Yesod/Form/Nic.hs
@@ -26,10 +26,10 @@ class Yesod a => YesodNic a where
 nicHtmlField :: YesodNic site => Field (HandlerT site IO) Html
 nicHtmlField = Field
     { fieldParse = \e _ -> return . Right . fmap (preEscapedToMarkup . sanitizeBalance) . listToMaybe $ e
-    , fieldView = \theId name attrs val _isReq -> do
+    , fieldView = \theId name attrs val isReq -> do
         toWidget [shamlet|
 $newline never
-    <textarea id="#{theId}" *{attrs} name="#{name}" .html>#{showVal val}
+    <textarea id="#{theId}" *{attrs} name="#{name}" :isReq:required .html>#{showVal val}
 |]
         addScript' urlNicEdit
         master <- getYesod


### PR DESCRIPTION
Hi,

just made `nicHtmlField` aware of `isReq` argument passed in constructor. Currently is silently ignored.

`required` attribute is valid for `<textarea>` in HTML5 and supported by most browsers.

Take care
