### PR TITLE
Upper bound on hspec for known breakage.

### DIFF
--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -24,7 +24,7 @@ library
                    , network                   >= 2.2
                    , http-types                >= 0.7
                    , HUnit                     >= 1.2
-                   , hspec                     >= 1.4
+                   , hspec                     >= 1.4      && < 2.0
                    , bytestring                >= 0.9
                    , case-insensitive          >= 0.2
                    , text


### PR DESCRIPTION
yesod-test 1.2.6 uses a type that doesn't exist in hspec >=2.0