### PR TITLE
Fix compilation error in yesod-websockets/sample.hs.

### DIFF
--- a/yesod-websockets/sample.hs
+++ b/yesod-websockets/sample.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE QuasiQuotes, TemplateHaskell, TypeFamilies #-}
+{-# LANGUAGE QuasiQuotes, TemplateHaskell, TypeFamilies, OverloadedStrings #-}
 import Yesod.Core
 import Yesod.WebSockets
 import qualified Data.Text.Lazy as TL


### PR DESCRIPTION
Add OverloadedStrings language extension.

I'm going to go ahead and merge this since it's a trivial change in the example.