### PR TITLE
Support "Logout" message

### DIFF
--- a/yesod-auth/Yesod/Auth/Message.hs
+++ b/yesod-auth/Yesod/Auth/Message.hs
@@ -60,6 +60,7 @@ data AuthMessage =
     | SendPasswordResetEmail
     | PasswordResetPrompt
     | InvalidUsernamePass
+    | Logout
 
 -- | Defaults to 'englishMessage'.
 defaultMessage :: AuthMessage -> Text
@@ -106,6 +107,7 @@ englishMessage SendPasswordResetEmail = "Send password reset email"
 englishMessage PasswordResetPrompt = "Enter your e-mail address or username below, and a password reset e-mail will be sent to you."
 englishMessage InvalidUsernamePass = "Invalid username/password combination"
 englishMessage (IdentifierNotFound ident) = "Login not found: " `mappend` ident
+englishMessage Logout = "Logout"
 
 portugueseMessage :: AuthMessage -> Text
 portugueseMessage NoOpenID = "Nenhum identificador OpenID encontrado"
@@ -149,6 +151,7 @@ portugueseMessage PasswordResetPrompt = "Insira seu endereço de e-mail ou nome 
 portugueseMessage InvalidUsernamePass = "Nome de usuário ou senha inválidos"
 -- TODO
 portugueseMessage i@(IdentifierNotFound _) = englishMessage i
+portugueseMessage Logout = "Sair" -- FIXME by Google Translate
 
 spanishMessage :: AuthMessage -> Text
 spanishMessage NoOpenID = "No se encuentra el identificador OpenID"
@@ -192,6 +195,7 @@ spanishMessage PasswordResetPrompt = "Escriba su cuenta de correo o nombre de us
 spanishMessage InvalidUsernamePass = "Combinación de nombre de usuario/contraseña invalida"
 -- TODO
 spanishMessage i@(IdentifierNotFound _) = englishMessage i
+spanishMessage Logout = "Finalizar la sesión" -- FIXME by Google Translate
 
 swedishMessage :: AuthMessage -> Text
 swedishMessage NoOpenID = "Fann ej OpenID identifierare"
@@ -236,6 +240,7 @@ swedishMessage PasswordResetPrompt = "Skriv in din emailadress eller användarna
 swedishMessage InvalidUsernamePass = "Ogiltig kombination av användarnamn och lösenord"
 -- TODO
 swedishMessage i@(IdentifierNotFound _) = englishMessage i
+swedishMessage Logout = "Loggar ut" -- FIXME by Google Translate
 
 germanMessage :: AuthMessage -> Text
 germanMessage NoOpenID = "Kein OpenID-Identifier gefunden"
@@ -279,6 +284,7 @@ germanMessage PasswordResetPrompt = "Nach Einhabe der Email-Adresse oder des Nut
 germanMessage InvalidUsernamePass = "Ungültige Kombination aus Nutzername und Passwort"
 -- TODO
 germanMessage i@(IdentifierNotFound _) = englishMessage i
+germanMessage Logout = "Ausloggen" -- FIXME by Google Translate
 
 frenchMessage :: AuthMessage -> Text
 frenchMessage NoOpenID = "Aucun fournisseur OpenID n'a été trouvé"
@@ -321,6 +327,7 @@ frenchMessage SendPasswordResetEmail = "Envoie d'un message électronique pour R
 frenchMessage PasswordResetPrompt = "Entrez votre adresse électronique ou votre nom d'utilisateur ci-dessous, et un message électronique de réinitialisation de mot de passe vous sera envoyé."
 frenchMessage InvalidUsernamePass = "Le couble nom d'utilisateur/mot de passe invalide"
 frenchMessage (IdentifierNotFound ident) = "Nom d'utilisateur introuvable: " `mappend` ident
+frenchMessage Logout = "Déconnecter" -- FIXME by Google Translate
 
 norwegianBokmålMessage :: AuthMessage -> Text
 norwegianBokmålMessage NoOpenID = "Ingen OpenID-identifiserer funnet"
@@ -364,6 +371,7 @@ norwegianBokmålMessage PasswordResetPrompt = "Enter your e-mail address or user
 norwegianBokmålMessage InvalidUsernamePass = "Invalid username/password combination"
 -- TODO
 norwegianBokmålMessage i@(IdentifierNotFound _) = englishMessage i
+norwegianBokmålMessage Logout = "Logge ut" -- FIXME by Google Translate
 
 japaneseMessage :: AuthMessage -> Text
 japaneseMessage NoOpenID = "OpenID識別子がありません"
