### PR TITLE
yesod-bin needs directory >= 1.2.1 due to System.Directory.findFiles

### DIFF
--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -52,7 +52,7 @@ executable             yesod
                      , bytestring         >= 0.9.1.4
                      , time               >= 1.1.4
                      , template-haskell
-                     , directory          >= 1.0
+                     , directory          >= 1.2.1
                      , Cabal
                      , unix-compat        >= 0.2          && < 0.5
                      , containers         >= 0.2


### PR DESCRIPTION
GHC 7.4 is no longer supported because of this (but also because of missing dep on ghc-prim and possibly other things)
