### PR TITLE
Redirect dynamically in GoogleEmail2 login page

### DIFF
--- a/yesod-auth/Yesod/Auth/GoogleEmail2.hs
+++ b/yesod-auth/Yesod/Auth/GoogleEmail2.hs
@@ -115,8 +115,7 @@ authGoogleEmail clientID clientSecret =
                     `mappend` renderQueryText True qs
 
     login tm = do
-        url <- getDest tm
-        [whamlet|<a href=#{url}>_{Msg.LoginGoogle}|]
+        [whamlet|<a href=@{tm forwardUrl}>_{Msg.LoginGoogle}|]
 
     dispatch :: YesodAuth site
              => Text


### PR DESCRIPTION
I think it is better to redirect dynamically every time, instead of building the Google URL into the login page, because it:
- Avoids the error "Invalid CSRF token from Google" when the session disappears in the time between loading the login page and trying to use it, for example if a user
  - logs out, deletes recent browser history, and tries to log back in, or
  - simply leaves the login page lying around for a while, so that the session expires.
- Makes the session cookie smaller when an alternative authentication method (other than Google) is used for a particular login, because the CSRF token will not be added in that case.
