### PR TITLE
Add functions to yesod-test to support the new CSRF middleware

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.4.3.2
+
+* Add `addTokenFromCookie` and `addTokenFromCookieNamedToHeaderNamed`, which support the new CSRF token middleware [#1058](https://github.com/yesodweb/yesod/pull/1058)
+* Add `getRequestCookies`, which returns the cookies from the most recent request [#1058](https://github.com/yesodweb/yesod/pull/1058)
+
 ## 1.4.3.1
 
 * Improved README

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -37,7 +37,7 @@ library
                    , time
                    , blaze-builder
                    , cookie
-                   , yesod-core                >= 1.4
+                   , yesod-core                >= 1.4.14
 
     exposed-modules: Yesod.Test
                      Yesod.Test.CssQuery


### PR DESCRIPTION
This PR adds functions to add CSRF tokens from cookies, supporting the new CSRF middleware added in #1017.