### PR TITLE
Have add-handler include the function arguments

### DIFF
--- a/yesod-bin/AddHandler.hs
+++ b/yesod-bin/AddHandler.hs
@@ -107,7 +107,9 @@ mkHandler name pattern methods = unlines
         , concat $ func : " :: " : map toArrow types ++ ["Handler Html"]
         , concat
             [ func
-            , " = error \"Not yet implemented: "
+            , " "
+            , concatMap toArgument types
+            , "= error \"Not yet implemented: "
             , func
             , "\""
             ]
@@ -118,6 +120,7 @@ mkHandler name pattern methods = unlines
     types = getTypes pattern
 
     toArrow t = concat [t, " -> "]
+    toArgument t = concat [uncapitalize t, " "]
 
     getTypes "" = []
     getTypes ('/':rest) = getTypes rest
@@ -126,3 +129,7 @@ mkHandler name pattern methods = unlines
       where
         (typ, rest') = break (== '/') rest
     getTypes rest = getTypes $ dropWhile (/= '/') rest
+
+uncapitalize :: String -> String
+uncapitalize (x:xs) = toLower x : xs
+uncapitalize "" = ""


### PR DESCRIPTION
Addresses #898 

This implementation styles the arguments like so:

``` haskell
getFooR :: UserId -> Handler Html
getFooR userId = error "Not yet implemented: getFooR"
```
