### PR TITLE
Adds export of email verify route

### DIFF
--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -30,6 +30,7 @@ module Yesod.Auth.Email
     , registerR
     , forgotPasswordR
     , setpassR
+    , verifyR
     , isValidPass
       -- * Types
     , Email
@@ -68,14 +69,12 @@ import Yesod.Form
 import Data.Time (getCurrentTime, addUTCTime)
 import Safe (readMay)
 
-loginR, registerR, forgotPasswordR, setpassR :: AuthRoute
+loginR, registerR, forgotPasswordR, setpassR, verifyR :: AuthRoute
 loginR = PluginR "email" ["login"]
 registerR = PluginR "email" ["register"]
 forgotPasswordR = PluginR "email" ["forgot-password"]
 setpassR = PluginR "email" ["set-password"]
-
-verify :: Text -> Text -> AuthRoute -- FIXME
-verify eid verkey = PluginR "email" ["verify", eid, verkey]
+verifyR eid verkey = PluginR "email" ["verify", eid, verkey]
 
 type Email = Text
 type VerKey = Text
@@ -345,7 +344,7 @@ registerHelper allowUsername dest = do
                 Nothing -> loginErrorMessageI dest (Msg.IdentifierNotFound identifier)
                 Just (lid, verKey, email) -> do
                     render <- getUrlRender
-                    let verUrl = render $ verify (toPathPiece lid) verKey
+                    let verUrl = render $ verifyR (toPathPiece lid) verKey
                     lift $ sendVerifyEmail email verKey verUrl
                     lift $ confirmationEmailSentResponse identifier
 

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -69,11 +69,13 @@ import Yesod.Form
 import Data.Time (getCurrentTime, addUTCTime)
 import Safe (readMay)
 
-loginR, registerR, forgotPasswordR, setpassR, verifyR :: AuthRoute
+loginR, registerR, forgotPasswordR, setpassR :: AuthRoute
 loginR = PluginR "email" ["login"]
 registerR = PluginR "email" ["register"]
 forgotPasswordR = PluginR "email" ["forgot-password"]
 setpassR = PluginR "email" ["set-password"]
+
+verifyR :: Text -> Text -> AuthRoute -- FIXME
 verifyR eid verkey = PluginR "email" ["verify", eid, verkey]
 
 type Email = Text


### PR DESCRIPTION
This allows users of the library to easily render VerUrl to use in verification emails to new users, if the user was created outside of the regular register functionality.

This would be useful when creating a user management system where the admin creates users instead of them registering. 