### PR TITLE
Style improvements for default generated homepage

### DIFF
--- a/yesod-bin/hsfiles/mongo.hsfiles
+++ b/yesod-bin/hsfiles/mongo.hsfiles
@@ -8997,6 +8997,7 @@ $maybe msg <- mmsg
 
   <li ##{aDomId}>If you had javascript enabled then you wouldn't be seeing this.
 
+  <hr />
   <li #form>
     This is an example trivial Form. Read the #
     \<a href="http://www.yesodweb.com/book/forms">Forms chapter<span class="glyphicon glyphicon-bookmark"></span></a> #
@@ -9008,6 +9009,7 @@ $maybe msg <- mmsg
       ^{formWidget}
       <button .btn .btn-primary type="submit">
          Send it! <span class="glyphicon glyphicon-upload"></span>
+  <hr />
 
   <li> And last but not least, Testing. In <em>tests/main.hs</em> you will find a #
     test suite that performs tests on this page. #
@@ -9018,10 +9020,24 @@ document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by th
 
 {-# START_FILE templates/homepage.lucius #-}
 h1 {
-    text-align: center
+    text-align: center;
+    margin-bottom: 30px
 }
 h2##{aDomId} {
     color: #990
+}
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+ol {
+    margin-bottom: 30px
+}
+footer {
+    text-align: center
+}
+.input-sm {
+    margin-left: 20px
 }
 
 {-# START_FILE test/Handler/CommonSpec.hs #-}

--- a/yesod-bin/hsfiles/mysql.hsfiles
+++ b/yesod-bin/hsfiles/mysql.hsfiles
@@ -9007,6 +9007,7 @@ $maybe msg <- mmsg
 
   <li ##{aDomId}>If you had javascript enabled then you wouldn't be seeing this.
 
+  <hr />
   <li #form>
     This is an example trivial Form. Read the #
     \<a href="http://www.yesodweb.com/book/forms">Forms chapter<span class="glyphicon glyphicon-bookmark"></span></a> #
@@ -9018,6 +9019,7 @@ $maybe msg <- mmsg
       ^{formWidget}
       <button .btn .btn-primary type="submit">
          Send it! <span class="glyphicon glyphicon-upload"></span>
+  <hr />
 
   <li> And last but not least, Testing. In <em>tests/main.hs</em> you will find a #
     test suite that performs tests on this page. #
@@ -9028,10 +9030,24 @@ document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by th
 
 {-# START_FILE templates/homepage.lucius #-}
 h1 {
-    text-align: center
+    text-align: center;
+    margin-bottom: 30px
 }
 h2##{aDomId} {
     color: #990
+}
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+ol {
+    margin-bottom: 30px
+}
+footer {
+    text-align: center
+}
+.input-sm {
+    margin-left: 20px
 }
 
 {-# START_FILE test/Handler/CommonSpec.hs #-}

--- a/yesod-bin/hsfiles/postgres-fay.hsfiles
+++ b/yesod-bin/hsfiles/postgres-fay.hsfiles
@@ -9122,6 +9122,7 @@ $maybe msg <- mmsg
 
   <li ##{aDomId}>If you had javascript enabled then you wouldn't be seeing this.
 
+  <hr />
   <li #form>
     This is an example trivial Form. Read the #
     \<a href="http://www.yesodweb.com/book/forms">Forms chapter<span class="glyphicon glyphicon-bookmark"></span></a> #
@@ -9133,6 +9134,7 @@ $maybe msg <- mmsg
       ^{formWidget}
       <button .btn .btn-primary type="submit">
          Send it! <span class="glyphicon glyphicon-upload"></span>
+  <hr />
 
   <li> And last but not least, Testing. In <em>tests/main.hs</em> you will find a #
     test suite that performs tests on this page. #
@@ -9148,10 +9150,24 @@ document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by th
 
 {-# START_FILE templates/homepage.lucius #-}
 h1 {
-    text-align: center
+    text-align: center;
+    margin-bottom: 30px
 }
 h2##{aDomId} {
     color: #990
+}
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+ol {
+    margin-bottom: 30px
+}
+footer {
+    text-align: center
+}
+.input-sm {
+    margin-left: 20px
 }
 
 {-# START_FILE test/Handler/CommonSpec.hs #-}

--- a/yesod-bin/hsfiles/postgres.hsfiles
+++ b/yesod-bin/hsfiles/postgres.hsfiles
@@ -9007,6 +9007,7 @@ $maybe msg <- mmsg
 
   <li ##{aDomId}>If you had javascript enabled then you wouldn't be seeing this.
 
+  <hr />
   <li #form>
     This is an example trivial Form. Read the #
     \<a href="http://www.yesodweb.com/book/forms">Forms chapter<span class="glyphicon glyphicon-bookmark"></span></a> #
@@ -9018,6 +9019,7 @@ $maybe msg <- mmsg
       ^{formWidget}
       <button .btn .btn-primary type="submit">
          Send it! <span class="glyphicon glyphicon-upload"></span>
+  <hr />
 
   <li> And last but not least, Testing. In <em>tests/main.hs</em> you will find a #
     test suite that performs tests on this page. #
@@ -9028,10 +9030,24 @@ document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by th
 
 {-# START_FILE templates/homepage.lucius #-}
 h1 {
-    text-align: center
+    text-align: center;
+    margin-bottom: 30px
 }
 h2##{aDomId} {
     color: #990
+}
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+ol {
+    margin-bottom: 30px
+}
+footer {
+    text-align: center
+}
+.input-sm {
+    margin-left: 20px
 }
 
 {-# START_FILE test/Handler/CommonSpec.hs #-}

--- a/yesod-bin/hsfiles/simple.hsfiles
+++ b/yesod-bin/hsfiles/simple.hsfiles
@@ -8888,6 +8888,7 @@ $maybe msg <- mmsg
 
   <li ##{aDomId}>If you had javascript enabled then you wouldn't be seeing this.
 
+  <hr />
   <li #form>
     This is an example trivial Form. Read the #
     \<a href="http://www.yesodweb.com/book/forms">Forms chapter<span class="glyphicon glyphicon-bookmark"></span></a> #
@@ -8899,6 +8900,7 @@ $maybe msg <- mmsg
       ^{formWidget}
       <button .btn .btn-primary type="submit">
          Send it! <span class="glyphicon glyphicon-upload"></span>
+  <hr />
 
   <li> And last but not least, Testing. In <em>tests/main.hs</em> you will find a #
     test suite that performs tests on this page. #
@@ -8909,10 +8911,24 @@ document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by th
 
 {-# START_FILE templates/homepage.lucius #-}
 h1 {
-    text-align: center
+    text-align: center;
+    margin-bottom: 30px
 }
 h2##{aDomId} {
     color: #990
+}
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+ol {
+    margin-bottom: 30px
+}
+footer {
+    text-align: center
+}
+.input-sm {
+    margin-left: 20px
 }
 
 {-# START_FILE test/Handler/CommonSpec.hs #-}

--- a/yesod-bin/hsfiles/sqlite.hsfiles
+++ b/yesod-bin/hsfiles/sqlite.hsfiles
@@ -9025,6 +9025,7 @@ $maybe msg <- mmsg
 
   <li ##{aDomId}>If you had javascript enabled then you wouldn't be seeing this.
 
+  <hr />
   <li #form>
     This is an example trivial Form. Read the #
     \<a href="http://www.yesodweb.com/book/forms">Forms chapter<span class="glyphicon glyphicon-bookmark"></span></a> #
@@ -9036,6 +9037,7 @@ $maybe msg <- mmsg
       ^{formWidget}
       <button .btn .btn-primary type="submit">
          Send it! <span class="glyphicon glyphicon-upload"></span>
+  <hr />
 
   <li> And last but not least, Testing. In <em>tests/main.hs</em> you will find a #
     test suite that performs tests on this page. #
@@ -9046,10 +9048,24 @@ document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by th
 
 {-# START_FILE templates/homepage.lucius #-}
 h1 {
-    text-align: center
+    text-align: center;
+    margin-bottom: 30px
 }
 h2##{aDomId} {
     color: #990
+}
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+ol {
+    margin-bottom: 30px
+}
+footer {
+    text-align: center
+}
+.input-sm {
+    margin-left: 20px
 }
 
 {-# START_FILE test/Handler/CommonSpec.hs #-}


### PR DESCRIPTION
As mentioned in #943, this pull makes some small style improvements to the "Welcome To Yesod!" homepage that's generated by default.

* Tweaked font size and line spacing.
* Added horizontal rules to separate form example.
* Gave form input and h1 some breathing room.
* Aligned footer.

Before:
![before](https://cloud.githubusercontent.com/assets/46677/6418500/88b4f8ec-be83-11e4-96fc-8b4bd05309a6.png)

After:
![after](https://cloud.githubusercontent.com/assets/46677/6418507/9380e218-be83-11e4-9efb-eaf6a1967e6b.png)