### PR TITLE
fix of issue #767 (great CPU usage in devel)

### DIFF
--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -405,7 +405,7 @@ watchForChanges filesModified hsSourceDirs extraFiles list = do
     newList <- getFileList hsSourceDirs extraFiles
     if list /= newList
       then do
-        let haskellFileChanged = not $ Map.null $
+        let haskellFileChanged = not $ Map.null $ Map.filterWithKey (const . isHaskell) $
                 Map.differenceWith compareTimes newList list `Map.union`
                 Map.differenceWith compareTimes list newList
         return (haskellFileChanged, newList)


### PR DESCRIPTION
Hi,

I've played a while with an annoying issue #767 when yesod binary run in a development mode consumes inappropriate amount of CPU cycles.
There is a recent partial fix which increases polling time interval of file list check (https://github.com/paul-rouse/yesod/commit/1d3b60abefb9833e9f3d3a382ae3404313638652) however find is not quite satisfactory.

Suggested fix removes polling interval entirely as you can completely rely on `filesModified` semaphore controlled by `System.FSNotify.watchTree` . Unless there is no alteration in source tree, there is no point to perform detailed check of changes.
After the fix applied CPU usage becomes minimal when idle (drops from 15% to 1% on my computer).

I can say the fix does work for me reliably after a several days of testing without any quirks (on Linux machine). Would welcome if users of other systems can confirm whether it also works for them.