### PR TITLE
Fix parameter order for uglifyjs.

### DIFF
--- a/yesod-static/Yesod/EmbeddedStatic/Generators.hs
+++ b/yesod-static/Yesod/EmbeddedStatic/Generators.hs
@@ -169,7 +169,7 @@ jasmine ct = return $ either (const ct) id $ minifym ct
 -- to both mangle and compress and the option \"-\" to cause uglifyjs to read from
 -- standard input.
 uglifyJs :: BL.ByteString -> IO BL.ByteString
-uglifyJs = compressTool "uglifyjs" ["-m", "-c", "-"]
+uglifyJs = compressTool "uglifyjs" ["-", "-m", "-c"]
 
 -- | Use <http://yui.github.io/yuicompressor/ YUI Compressor> to compress javascript.
 -- Assumes a script @yuicompressor@ is located in the path.  If not, you can still


### PR DESCRIPTION
UglifyJS2 requires filenames (or "-") first, then options. Otherwise it just prints "Error parsing arguments in: -". Tested with uglify-js 2.4.24.