### PR TITLE
Fixes the "reader not in scope" error

### DIFF
--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -74,7 +74,7 @@ executable             yesod
                      , system-fileio      >= 0.3          && < 0.4
                      , unordered-containers
                      , yaml               >= 0.8          && < 0.9
-                     , optparse-applicative >= 0.5
+                     , optparse-applicative >= 0.5        && <= 0.9.1.1
                      , fsnotify           >= 0.0          && < 0.2
                      , split              >= 0.2          && < 0.3
                      , file-embed


### PR DESCRIPTION
This fixes the error:

[10 of 10] Compiling Main             ( main.hs, dist/build/yesod/yesod-tmp/Main.o )

main.hs:192:35:
    Not in scope: ‘reader’
    Perhaps you meant one of these:
      ‘header’ (imported from Options.Applicative),
      ‘readIO’ (imported from Prelude), ‘readLn’ (imported from Prelude)
cabal: Error: some packages failed to install:
yesod-bin-1.2.12.5 failed during the building phase. The exception was:
ExitFailure 1
