### PR TITLE
Document Route typeclasses

### DIFF
--- a/yesod-core/Yesod/Routes/Class.hs
+++ b/yesod-core/Yesod/Routes/Class.hs
@@ -10,12 +10,15 @@ import Data.Text (Text)
 import Data.Set (Set)
 
 class Eq (Route a) => RenderRoute a where
-    -- | The type-safe URLs associated with a site argument.
+    -- | The <http://www.yesodweb.com/book/routing-and-handlers type-safe URLs> associated with a site argument.
     data Route a
-    renderRoute :: Route a -> ([Text], [(Text, Text)])
+    renderRoute :: Route a
+                -> ([Text], [(Text, Text)]) -- ^ The path of the URL split on forward slashes, and a list of query parameters with their associated value.
 
 class RenderRoute a => ParseRoute a where
-    parseRoute :: ([Text], [(Text, Text)]) -> Maybe (Route a)
+    parseRoute :: ([Text], [(Text, Text)]) -- ^ The path of the URL split on forward slashes, and a list of query parameters with their associated value.
+               -> Maybe (Route a)
 
 class RenderRoute a => RouteAttrs a where
-    routeAttrs :: Route a -> Set Text
+    routeAttrs :: Route a
+               -> Set Text -- ^ A set of <http://www.yesodweb.com/book/route-attributes attributes associated with the route>.


### PR DESCRIPTION
I found it unclear what arguments `parseRoute` took, and what `renderRoute` returned, so I documented them. I also added references to Yesod book chapters for the `routeAttrs` function and `Route` data declaration.
