### PR TITLE
Add dependency on data-default-class to project templates.

### DIFF
--- a/yesod-bin/hsfiles/mongo.hsfiles
+++ b/yesod-bin/hsfiles/mongo.hsfiles
@@ -464,6 +464,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.1
                  , data-default
+                 , data-default-class
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4

--- a/yesod-bin/hsfiles/mysql.hsfiles
+++ b/yesod-bin/hsfiles/mysql.hsfiles
@@ -476,6 +476,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.1
                  , data-default
+                 , data-default-class
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4

--- a/yesod-bin/hsfiles/postgres-fay.hsfiles
+++ b/yesod-bin/hsfiles/postgres-fay.hsfiles
@@ -521,6 +521,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.1
                  , data-default
+                 , data-default-class
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4

--- a/yesod-bin/hsfiles/postgres.hsfiles
+++ b/yesod-bin/hsfiles/postgres.hsfiles
@@ -476,6 +476,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.1
                  , data-default
+                 , data-default-class
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4

--- a/yesod-bin/hsfiles/simple.hsfiles
+++ b/yesod-bin/hsfiles/simple.hsfiles
@@ -393,6 +393,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.1
                  , data-default
+                 , data-default-class
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4

--- a/yesod-bin/hsfiles/sqlite.hsfiles
+++ b/yesod-bin/hsfiles/sqlite.hsfiles
@@ -476,6 +476,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 3.1
                  , data-default
+                 , data-default-class
                  , aeson                         >= 0.6        && < 0.9
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4


### PR DESCRIPTION
 Here's the error I get without this fix to add a dependency on data-default-class in generate projects:

Linux: Ubuntu trusty (Ubuntu 14.04.1 LTS)

(yesod init for some project fooey)

```
harold@omnom:~$ cd fooey && cabal install -j --enable-tests --max-backjumps=-1 --reorder-goals
Resolving dependencies...
Configuring fooey-0.0.0...
Building fooey-0.0.0...
Failed to install fooey-0.0.0
Last 10 lines of the build log ( /home/harold/.cabal/logs/fooey-0.0.0.log ):
$ loggerSet $ appLogger foundation}'
In a stmt of a 'do' block:
logWare <- mkRequestLogger
(def
{outputFormat = if development then
Detailed True
else
Apache FromSocket,
destination = RequestLogger.Logger
$ loggerSet $ appLogger foundation})
cabal: Error: some packages failed to install:
fooey-0.0.0 failed during the building phase. The exception was:
ExitFailure 1
harold@omnom:~/fooey$ 
```
