### PR TITLE
update warp-tls's version

### DIFF
--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -88,7 +88,7 @@ executable             yesod
                      , wai-extra
                      , data-default-class
                      , streaming-commons
-                     , warp-tls
+                     , warp-tls           >= 3.0.1
                      , async
 
     ghc-options:       -Wall -threaded -rtsopts


### PR DESCRIPTION
yesod-bin uses ``` Network.Wai.Handler.WarpTLS.tlsSettingsMemory``` which is introduced in wrap-tls-3.0.1
