### PR TITLE
Parallelize hashing of static files

### DIFF
--- a/yesod-static/Yesod/Static.hs
+++ b/yesod-static/Yesod/Static.hs
@@ -100,6 +100,7 @@ import System.Directory (createDirectoryIfMissing)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as TLE
 import Data.Default
+import Control.Parallel.Strategies
 --import Text.Lucius (luciusRTMinified)
 
 import Network.Wai.Application.Static
@@ -270,10 +271,11 @@ publicFiles dir = mkStaticFiles' dir False
 mkHashMap :: FilePath -> IO (M.Map FilePath S8.ByteString)
 mkHashMap dir = do
     fs <- getFileListPieces dir
-    hashAlist fs >>= return . M.fromList
+    hashList <- sequence (hashAlist fs)
+    return $ M.fromList hashList
   where
-    hashAlist :: [[String]] -> IO [(FilePath, S8.ByteString)]
-    hashAlist fs = mapM hashPair fs
+    hashAlist :: [[String]] -> [IO (FilePath, S8.ByteString)]
+    hashAlist fs = parMap rpar hashPair fs
       where
         hashPair :: [String] -> IO (FilePath, S8.ByteString)
         hashPair pieces = do let file = pathFromRawPieces dir pieces

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -54,6 +54,7 @@ library
                    , unordered-containers  >= 0.2
                    , process
                    , async
+                   , parallel              >= 3.2
 
                    , attoparsec            >= 0.10
                    , blaze-builder         >= 0.3
@@ -109,6 +110,7 @@ test-suite tests
                    , resourcet
                    , unordered-containers
                    , async
+                   , parallel
                    , process
                    , conduit-extra
 


### PR DESCRIPTION
This is for #732. It parallelizes the hashing of static files by using `Control.Parallel.Strategies.parMap` from the [parallel](https://hackage.haskell.org/package/parallel-3.2.0.4/docs/Control-Parallel-Strategies.html#g:7) package.