### PR TITLE
yesod-auth: google sign-in ask for profile permission

### DIFF
--- a/yesod-auth/Yesod/Auth/GoogleEmail2.hs
+++ b/yesod-auth/Yesod/Auth/GoogleEmail2.hs
@@ -152,7 +152,7 @@ authPlugin storeToken clientID clientSecret =
         csrf <- getCreateCsrfToken
         render <- getUrlRender
         let qs = map (second Just)
-                [ ("scope", "email")
+                [ ("scope", "email profile")
                 , ("state", csrf)
                 , ("redirect_uri", render $ tm complete)
                 , ("response_type", "code")

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.4.6
+version:         1.4.6.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
somehow we are able to read the profile
of most users without this