### PR TITLE
Disregard proxy environment variables in yesod devel

### DIFF
--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -68,7 +68,9 @@ import           Data.Streaming.Network                (bindPortTCP)
 import           Network                               (withSocketsDo)
 import           Network.HTTP.Conduit                  (conduitManagerSettings, newManager)
 import           Data.Default.Class                    (def)
+#if MIN_VERSION_http_client(0,4,7)
 import           Network.HTTP.Client                   (managerSetProxy, noProxy)
+#endif
 import           Network.HTTP.ReverseProxy             (ProxyDest (ProxyDest),
                                                         waiProxyToSettings, wpsTimeout, wpsOnExc)
 import qualified Network.HTTP.ReverseProxy             as ReverseProxy
@@ -125,7 +127,11 @@ cabalProgram opts | isCabalDev opts = "cabal-dev"
 -- 3001, give an appropriate message to the user.
 reverseProxy :: DevelOpts -> I.IORef Int -> IO ()
 reverseProxy opts iappPort = do
+#if MIN_VERSION_http_client(0,4,7)
     manager <- newManager $ managerSetProxy noProxy conduitManagerSettings
+#else
+    manager <- newManager conduitManagerSettings
+#endif
     let refreshHtml = LB.fromChunks $ return $(embedFile "refreshing.html")
     let onExc _ req
             | maybe False (("application/json" `elem`) . parseHttpAccept)

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -68,6 +68,7 @@ import           Data.Streaming.Network                (bindPortTCP)
 import           Network                               (withSocketsDo)
 import           Network.HTTP.Conduit                  (conduitManagerSettings, newManager)
 import           Data.Default.Class                    (def)
+import           Network.HTTP.Client                   (managerSetProxy, noProxy)
 import           Network.HTTP.ReverseProxy             (ProxyDest (ProxyDest),
                                                         waiProxyToSettings, wpsTimeout, wpsOnExc)
 import qualified Network.HTTP.ReverseProxy             as ReverseProxy
@@ -124,7 +125,7 @@ cabalProgram opts | isCabalDev opts = "cabal-dev"
 -- 3001, give an appropriate message to the user.
 reverseProxy :: DevelOpts -> I.IORef Int -> IO ()
 reverseProxy opts iappPort = do
-    manager <- newManager conduitManagerSettings
+    manager <- newManager $ managerSetProxy noProxy conduitManagerSettings
     let refreshHtml = LB.fromChunks $ return $(embedFile "refreshing.html")
     let onExc _ req
             | maybe False (("application/json" `elem`) . parseHttpAccept)

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -78,6 +78,7 @@ executable             yesod
                      , http-reverse-proxy >= 0.4
                      , network
                      , http-conduit       >= 2.1.4
+                     , http-client
                      , project-template   >= 0.1.1
                      , transformers
                      , transformers-compat

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -78,7 +78,7 @@ executable             yesod
                      , http-reverse-proxy >= 0.4
                      , network
                      , http-conduit       >= 2.1.4
-                     , http-client        >= 0.4.7
+                     , http-client
                      , project-template   >= 0.1.1
                      , transformers
                      , transformers-compat

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -78,7 +78,7 @@ executable             yesod
                      , http-reverse-proxy >= 0.4
                      , network
                      , http-conduit       >= 2.1.4
-                     , http-client
+                     , http-client        >= 0.4.7
                      , project-template   >= 0.1.1
                      , transformers
                      , transformers-compat


### PR DESCRIPTION
After the change to proxy settings in http-client (https://github.com/snoyberg/http-client/issues/94) the ```yesod devel``` reverse proxy now attempts to connect to the application via any further proxy specified by the environment variables.  I can't see any reason why the new behaviour might be useful in this specific case, so it seems better to me to force no proxy - am I missing something?