### PR TITLE
Thread leak when calling neverExpires 

### DIFF
--- a/yesod-core/Yesod/Core/Dispatch.hs
+++ b/yesod-core/Yesod/Core/Dispatch.hs
@@ -240,5 +240,5 @@ warpEnv site = do
 getGetMaxExpires :: IO (IO Text)
 getGetMaxExpires = mkAutoUpdate defaultUpdateSettings
   { updateAction = getCurrentMaxExpiresRFC1123
-  , updateFreq = 60 * 60 * 1000000 -- Update once per hour
+  , updateFreq = 24 * 60 * 60 * 1000000 -- Update once per day
   }

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -733,7 +733,7 @@ cacheSeconds i = setHeader "Cache-Control" $ T.concat
 -- is never (realistically) expired.
 neverExpires :: MonadHandler m => m ()
 neverExpires = do
-    askHandlerEnv >>= liftIO . rheGetMaxExpires >>= setHeader "Expires"
+    setHeader "Expires" . rheMaxExpires =<< askHandlerEnv
     cacheSeconds oneYear
   where
     oneYear :: Int

--- a/yesod-core/Yesod/Core/Internal/Util.hs
+++ b/yesod-core/Yesod/Core/Internal/Util.hs
@@ -54,6 +54,8 @@ formatRFC1123 = T.pack . formatTime defaultTimeLocale "%a, %d %b %Y %X %Z"
 formatRFC822 :: UTCTime -> T.Text
 formatRFC822 = T.pack . formatTime defaultTimeLocale "%a, %d %b %Y %H:%M:%S %z"
 
--- | Format the time a year from now as per RFC 1123.
+{- | Get the time 365 days from now in RFC 1123 format. For use as an expiry
+date on a resource that never expires. See RFC 2616 section 14.21 for details.
+-}
 getCurrentMaxExpiresRFC1123 :: IO T.Text
 getCurrentMaxExpiresRFC1123 = liftM (formatRFC1123 . addUTCTime (60*60*24*365)) getCurrentTime

--- a/yesod-core/Yesod/Core/Internal/Util.hs
+++ b/yesod-core/Yesod/Core/Internal/Util.hs
@@ -5,13 +5,16 @@ module Yesod.Core.Internal.Util
     , formatW3
     , formatRFC1123
     , formatRFC822
+    , getCurrentMaxExpiresRFC1123
     ) where
 
 import           Data.Int       (Int64)
 import           Data.Serialize (Get, Put, Serialize (..))
 import qualified Data.Text      as T
 import           Data.Time      (Day (ModifiedJulianDay, toModifiedJulianDay),
-                                 DiffTime, UTCTime (..), formatTime)
+                                 DiffTime, UTCTime (..), formatTime,
+                                 getCurrentTime, addUTCTime)
+import           Control.Monad  (liftM)
 
 #if MIN_VERSION_time(1,5,0)
 import           Data.Time      (defaultTimeLocale)
@@ -50,3 +53,7 @@ formatRFC1123 = T.pack . formatTime defaultTimeLocale "%a, %d %b %Y %X %Z"
 -- | Format as per RFC 822.
 formatRFC822 :: UTCTime -> T.Text
 formatRFC822 = T.pack . formatTime defaultTimeLocale "%a, %d %b %Y %H:%M:%S %z"
+
+-- | Format the time a year from now as per RFC 1123.
+getCurrentMaxExpiresRFC1123 :: IO T.Text
+getCurrentMaxExpiresRFC1123 = liftM (formatRFC1123 . addUTCTime (60*60*24*365)) getCurrentTime

--- a/yesod-core/Yesod/Core/Types.hs
+++ b/yesod-core/Yesod/Core/Types.hs
@@ -183,10 +183,10 @@ data RunHandlerEnv site = RunHandlerEnv
     , rheUpload   :: !(RequestBodyLength -> FileUpload)
     , rheLog      :: !(Loc -> LogSource -> LogLevel -> LogStr -> IO ())
     , rheOnError  :: !(ErrorResponse -> YesodApp)
-    , rheGetMaxExpires :: IO Text
       -- ^ How to respond when an error is thrown internally.
       --
       -- Since 1.2.0
+    , rheMaxExpires :: !Text
     }
 
 data HandlerData site parentRoute = HandlerData
@@ -202,6 +202,7 @@ data YesodRunnerEnv site = YesodRunnerEnv
     , yreSite           :: !site
     , yreSessionBackend :: !(Maybe SessionBackend)
     , yreGen            :: !MWC.GenIO
+    , yreGetMaxExpires  :: IO Text
     }
 
 data YesodSubRunnerEnv sub parent parentMonad = YesodSubRunnerEnv


### PR DESCRIPTION
My commit (42f098ff64d5a9c8f8cccac7ebc940ecdf45dfc4) causes `neverExpires` to leak threads rather badly. See https://groups.google.com/forum/#!topic/yesodweb/TJgI1LKtMgM for graphs.

I clearly misunderstood where I'd added the call to `mkAutoUpdate` - I intended it to be when the application was being set up but now I look at it again I see that it's calling it in every handler.

I can't promise I will be able to fix this for a few days, but a fix is on its way.

Deepest apologies!