### PR TITLE
Improve error message when "yesod devel" complains about the GHC version...

### DIFF
--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -321,7 +321,7 @@ removeFileIfExists file = removeFile file `Ex.catch` handler
 mkRebuild :: String -> FilePath -> DevelOpts -> (FilePath, FilePath) -> IO (IO Bool)
 mkRebuild ghcVer cabalFile opts (ldPath, arPath)
   | GHC.cProjectVersion /= ghcVer =
-       failWith "Yesod has been compiled with a different GHC version, please reinstall"
+       failWith "Yesod has been compiled with a different GHC version, please reinstall yesod-bin"
   | forceCabal opts               = return (rebuildCabal opts)
   | otherwise                     =
       return $ do


### PR DESCRIPTION
....

I hit this problem and the fix was to reinstall yesod-bin (because I'd
upgraded my version of ghc):

    cabal install --reinstall yesod-bin

See issue #476 .