### PR TITLE
mkYesodGeneral: Argument types can now be polymorphic

### DIFF
--- a/yesod-core/Yesod/Core/Dispatch.hs
+++ b/yesod-core/Yesod/Core/Dispatch.hs
@@ -11,6 +11,7 @@ module Yesod.Core.Dispatch
     , parseRoutesFile
     , parseRoutesFileNoCheck
     , mkYesod
+    , mkYesodWith
       -- ** More fine-grained
     , mkYesodData
     , mkYesodSubData

--- a/yesod-core/Yesod/Core/Internal/TH.hs
+++ b/yesod-core/Yesod/Core/Internal/TH.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE CPP #-}
 module Yesod.Core.Internal.TH where
 
 import Prelude hiding (exp)
@@ -94,7 +95,13 @@ mkYesodGeneral name args isSub resS = do
                    case arg of
                      Left  t  -> ( ConT (mkName t):xs, n:ns, cs )
                      Right ts -> ( VarT n         :xs,   ns
-                                 , fmap (\t -> AppT (ConT $ mkName t) (VarT n)) ts ++ cs )
+                                 , fmap (\t -> 
+#if MIN_VERSION_base(4,8,0)
+                                               AppT (ConT $ mkName t) (VarT n)
+#else
+                                               ClassP (mkName t) [VarT n]
+#endif
+                                          ) ts ++ cs )
                  ) ([],vns,[]) args
         site = foldl' AppT (ConT $ mkName name) argtypes
         res = map (fmap parseType) resS

