### PR TITLE
Perform `onLogout` before session cleaning

### DIFF
--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -295,9 +295,9 @@ clearCreds :: YesodAuth master
            -> HandlerT master IO ()
 clearCreds doRedirects = do
     y <- getYesod
+    onLogout
     deleteSession credsKey
     when doRedirects $ do
-        onLogout
         redirectUltDest $ logoutDest y
 
 getCheckR :: AuthHandler master TypedContent


### PR DESCRIPTION
There is setuations where this hook must get some data from session, so it must be performed before session cleaning.