### PR TITLE
Enable stack with yesod keter

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,3 +15,4 @@ packages:
   - ./yesod-websockets
 extra-deps:
   - wai-app-static-3.1.0
+  - nonce-1.0.2

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -88,14 +88,14 @@ lockFile :: FilePath
 lockFile =  "yesod-devel/devel-terminate"
 
 writeLock :: DevelOpts -> IO ()
-writeLock opts = do
+writeLock _opts = do
     createDirectoryIfMissing True "yesod-devel"
     writeFile lockFile ""
     createDirectoryIfMissing True "dist" -- for compatibility with old devel.hs
     writeFile "dist/devel-terminate" ""
 
 removeLock :: DevelOpts -> IO ()
-removeLock opts = do
+removeLock _opts = do
     removeFileIfExists lockFile
     removeFileIfExists "dist/devel-terminate"  -- for compatibility with old devel.hs
 
@@ -138,6 +138,8 @@ defaultDevelOpts = DevelOpts
     , proxyTimeout = 10
     , useReverseProxy = True
     , terminateWith = TerminateOnEnter
+    , develConfigOpts = []
+    , develEnv = Nothing
     }
 
 cabalProgram :: DevelOpts -> FilePath
@@ -197,7 +199,7 @@ reverseProxy opts iappPort = do
     putStrLn ""
     loop (race_ httpProxy httpsProxy) `Ex.catch` \e -> do
         print (e :: Ex.SomeException)
-        exitFailure
+        _ <- exitFailure
         Ex.throwIO e -- heh, just for good measure
   where
     loop proxies = forever $ do
@@ -524,7 +526,7 @@ lookupLdAr = do
 
 lookupLdAr' :: IO (Maybe (FilePath, FilePath))
 lookupLdAr' = do
-#if MIN_VERSION_Cabal(1,22,0)
+#if MIN_VERSION_Cabal(1,18,0)
   (_, _, pgmc) <- D.configCompilerEx (Just D.GHC) Nothing Nothing D.defaultProgramConfiguration D.silent
 #else
   (_, pgmc) <- D.configCompiler (Just D.GHC) Nothing Nothing D.defaultProgramConfiguration D.silent

--- a/yesod-bin/HsFile.hs
+++ b/yesod-bin/HsFile.hs
@@ -3,9 +3,9 @@
 module HsFile (mkHsFile) where
 import Text.ProjectTemplate (createTemplate)
 import Data.Conduit 
-    ( ($$), (=$), ConduitM, awaitForever, yield, Source )
+    ( ($$), (=$), awaitForever)
 import Data.Conduit.Filesystem (sourceDirectory)
-import Control.Monad.Trans.Resource (ResourceT, runResourceT)
+import Control.Monad.Trans.Resource (runResourceT)
 import qualified Data.Conduit.List as CL
 import qualified Data.ByteString as BS
 import Control.Monad.IO.Class (liftIO)

--- a/yesod-bin/Keter.hs
+++ b/yesod-bin/Keter.hs
@@ -11,7 +11,6 @@ import System.Process
 import Control.Monad
 import System.Directory hiding (findFiles)
 import Data.Maybe (mapMaybe)
-import System.Directory (removeDirectoryRecursive)
 import System.FilePath ((</>))
 import qualified Codec.Archive.Tar as Tar
 import Control.Exception

--- a/yesod-bin/Keter.hs
+++ b/yesod-bin/Keter.hs
@@ -28,7 +28,7 @@ keter :: String -- ^ cabal command
       -> Bool -- ^ no build?
       -> Bool -- ^ no copy to?
       -> IO ()
-keter _cabal noBuild noCopyTo = do
+keter cabal noBuild noCopyTo = do
     ketercfg <- keterConfig
     mvalue <- decodeFile ketercfg
     value <-
@@ -72,11 +72,12 @@ keter _cabal noBuild noCopyTo = do
         collapse' (x:xs) = x : collapse' xs
         collapse' [] = []
 
-    unless noBuild $ do
-        run "stack" ["clean"]
-        -- run cabal ["configure"]
-        createDirectoryIfMissing True "./dist/bin"
-        run "stack" $ words "--local-bin-path ./dist/bin build --copy-bins"
+    unless noBuild $ if elem "stack.yaml" files
+        then do run "stack" ["clean"]
+                createDirectoryIfMissing True "./dist/bin"
+                run "stack"
+                    (words "--local-bin-path ./dist/bin build --copy-bins")
+        else mapM_ (\x -> run cabal [x]) ["clean", "configure", "build"]
 
     _ <- try' $ removeDirectoryRecursive "static/tmp"
 

--- a/yesod-bin/Keter.hs
+++ b/yesod-bin/Keter.hs
@@ -28,7 +28,7 @@ keter :: String -- ^ cabal command
       -> Bool -- ^ no build?
       -> Bool -- ^ no copy to?
       -> IO ()
-keter cabal noBuild noCopyTo = do
+keter _cabal noBuild noCopyTo = do
     ketercfg <- keterConfig
     mvalue <- decodeFile ketercfg
     value <-
@@ -73,9 +73,10 @@ keter cabal noBuild noCopyTo = do
         collapse' [] = []
 
     unless noBuild $ do
-        run cabal ["clean"]
-        run cabal ["configure"]
-        run cabal ["build"]
+        run "stack" ["clean"]
+        -- run cabal ["configure"]
+        createDirectoryIfMissing True "./dist/bin"
+        run "stack" $ words "--local-bin-path ./dist/bin build --copy-bins"
 
     _ <- try' $ removeDirectoryRecursive "static/tmp"
 

--- a/yesod-bin/ghcwrapper.hs
+++ b/yesod-bin/ghcwrapper.hs
@@ -9,7 +9,7 @@ import           Control.Monad                     (when)
 import           Data.Maybe                        (fromMaybe)
 
 import           Distribution.Compiler             (CompilerFlavor (..))
-import           Distribution.Simple.Configure     (configCompiler)
+import qualified Distribution.Simple.Configure as D
 import           Distribution.Simple.Program       (arProgram,
                                                     defaultProgramConfiguration,
                                                     ghcProgram, ldProgram,
@@ -44,7 +44,11 @@ outFile = "yesod-devel/ghcargs.txt"
 
 runProgram :: Program -> [String] -> IO ExitCode
 runProgram pgm args = do
-  (comp, pgmc) <- configCompiler (Just GHC) Nothing Nothing defaultProgramConfiguration silent
+#if MIN_VERSION_Cabal(1,18,0)
+  (_, comp, pgmc) <- D.configCompilerEx (Just GHC) Nothing Nothing defaultProgramConfiguration silent
+#else
+  (comp, pgmc) <- D.configCompiler (Just GHC) Nothing Nothing defaultProgramConfiguration silent
+#endif
   pgmc' <- configureAllKnownPrograms silent pgmc
   case lookupProgram pgm pgmc' of
     Nothing -> do


### PR DESCRIPTION
Cabal is used as usual unless stack.yaml exists.

Executables are placed in ./dist/bin, a location of my own creation. Maybe
./dist-stack would be better, though? Or worse?