### PR TITLE
Don't show source location for logs that don't have that information

### DIFF
--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -633,10 +633,6 @@ formatLogMessage :: IO ZonedDate
                  -> IO LogStr
 formatLogMessage getdate loc src level msg = do
     now <- getdate
-    let sourceSuffix = if loc_package loc == "<unknown>" then "" else mempty
-          `mappend` " @(" 
-          `mappend` toLogStr (fileLocationToString loc) 
-          `mappend` ")"
     return $ mempty
         `mappend` toLogStr now 
         `mappend` " [" 
@@ -650,6 +646,11 @@ formatLogMessage getdate loc src level msg = do
         `mappend` msg 
         `mappend` sourceSuffix
         `mappend` "\n"
+    where 
+    sourceSuffix = if loc_package loc == "<unknown>" then "" else mempty
+        `mappend` " @(" 
+        `mappend` toLogStr (fileLocationToString loc) 
+        `mappend` ")"
 
 -- | Customize the cookies used by the session backend.  You may
 -- use this function on your definition of 'makeSessionBackend'.

--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -615,7 +615,14 @@ asyncHelper render scripts jscript jsLoc =
                     Nothing -> Nothing
                     Just j -> Just $ jelper j
 
--- | Default formatting for log messages.
+-- | Default formatting for log messages. When you use
+-- the template haskell logging functions for to log with information
+-- about the source location, that information will be appended to 
+-- the end of the log. When you use the non-TH logging functions, 
+-- like 'logDebugN', this function does not include source 
+-- information. This currently works by checking to see if the
+-- package name is the string \"\<unknown\>\". This is a hack,
+-- but it removes some of the visual clutter from non-TH logs.
 --
 -- Since 1.4.10
 formatLogMessage :: IO ZonedDate
@@ -626,20 +633,23 @@ formatLogMessage :: IO ZonedDate
                  -> IO LogStr
 formatLogMessage getdate loc src level msg = do
     now <- getdate
-    return $
-        toLogStr now `mappend`
-        " [" `mappend`
-        (case level of
+    let sourceSuffix = if loc_package loc == "<unknown>" then "" else mempty
+          `mappend` " @(" 
+          `mappend` toLogStr (fileLocationToString loc) 
+          `mappend` ")"
+    return $ mempty
+        `mappend` toLogStr now 
+        `mappend` " [" 
+        `mappend` (case level of
             LevelOther t -> toLogStr t
-            _ -> toLogStr $ drop 5 $ show level) `mappend`
-        (if T.null src
+            _ -> toLogStr $ drop 5 $ show level) 
+        `mappend` (if T.null src
             then mempty
-            else "#" `mappend` toLogStr src) `mappend`
-        "] " `mappend`
-        msg `mappend`
-        " @(" `mappend`
-        toLogStr (fileLocationToString loc) `mappend`
-        ")\n"
+            else "#" `mappend` toLogStr src) 
+        `mappend` "] " 
+        `mappend` msg 
+        `mappend` sourceSuffix
+        `mappend` "\n"
 
 -- | Customize the cookies used by the session backend.  You may
 -- use this function on your definition of 'makeSessionBackend'.


### PR DESCRIPTION
https://github.com/yesodweb/yesod/issues/1026

Don't merge this yet. I haven't tested it. Two questions:

  - There's a line in a haddock comment I added where I try to escape some special characters. Did I do this right?
  - Is there any reason we can't use `<>` instead of `mappend`? I'd much rather switch to that.