@@ -407,6 +415,7 @@ japaneseMessage PasswordResetPrompt = "以下にメールアドレスまたは�
 japaneseMessage InvalidUsernamePass = "ユーザ名とパスワードの組み合わせが間違っています"
 japaneseMessage (IdentifierNotFound ident) =
   ident `mappend` "は登録されていません"
+japaneseMessage Logout = "ログアウト" -- FIXME by Google Translate
 
 finnishMessage :: AuthMessage -> Text
 finnishMessage NoOpenID = "OpenID-tunnistetta ei löydy"
@@ -451,6 +460,7 @@ finnishMessage PasswordResetPrompt = "Anna sähköpostiosoitteesi tai käyttäj�
 finnishMessage InvalidUsernamePass = "Virheellinen käyttäjänimi tai salasana."
 -- TODO
 finnishMessage i@(IdentifierNotFound _) = englishMessage i
+finnishMessage Logout = "Kirjaudu ulos" -- FIXME by Google Translate
 
 chineseMessage :: AuthMessage -> Text
 chineseMessage NoOpenID = "无效的OpenID"
@@ -494,6 +504,7 @@ chineseMessage PasswordResetPrompt = "输入你的邮箱地址或用户名，你
 chineseMessage InvalidUsernamePass = "无效的用户名/密码组合"
 -- TODO
 chineseMessage i@(IdentifierNotFound _) = englishMessage i
+chineseMessage Logout = "註銷" -- FIXME by Google Translate
 
 czechMessage :: AuthMessage -> Text
 czechMessage NoOpenID = "Nebyl nalezen identifikátor OpenID"
@@ -535,6 +546,7 @@ czechMessage PasswordResetPrompt = "Zadejte svou e-mailovou adresu nebo uživate
 czechMessage InvalidUsernamePass = "Neplatná kombinace uživatelského jména a hesla"
 -- TODO
 czechMessage i@(IdentifierNotFound _) = englishMessage i
+czechMessage Logout = "Odhlásit" -- FIXME by Google Translate
 
 -- Так как e-mail – это фактическое сокращение словосочетания electronic mail,
 -- для русского перевода так же использовано сокращение: эл.почта
@@ -564,11 +576,11 @@ russianMessage NewPass = "Новый пароль"
 russianMessage ConfirmPass = "Подтверждение"
 russianMessage PassMismatch = "Пароли не совпадают, повторите снова"
 russianMessage PassUpdated = "Пароль обновлён"
-russianMessage Facebook = "Вход с помощью Facebook"
-russianMessage LoginViaEmail = "Вход по адресу эл.почты"
+russianMessage Facebook = "Войти с помощью Facebook"
+russianMessage LoginViaEmail = "Войти по адресу эл.почты"
 russianMessage InvalidLogin = "Неверный логин"
 russianMessage NowLoggedIn = "Вход выполнен"
-russianMessage LoginTitle = "Вход"
+russianMessage LoginTitle = "Войти"
 russianMessage PleaseProvideUsername = "Пожалуйста, введите ваше имя пользователя"
 russianMessage PleaseProvidePassword = "Пожалуйста, введите ваш пароль"
 russianMessage NoIdentifierProvided = "Не указан адрес эл.почты/имя пользователя"
@@ -579,6 +591,7 @@ russianMessage SendPasswordResetEmail = "Отправить письмо для 
 russianMessage PasswordResetPrompt = "Введите адрес эл.почты или ваше имя пользователя ниже, вам будет отправлено письмо для сброса пароля."
 russianMessage InvalidUsernamePass = "Неверное сочетание имени пользователя и пароля"
 russianMessage (IdentifierNotFound ident) = "Логин не найден: " `mappend` ident
+russianMessage Logout = "Выйти"
 
 dutchMessage :: AuthMessage -> Text
 dutchMessage NoOpenID = "Geen OpenID identificator gevonden"
@@ -621,3 +634,4 @@ dutchMessage SendPasswordResetEmail = "Stuur een wachtwoord reset e-mail"
 dutchMessage PasswordResetPrompt = "Voer uw e-mailadres of gebruikersnaam hieronder in, er zal een e-mail naar u worden verzonden waarmee u uw wachtwoord kunt wijzigen."
 dutchMessage InvalidUsernamePass = "Ongeldige gebruikersnaam/wachtwoord combinatie"
 dutchMessage (IdentifierNotFound ident) = "Inloggegevens niet gevonden: " `mappend` ident
+dutchMessage Logout = "Logout" -- FIXME NOT TRANSLATED


### PR DESCRIPTION
Added support for `Logout` message, all translations made with Google
Translate, except: Russian translation (by hand) and Dutch translation
(do not translated)
