### PR TITLE
Decouple YesodAuthPersist from Persistent

### DIFF
--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -393,7 +393,7 @@ class (YesodAuth master, YesodPersist master) => YesodAuthPersist master where
     --
     -- Since 1.2.0
     type AuthEntity master :: *
-    type instance AuthEntity master = KeyEntity (AuthId master)
+    type AuthEntity master = KeyEntity (AuthId master)
 
     getAuthEntity :: AuthId master -> HandlerT master IO (Maybe (AuthEntity master))
 


### PR DESCRIPTION
Hi!  This is the change described in https://groups.google.com/d/msg/yesodweb/HDd01ymvE5Y/yMRk9UDSF-sJ.

I had some trouble getting it tested.  What’s the preferred way to get development versions of the Yesod ecosystem building/running, by the way?

The versions of the scaffolded site that use Persistent will need an extra `instance YesodAuthPersist App` in `Foundation.hs` if this goes in.