--- a/yesod-core/Yesod/Core/Internal/TH.hs
+++ b/yesod-core/Yesod/Core/Internal/TH.hs
@@ -96,7 +96,7 @@ mkYesodGeneral name args isSub resS = do
                      Left  t  -> ( ConT (mkName t):xs, n:ns, cs )
                      Right ts -> ( VarT n         :xs,   ns
                                  , fmap (\t -> 
-#if MIN_VERSION_base(4,8,0)
+#if MIN_VERSION_template_haskell(2,10,0)
                                                AppT (ConT $ mkName t) (VarT n)
 #else
                                                ClassP (mkName t) [VarT n]

--- a/yesod-core/Yesod/Core/Internal/TH.hs
+++ b/yesod-core/Yesod/Core/Internal/TH.hs
@@ -16,6 +16,7 @@ import qualified Network.Wai as W
 import Data.ByteString.Lazy.Char8 ()
 import Data.List (foldl')
 import Control.Monad (replicateM)
+import Data.Either (partitionEithers)
 
 import Yesod.Routes.TH
 import Yesod.Routes.Parse
@@ -32,6 +33,12 @@ mkYesod :: String -- ^ name of the argument datatype
         -> Q [Dec]
 mkYesod name = fmap (uncurry (++)) . mkYesodGeneral name [] False
 
+mkYesodWith :: String
+            -> [Either String [String]]
+            -> [ResourceTree String]
+            -> Q [Dec]
+mkYesodWith name args = fmap (uncurry (++)) . mkYesodGeneral name args False
+
 -- | Sometimes, you will want to declare your routes in one file and define
 -- your handlers elsewhere. For example, this is the only way to break up a
 -- monolithic file into smaller parts. Use this function, paired with
@@ -45,7 +52,7 @@ mkYesodSubData name res = mkYesodDataGeneral name True res
 mkYesodDataGeneral :: String -> Bool -> [ResourceTree String] -> Q [Dec]
 mkYesodDataGeneral name isSub res = do
     let (name':rest) = words name
-    fmap fst $ mkYesodGeneral name' rest isSub res
+    fmap fst $ mkYesodGeneral name' (fmap Left rest) isSub res
 
 -- | See 'mkYesodData'.
 mkYesodDispatch :: String -> [ResourceTree String] -> Q [Dec]
@@ -60,9 +67,12 @@ masterTypeSyns vs site =
       $ ConT ''WidgetT `AppT` site `AppT` ConT ''IO `AppT` ConT ''()
     ]
 
+-- | 'Left' arguments indicate a monomorphic type, a 'Right' argument
+--   indicates a polymorphic type, and provides the list of classes
+--   the type must be instance of.
 mkYesodGeneral :: String                   -- ^ foundation type
-               -> [String]                 -- ^ arguments for the type
-               -> Bool                     -- ^ it this a subsite
+               -> [Either String [String]] -- ^ arguments for the type
+               -> Bool                     -- ^ is this a subsite
                -> [ResourceTree String]
                -> Q([Dec],[Dec])
 mkYesodGeneral name args isSub resS = do
@@ -75,17 +85,22 @@ mkYesodGeneral name args isSub resS = do
                 NewtypeD _ _ vs _ _ -> length vs
                 _ -> 0
             _ -> 0
+        (mtys,ptys) = partitionEithers args
     -- Generate as many variable names as the arity indicates
-    vns <- replicateM arity $ newName "t"
-        -- Variables for type parameters
-    let vs = fmap VarT vns
+    vns <- replicateM (arity - length mtys) $ newName "t"
         -- Base type (site type with variables)
-        basety = foldl' AppT (ConT $ mkName name) vs
-        site = foldl' AppT basety (map (VarT . mkName) args)
+    let (argtypes,cxt) = (\(ns,r,cs) -> (ns ++ fmap VarT r, cs)) $
+          foldr (\arg (xs,n:ns,cs) ->
+                   case arg of
+                     Left  t  -> ( ConT (mkName t):xs, n:ns, cs )
+                     Right ts -> ( VarT n         :xs,   ns
+                                 , fmap (\t -> AppT (ConT $ mkName t) (VarT n)) ts ++ cs )
+                 ) ([],vns,[]) args
+        site = foldl' AppT (ConT $ mkName name) argtypes
         res = map (fmap parseType) resS
     renderRouteDec <- mkRenderRouteInstance site res
     routeAttrsDec  <- mkRouteAttrsInstance site res
-    dispatchDec    <- mkDispatchInstance site res
+    dispatchDec    <- mkDispatchInstance site cxt res
     parse <- mkParseRouteInstance site res
     let rname = mkName $ "resources" ++ name
     eres <- lift resS
@@ -128,12 +143,13 @@ mkMDS rh = MkDispatchSettings
 -- when writing library/plugin for yesod, this combinator becomes
 -- handy.
 mkDispatchInstance :: Type                -- ^ The master site type
+                   -> Cxt                 -- ^ Context of the instance
                    -> [ResourceTree a]    -- ^ The resource
                    -> DecsQ
-mkDispatchInstance master res = do
+mkDispatchInstance master cxt res = do
     clause' <- mkDispatchClause (mkMDS [|yesodRunner|]) res
     let thisDispatch = FunD 'yesodDispatch [clause']
-    return [InstanceD [] yDispatch [thisDispatch]]
+    return [InstanceD cxt yDispatch [thisDispatch]]
   where
     yDispatch = ConT ''YesodDispatch `AppT` master
 


### PR DESCRIPTION
PR related with #1051.

## Summary

I made some changes to ``mkYesodGeneral``, so that it is possible to create sites with polymorphic type parameters.

## Type change

The type of ``mkYesodGeneral`` has changed from ``String -> [String] -> Bool -> [ResourceTree String] -> Q ([Dec],[Dec])`` to ``String -> [Either String [String]] -> Bool -> [ResourceTree String] -> Q ([Dec],[Dec])``. The ``[String]`` argument was used to pass monomorphic type arguments to the type named by the first argument. In the new function, you can either specify a monomorphic type (using ``Left``) or a polymorphic type (using ``Right``). The list of ``String``s represents a list of classes that will be added to the context of the ``YesodDispatch`` instance.

I know this might seem confusing, but I thought it was the closest way to achieve what I wanted without making substantial changes. Plus, everything that worked before, should still work without changes.

## Example

An example to explain how the new mkYesodGeneral works:

```haskell
data Foo a = Foo a

class Bar a where
  ...

mkYesodWith "Foo" [Right ["Bar"]] (...)
```

This would create Yesod types and instances for the type ``Foo``, and the ``YesodDispatch``class would look like:

```haskell
instance Bar a => YesodDispatch (Foo a) where
   ...
```

The ``Handler`` will be parametrized too:

```haskell
getSomethingR :: Handler a x
getSomethingR = ...
```

If you write a route handler like:

```haskell
getSomethingElseR :: Bar a => Handler a x
getSomethingElseR = ...
```

Since the ``Bar a`` constraint has been added to the ``YesodDispatch`` instance context, it won't fail because a missing instance.

Note that the type variable of polymorphic parameters is not given by the user, but automatically generated by ``mkYesodGeneral``.

## Other considerations

* The ``Either`` type is a little obscure, in the sense that it doesn't really tell us much about the intention of the argument. In the first place I considered defining a new type to make the intention of the argument clearer. I failed to the ``Either`` side because I wanted to make as little changes as possible.

* New ``mkYesodGeneral`` uses a very simple pattern match to deduce the arity of the site type. This has flaws. For example, it doesn't see through type synonyms, which will consider of arity 0. In any case, this means that for many cases it will just work as it has been working before.

* A new function ``mkYesodWith`` was added in the spirit of ``mkYesod``, but with an additional argument to pass type parameters (either monomorphic or polymorphic). The name was chosen arbitrarily and can be changed to any other.

* In issue #1051 was suggested to make ``mkYesodGeneral`` arguments be of type ``Name`` instead of ``String``, which probably makes sense, but I didn't want to do it just yet.

## Epilogue

Please, let me know any changes that are needed to get this functionality merged. I need it for a server I'm writing where the site type is parametrized. This shouldn't affect any yesod users as ``mkYesod`` will behave exactly the same way for traditional use cases. This change will only make possible to compile more cases.

Thanks!