### PR TITLE
yesod-test: have `request` not default to the form-urlencoded Content-Type

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,3 +1,9 @@
+## 1.5.0.1
+
+* Fixed the `application/x-www-form-urlencoded` header being added to all requests, even those sending a binary POST body [#1064](https://github.com/yesodweb/yesod/pull/1064/files)
+	* The `application/x-www-form-urlencoded` Content-Type header is now only added if key-value POST parameters are added
+	* If no key-values pairs are added, or the request body is set with `setRequestBody`, no default Content-Type header is set
+
 ## 1.5
 
 * remove deprecated addNonce functions

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -60,6 +60,7 @@ test-suite test
                           , yesod-form
                           , text
                           , wai
+                          , http-types
 
 source-repository head
   type: git


### PR DESCRIPTION
* Only set the Content-Type to `application/x-www-form-urlencoded` if key-value pairs are added
* Previously the `application/x-www-form-urlencoded` Content-Type would be added even if you set a binary request body.
	* You could add your own Content-Type with `addRequestHeader`, but this resulted in multiple Content-Type headers.
* Closes #1063