### PR TITLE
added functions to simplify application of an ssl-only policy to a site

### DIFF
--- a/yesod-core/Yesod/Core.hs
+++ b/yesod-core/Yesod/Core.hs
@@ -47,6 +47,8 @@ module Yesod.Core
     , defaultClientSessionBackend
     , envClientSessionBackend
     , clientSessionBackend
+    , sslOnlySessions
+    , sslOnlyMiddleware
     , clientSessionDateCacher
     , loadClientSession
     , Header(..)

--- a/yesod-core/test/YesodCoreTest.hs
+++ b/yesod-core/test/YesodCoreTest.hs
@@ -20,6 +20,7 @@ import qualified YesodCoreTest.Streaming as Streaming
 import qualified YesodCoreTest.Reps as Reps
 import qualified YesodCoreTest.Auth as Auth
 import qualified YesodCoreTest.LiteApp as LiteApp
+import qualified YesodCoreTest.Ssl as Ssl
 
 import Test.Hspec
 
@@ -44,3 +45,5 @@ specs = do
       Reps.specs
       Auth.specs
       LiteApp.specs
+      Ssl.unsecSpec
+      Ssl.sslOnlySpec

--- a/yesod-core/test/YesodCoreTest/Ssl.hs
+++ b/yesod-core/test/YesodCoreTest/Ssl.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE TypeFamilies, QuasiQuotes, TemplateHaskell, MultiParamTypeClasses, OverloadedStrings #-}
+module YesodCoreTest.Ssl ( sslOnlySpec, unsecSpec ) where
+import qualified YesodCoreTest.StubSslOnly as Ssl
+import qualified YesodCoreTest.StubUnsecured as Unsecured
+import Yesod.Core
+import Test.Hspec
+import Network.Wai
+import Network.Wai.Test
+import qualified Data.ByteString.Char8 as C8
+import qualified Web.Cookie as Cookie
+import qualified Data.List as DL
+
+type CookieSpec = Cookie.SetCookie -> Bool
+
+type ResponseExpectation = SResponse -> Session ()
+
+homeFixtureFor :: YesodDispatch a => a -> ResponseExpectation -> IO ()
+homeFixtureFor app assertion = do
+    wa <- toWaiApp app
+    runSession (getHome >>= assertion) wa
+  where
+    getHome = request defaultRequest
+
+cookieShouldSatisfy :: String -> CookieSpec -> ResponseExpectation
+cookieShouldSatisfy name spec response =
+    liftIO $
+      case DL.filter matchesName $ cookiesIn response of
+          [] -> expectationFailure $ DL.concat
+            [ "Expected a cookie named "
+            , name
+            , " but none is set"
+            ]
+          [c] -> c `shouldSatisfy` spec
+          _ -> expectationFailure $ DL.concat
+            [ "Expected one cookie named "
+            , name
+            , " but found more than one"
+            ]
+  where
+    matchesName c = (Cookie.setCookieName c) == C8.pack name
+    cookiesIn r =
+      DL.map
+        (Cookie.parseSetCookie . snd)
+        (DL.filter (("Set-Cookie"==) . fst) $ simpleHeaders r)
+
+sslOnlySpec :: Spec
+sslOnlySpec = describe "A Yesod application with sslOnly on" $ do
+    it "serves a Strict-Transport-Security header in all responses" $
+        atHome $ assertHeader "Strict-Transport-Security"
+                              "max-age=7200; includeSubDomains"
+    it "sets the Secure flag on its session cookie" $
+        atHome $ "_SESSION" `cookieShouldSatisfy` Cookie.setCookieSecure
+  where
+    atHome = homeFixtureFor Ssl.App
+
+unsecSpec :: Spec
+unsecSpec = describe "A Yesod application with sslOnly off" $ do
+    it "never serves a Strict-Transport-Security header" $ do
+        atHome $ assertNoHeader "Strict-Transport-Security"
+    it "does not set the Secure flag on its session cookie" $ do
+        atHome $ "_SESSION" `cookieShouldSatisfy` isNotSecure
+  where
+    atHome = homeFixtureFor Unsecured.App
+    isNotSecure c = not $ Cookie.setCookieSecure c

--- a/yesod-core/test/YesodCoreTest/StubSslOnly.hs
+++ b/yesod-core/test/YesodCoreTest/StubSslOnly.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TypeFamilies, QuasiQuotes, TemplateHaskell, MultiParamTypeClasses, OverloadedStrings #-}
+module YesodCoreTest.StubSslOnly ( App ( App ) ) where
+
+import Yesod.Core
+import qualified Web.ClientSession                  as CS
+
+data App = App
+
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+|]
+
+instance Yesod App where
+    yesodMiddleware = defaultYesodMiddleware . (sslOnlyMiddleware 120)
+    makeSessionBackend _ = sslOnlySessions $
+        fmap Just $ defaultClientSessionBackend 120 CS.defaultKeyFile
+
+getHomeR :: Handler Html
+getHomeR = defaultLayout
+    [whamlet|
+        <p>
+            Welcome to my test application.
+    |]

--- a/yesod-core/test/YesodCoreTest/StubUnsecured.hs
+++ b/yesod-core/test/YesodCoreTest/StubUnsecured.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE TypeFamilies, QuasiQuotes, TemplateHaskell, MultiParamTypeClasses, OverloadedStrings #-}
+module YesodCoreTest.StubUnsecured ( App ( App ) ) where
+
+import Yesod.Core
+
+data App = App
+
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+|]
+
+instance Yesod App
+
+getHomeR :: Handler Html
+getHomeR = defaultLayout
+    [whamlet|
+        <p>
+            Welcome to my test application.
+    |]

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -138,6 +138,8 @@ test-suite tests
     cpp-options:   -DTEST
     build-depends: base
                   ,hspec >= 1.3
+                  ,hspec-expectations
+                  ,clientsession
                   ,wai >= 3.0
                   ,yesod-core
                   ,bytestring
@@ -159,6 +161,7 @@ test-suite tests
                   , streaming-commons
                   , wai-extra
                   , mwc-random
+                  , cookie >= 0.4.1    && < 0.5
     ghc-options:     -Wall
     extensions: TemplateHaskell
 


### PR DESCRIPTION
This is the alternate design to my [other pull request](https://github.com/yesodweb/yesod/pull/891) on the same topic.  This is obviously simpler.  No changes are necessary to the scaffolding, since the default behavior of not applying an ssl-only policy is unchanged.  As mentioned in the discussion on the other PR, this approach adds a coordinated-configuration burden to scaffolded and default sites in order to avoid the danger, existing in the other design, that a user would define an ssl-only policy on their site but fail to apply it in their customizations.

I assume it's worth changing the text of the yesod book's chapter on sessions to include some note about this, but I'm not sure if that's in a repo I can offer a PR for.  Let me know.
