### PR TITLE
Fix pluralization in template loading error message

### DIFF
--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -102,7 +102,7 @@ combine func file isReload tls = do
             , func
             , " on "
             , show file
-            , ", but no template were found."
+            , ", but no templates were found."
             ]
         exps -> return $ DoE $ map NoBindS exps
   where


### PR DESCRIPTION
I got this error message using `widgetFile` and noticed the pluralization was incorrect:

```
Handler/PostDetails.hs:8:21:
    Exception when trying to run compile-time code:
      Called widgetFileReload on "postDetails/post.hamlet", but no template were found.
    Code: widgetFile "postDetails/post.hamlet"
    In the splice: $(widgetFile "postDetails/post.hamlet")
```

It should be "but no templates were found".