### PR TITLE
Add envClientSessionBackend, ENV-based session key

### DIFF
--- a/yesod-core/Yesod/Core.hs
+++ b/yesod-core/Yesod/Core.hs
@@ -45,6 +45,7 @@ module Yesod.Core
     , SessionBackend (..)
     , customizeSessionCookies
     , defaultClientSessionBackend
+    , envClientSessionBackend
     , clientSessionBackend
     , clientSessionDateCacher
     , loadClientSession

--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -598,6 +598,32 @@ defaultClientSessionBackend minutes fp = do
   (getCachedDate, _closeDateCacher) <- clientSessionDateCacher timeout
   return $ clientSessionBackend key getCachedDate
 
+-- | Create a @SessionBackend@ which reads the session key from the named
+-- environment variable.
+--
+-- This can be useful if:
+--
+-- 1. You can't rely on a persistent file system (e.g. Heroku)
+-- 2. Your application is open source (e.g. you can't commit the key)
+--
+-- By keeping a consistent value in the environment variable, your users will
+-- have consistent sessions without relying on the file system.
+--
+-- Note: A suitable value should only be obtained in one of two ways:
+--
+-- 1. Run this code without the variable set, a value will be generated and
+--    printed on @/dev/stdout/@
+-- 2. Use @clientsession-generate@
+--
+envClientSessionBackend :: Int -- ^ minutes
+                        -> String -- ^ environment variable name
+                        -> IO SessionBackend
+envClientSessionBackend minutes name = do
+    key <- CS.getKeyEnv name
+    let timeout = fromIntegral (minutes * 60)
+    (getCachedDate, _closeDateCacher) <- clientSessionDateCacher timeout
+    return $ clientSessionBackend key getCachedDate
+
 jsToHtml :: Javascript -> Html
 jsToHtml (Javascript b) = preEscapedToMarkup $ toLazyText b
 

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -34,7 +34,7 @@ library
                    , blaze-builder         >= 0.2.1.4  && < 0.4
                    , transformers          >= 0.2.2
                    , mtl
-                   , clientsession         >= 0.9      && < 0.10
+                   , clientsession         >= 0.9.1    && < 0.10
                    , random                >= 1.0.0.2  && < 1.2
                    , cereal                >= 0.3
                    , old-locale            >= 1.0.0.2  && < 1.1


### PR DESCRIPTION
This can be useful if:
1. You can't rely on a persistent file system (e.g. Heroku)
2. Your application is open source (e.g. you can't commit the key)

By keeping a consistent value in the environment variable, your users will have
consistent sessions without relying on the file system.

Usage:

```
makeSessionBackend _ = fmap Just $ envClientSessionBackend 120 "SESSION_KEY"
```

Related: https://github.com/yesodweb/yesod/issues/806

Totally open to bikeshedding the function name.
