### PR TITLE
Fix add-handler putting two routes on one line

### DIFF
--- a/yesod-bin/AddHandler.hs
+++ b/yesod-bin/AddHandler.hs
@@ -83,17 +83,19 @@ fixCabal name =
         (spaces, x') = span isSpace x
 
 fixRoutes :: String -> String -> String -> String -> String
-fixRoutes name pattern methods =
-    (++ l)
+fixRoutes name pattern methods fileContents =
+    fileContents ++ l
   where
     l = concat
-        [ pattern
+        [ startingCharacter
+        , pattern
         , " "
         , name
         , "R "
         , methods
         , "\n"
         ]
+    startingCharacter = if "\n" `isSuffixOf` fileContents then "" else "\n"
 
 mkHandler :: String -> String -> String -> String
 mkHandler name pattern methods = unlines


### PR DESCRIPTION
* If there is a new line at the end of the file, add the route as normal
* If there isn't, add a newline character before the route
* Closes #921

I tested this on OS X. I'm not super familiar with what type of newlines Windows programmers use; I'm not sure if that's an issue here.