### PR TITLE
expose Yesod/Routes/TH/Types.hs

### DIFF
--- a/yesod-core/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/Yesod/Routes/TH/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE TemplateHaskell #-}
+-- | Warning! This module is considered internal and may have breaking changes
 module Yesod.Routes.TH.Types
     ( -- * Data types
       Resource (..)

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -74,6 +74,7 @@ library
                      Yesod.Core.Widget
                      Yesod.Core.Internal
                      Yesod.Core.Types
+                     Yesod.Routes.TH.Types
     other-modules:   Yesod.Core.Internal.Session
                      Yesod.Core.Internal.Request
                      Yesod.Core.Class.Handler
@@ -96,7 +97,6 @@ library
                      Yesod.Routes.TH.RenderRoute
                      Yesod.Routes.TH.ParseRoute
                      Yesod.Routes.TH.RouteAttrs
-                     Yesod.Routes.TH.Types
 
     ghc-options:     -Wall
     -- Following line added due to: https://github.com/yesodweb/yesod/issues/545


### PR DESCRIPTION
We need these types for yesod-routes-typescript. They used to be exposed in yesod-routes. Perhaps the module should be given an Internal prefix? But these types seem stable now, so I am all for just exporting them for use cases like ours.
