### PR TITLE
mkYesodGeneral: Assume type arity 0 when type is not in scope at splicing time

### DIFF
--- a/yesod-core/test/YesodCoreTest/RawResponse.hs
+++ b/yesod-core/test/YesodCoreTest/RawResponse.hs
@@ -24,13 +24,13 @@ import Data.Streaming.Network (bindPortTCP)
 import Network.HTTP.Types (status200)
 import Blaze.ByteString.Builder (fromByteString)
 
-data App = App
-
 mkYesod "App" [parseRoutes|
 / HomeR GET
 /wai-stream WaiStreamR GET
 /wai-app-stream WaiAppStreamR GET
 |]
+
+data App = App
 
 instance Yesod App
 


### PR DESCRIPTION
This avoids calling `reify` when the reified type is not in scope at splicing time (TH call). Since we still need to specify the arity of the type, we assume it to be 0, producing code equivalent to the code produced by previous versions of yesod (before 1.4.14).

I'm not sure this is a step forward, so please, before merging, read my comment https://github.com/yesodweb/yesod/issues/1059#issuecomment-133948435.