### PR TITLE
Export log formatting

### DIFF
--- a/yesod-core/Yesod/Core.hs
+++ b/yesod-core/Yesod/Core.hs
@@ -30,6 +30,11 @@ module Yesod.Core
     , AuthResult (..)
     , unauthorizedI
       -- * Logging
+    , defaultMakeLogger
+    , defaultMessageLoggerSource
+    , defaultShouldLog
+    , defaultShouldLogIO
+    , formatLogMessage
     , LogLevel (..)
     , logDebug
     , logInfo

--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -26,7 +26,6 @@ import Data.Aeson (object, (.=))
 import           Data.List                          (foldl')
 import           Data.List                          (nub)
 import qualified Data.Map                           as Map
-import           Data.Maybe                         (fromMaybe)
 import           Data.Monoid
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T

--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -322,7 +322,7 @@ defaultMessageLoggerSource ckLoggable logger loc source level msg = do
         loggerPutStr logger
 
 -- | Default implementation of 'shouldLog'. Logs everything at or
--- above 'logLevel'.
+-- above 'LevelInfo'.
 defaultShouldLog :: LogSource -> LogLevel -> Bool
 defaultShouldLog _ level = level >= LevelInfo
 

--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -254,7 +254,7 @@ class RenderRoute site => Yesod site where
 
     -- | Should we log the given log source/level combination.
     --
-    -- Default: the 'shouldLog' function.
+    -- Default: the 'defaultShouldLog' function.
     shouldLog :: site -> LogSource -> LogLevel -> Bool
     shouldLog _ = defaultShouldLog
 


### PR DESCRIPTION
Make the advice in the `makeLogger` haddock practical:

For logging during app startup, it recommends creating a `Logger`, using during startup, and then supplying it to `makeLogger` when creating the `Yesod` instance. But for that to be practical, you need access to the default implementations of the various logging-related methods of `Yesod` and/or the `formatLogMessage` function. Unfortunately, none of those are available before the `Yesod` instance is actually created, leading to a chicken-and-egg problem.

This PR moves the default implementations of the logging-related methods to separate functions that don't depend on the `Yesod` instance, and exports all of those plus `formatLogMessage` from `Yesod.Core`.