### PR TITLE
yesod-persistent: workarount tests build failure

### DIFF
--- a/yesod-persistent/test/Yesod/PersistSpec.hs
+++ b/yesod-persistent/test/Yesod/PersistSpec.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings, TemplateHaskell, QuasiQuotes, TypeFamilies #-}
 {-# LANGUAGE EmptyDataDecls, FlexibleContexts, GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE CPP #-}
 module Yesod.PersistSpec where
 


### PR DESCRIPTION
Test failed to build as:

> test/Yesod/PersistSpec.hs:16:1:
>     Illegal instance declaration for ‘ToBackendKey SqlBackend Person’
>       (All instance types must be of the form (T t1 ... tn)
>        where T is not a synonym.
>        Use TypeSynonymInstances if you want to disable this.)
>     In the instance declaration for ‘ToBackendKey SqlBackend Person’

Might not be the best fix, please check if it makes sense.

Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
