### PR TITLE
Demonstrate failing CSRF token lookup (don't merge)

### DIFF
--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -156,6 +156,13 @@ main = hspec $ do
                     setMethod "POST"
                     setUrl ("/labels" :: Text)
                     byLabel "Foo Bar" "yes"
+
+        ydescribe "tokens" $ do
+            yit "can find a CSRF token field" $ do
+                get ("/tokens" :: Text)
+                request $ do
+                    addNonce_ "#formId"
+
     describe "cookies" $ yesodSpec cookieApp $ do
         yit "should send the cookie #730" $ do
             get ("/" :: Text)
@@ -200,6 +207,8 @@ app = liteApp $ do
 
     onStatic "labels" $ dispatchTo $
         return ("<html><label><input type='checkbox' name='fooname' id='foobar'>Foo Bar</label></html>" :: Text)
+    onStatic "tokens" $ dispatchTo $
+        return ("<html><form id='formId'><input name='_token' type='hidden' value='bar'></form></html>" :: Text)
 
 
 cookieApp :: LiteApp


### PR DESCRIPTION
This isn't quite a PR yet, this just demonstrates a bug where `addNonce_` fails to lookup a form by ID.

I believe this is because [this code](https://github.com/yesodweb/yesod/blob/2fb7cccf15c04cef78158f792cf1a569bd87ceec/yesod-test/Yesod/Test.hs#L493) concatenates the selector with `"input[name=_token][type=hidden][value]"`, causing the CSS query to be `"#formIDinput[name=_token][type=hidden][value]"`. If I add a space after `"#formID"` (`"#formID "`), then the query works correctly.

``` haskell
matches <- htmlQuery' rbdResponse $ scope <> "input[name=_token][type=hidden][value]"
```

I initially guessed I could easily fix it by adding a space before `input`, but that lead to a 500 error on another test, so I'm still investigating.
