### PR TITLE
Draft of adding CSRF protection for AJAX requests

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.14
+
+* Add CSRF protection functions and middleware based on HTTP cookies and headers [#1017](https://github.com/yesodweb/yesod/pull/1017)
+
 ## 1.4.13
 
 * Add mkYesodGeneral, which allows creating sites with polymorphic type parameters [#1055](https://github.com/yesodweb/yesod/pull/1055)

--- a/yesod-core/Yesod/Core.hs
+++ b/yesod-core/Yesod/Core.hs
@@ -57,6 +57,12 @@ module Yesod.Core
     , clientSessionDateCacher
     , loadClientSession
     , Header(..)
+    -- * CSRF protection
+    , defaultCsrfMiddleware
+    , defaultCsrfSetCookieMiddleware
+    , csrfSetCookieMiddleware
+    , defaultCsrfCheckMiddleware
+    , csrfCheckMiddleware
     -- * JS loaders
     , ScriptLoadPosition (..)
     , BottomOfHeadAsync

--- a/yesod-core/test/YesodCoreTest.hs
+++ b/yesod-core/test/YesodCoreTest.hs
@@ -21,6 +21,7 @@ import qualified YesodCoreTest.Reps as Reps
 import qualified YesodCoreTest.Auth as Auth
 import qualified YesodCoreTest.LiteApp as LiteApp
 import qualified YesodCoreTest.Ssl as Ssl
+import qualified YesodCoreTest.Csrf as Csrf
 
 import Test.Hspec
 
@@ -47,3 +48,4 @@ specs = do
       LiteApp.specs
       Ssl.unsecSpec
       Ssl.sslOnlySpec
+      Csrf.csrfSpec

--- a/yesod-core/test/YesodCoreTest/Csrf.hs
+++ b/yesod-core/test/YesodCoreTest/Csrf.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TypeFamilies, QuasiQuotes, TemplateHaskell, MultiParamTypeClasses, OverloadedStrings #-}
+
+module YesodCoreTest.Csrf (csrfSpec, Widget, resourcesApp) where
+
+import Yesod.Core
+
+import Test.Hspec
+import Network.Wai
+import Network.Wai.Test
+import Web.Cookie
+import qualified Data.Map as Map
+import Data.ByteString.Lazy (fromStrict)
+import Data.Monoid ((<>))
+
+data App = App
+
+mkYesod "App" [parseRoutes|
+/ HomeR GET POST
+|]
+
+instance Yesod App where
+    yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
+
+getHomeR :: Handler Html
+getHomeR = defaultLayout
+    [whamlet|
+        <p>
+            Welcome to my test application.
+    |]
+
+postHomeR :: Handler Html
+postHomeR = defaultLayout
+    [whamlet|
+        <p>
+            Welcome to my test application.
+    |]
+
+runner :: Session () -> IO ()
+runner f = toWaiApp App >>= runSession f
+
+csrfSpec :: Spec
+csrfSpec = describe "A Yesod application with the defaultCsrfMiddleware" $ do
+    it "serves a includes a cookie in a GET request" $ runner $ do
+        res <- request defaultRequest
+        assertStatus 200 res
+        assertClientCookieExists "Should have an XSRF-TOKEN cookie" defaultCsrfCookieName
+
+    it "200s write requests with the correct CSRF header, but no param" $ runner $ do
+        getRes <- request defaultRequest
+        assertStatus 200 getRes
+        csrfValue <- fmap setCookieValue requireCsrfCookie
+        postRes <- request (defaultRequest { requestMethod = "POST", requestHeaders = [(defaultCsrfHeaderName, csrfValue)] })
+        assertStatus 200 postRes
+
+    it "200s write requests with the correct CSRF param, but no header" $ runner $ do
+        getRes <- request defaultRequest
+        assertStatus 200 getRes
+        csrfValue <- fmap setCookieValue requireCsrfCookie
+
+        let body = "_token=" <> csrfValue
+        postRes <- srequest $ SRequest (defaultRequest { requestMethod = "POST", requestHeaders = [("Content-Type","application/x-www-form-urlencoded")] }) (fromStrict body)
+        assertStatus 200 postRes
+
+
+    it "403s write requests without the CSRF header" $ runner $ do
+        res <- request (defaultRequest { requestMethod = "POST" })
+        assertStatus 403 res
+
+    it "403s write requests with the wrong CSRF header" $ runner $ do
+        getRes <- request defaultRequest
+        assertStatus 200 getRes
+        csrfValue <- fmap setCookieValue requireCsrfCookie
+
+        res <- request (defaultRequest { requestMethod = "POST", requestHeaders = [(defaultCsrfHeaderName, csrfValue <> "foo")] })
+        assertStatus 403 res
+        
+    it "403s write requests with the wrong CSRF param" $ runner $ do
+        getRes <- request defaultRequest
+        assertStatus 200 getRes
+        csrfValue <- fmap setCookieValue requireCsrfCookie
+
+        let body = "_token=" <> (csrfValue <> "foo")
+        postRes <- srequest $ SRequest (defaultRequest { requestMethod = "POST", requestHeaders = [("Content-Type","application/x-www-form-urlencoded")] }) (fromStrict body)
+        assertStatus 403 postRes
+
+
+requireCsrfCookie :: Session SetCookie
+requireCsrfCookie = do
+    cookies <- getClientCookies
+    case Map.lookup defaultCsrfCookieName cookies of
+        Just c -> return c
+        Nothing -> error "Failed to lookup CSRF cookie"

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -69,6 +69,7 @@ library
                    , word8
                    , auto-update
                    , semigroups
+                   , byteable
 
     exposed-modules: Yesod.Core
                      Yesod.Core.Content


### PR DESCRIPTION
cf #1016

~~The code is missing tests and high-level documentation, but should be ready for review otherwise.~~

* Thoughts on what the default name should be for the CSRF cookie and header? I'm not super familiar with what other frameworks use (I see Angular uses "XSRF" and Rails uses "csrf"). Yesod uses "CSRF" in its functions instead of "XSRF", which is a strike against using "XSRF" for the naming scheme, even if it ends up being more consistent with tools like Angular.
* Is yesod-core the right home for these functions?

cc @gregwebs 