### PR TITLE
Expose Yesod.Routes.Class

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -74,6 +74,7 @@ library
                      Yesod.Core.Widget
                      Yesod.Core.Internal
                      Yesod.Core.Types
+                     Yesod.Routes.Class
     other-modules:   Yesod.Core.Internal.Session
                      Yesod.Core.Internal.Request
                      Yesod.Core.Class.Handler
@@ -89,7 +90,6 @@ library
                      Paths_yesod_core
 
                      Yesod.Routes.TH
-                     Yesod.Routes.Class
                      Yesod.Routes.Parse
                      Yesod.Routes.Overlap
                      Yesod.Routes.TH.Dispatch


### PR DESCRIPTION
This is not necessary but it helps if there is user code that uses (Route a) in its signatures.
