### PR TITLE
Document Yesod.Form.Bootstrap3

### DIFF
--- a/yesod-form/Yesod/Form/Bootstrap3.hs
+++ b/yesod-form/Yesod/Form/Bootstrap3.hs
@@ -203,9 +203,9 @@ data BootstrapSubmit msg =
         { bsValue   :: msg
           -- ^ The text of the submit button.
         , bsClasses :: Text
-          -- ^ Classes added to the @<button>@.
+          -- ^ Classes added to the @\<button>@.
         , bsAttrs   :: [(Text, Text)]
-          -- ^ Attributes added to the @<button>@.
+          -- ^ Attributes added to the @\<button>@.
         } deriving (Show)
 
 instance IsString msg => IsString (BootstrapSubmit msg) where
@@ -224,7 +224,7 @@ instance IsString msg => IsString (BootstrapSubmit msg) where
 -- >        <*> areq textField "Surname" Nothing
 -- >        <*  bootstrapSubmit ("Register" :: BootstrapSubmit Text)
 --
--- (Note that @<*@ is not a typo.)
+-- (Note that '<*' is not a typo.)
 --
 -- Alternatively, you may also just create the submit button
 -- manually as well in order to have more control over its


### PR DESCRIPTION
I felt like the Yesod.Form.Boostrap3 module could use some documentation based on my own experiences, [a question on the mailing list](https://groups.google.com/forum/#!topic/yesodweb/q9f52hSz31o), and a [StackOverflow question](http://stackoverflow.com/q/23350621/1176156). 

Preview available here http://maxgabriel.github.io/yesod/Yesod.Form.Bootstrap3.html (Though I feel like there must be a better way to share HTML/CSS/JS than uploading it to a Github blog...)

Current Haddocks for this module are [here](https://hackage.haskell.org/package/yesod-form/docs/Yesod-Form-Bootstrap3.html).

I haven't done much major Haddock work so I'm unsure how good my documentation is stylistically (for example, `$example` at the top of the file to reference paragraphs at the bottom—I copied that from Aeson).
