### PR TITLE
Test middleware

### DIFF
--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.4.3.1
+version:            1.5
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
I want to see a request logger of the tests. Allowing me to configure my middleware for tests accomplishes this. I didn't see how to make this change in a non-breaking way.

The type alias is questionable, but may be helpful.

We can hold off on merging for a while since it is a breaking change