### PR TITLE
Add Foldable and Traversable instances for FormResult

### DIFF
--- a/yesod-form/Yesod/Form/Types.hs
+++ b/yesod-form/Yesod/Form/Types.hs
@@ -35,6 +35,8 @@ import Data.String (IsString (..))
 import Yesod.Core
 import qualified Data.Map as Map
 import Data.Semigroup (Semigroup, (<>))
+import Data.Traversable
+import Data.Foldable
 
 -- | A form can produce three different results: there was no data available,
 -- the data was invalid, or there was a successful parse.
@@ -61,6 +63,16 @@ instance Monoid m => Monoid (FormResult m) where
     mappend x y = mappend <$> x <*> y
 instance Semigroup m => Semigroup (FormResult m) where
     x <> y = (<>) <$> x <*> y
+instance Foldable FormResult where
+    foldMap f r = case r of
+      FormSuccess a -> f a
+      FormFailure errs -> mempty
+      FormMissing -> mempty
+instance Traversable FormResult where
+    traverse f r = case r of
+      FormSuccess a -> fmap FormSuccess (f a)
+      FormFailure errs -> pure (FormFailure errs)
+      FormMissing -> pure FormMissing
 
 -- | The encoding type required by a form. The 'ToHtml' instance produces values
 -- that can be inserted directly into HTML.

--- a/yesod-form/Yesod/Form/Types.hs
+++ b/yesod-form/Yesod/Form/Types.hs
@@ -63,11 +63,15 @@ instance Monoid m => Monoid (FormResult m) where
     mappend x y = mappend <$> x <*> y
 instance Semigroup m => Semigroup (FormResult m) where
     x <> y = (<>) <$> x <*> y
+
+-- | Since 1.4.4.2
 instance Foldable FormResult where
     foldMap f r = case r of
       FormSuccess a -> f a
       FormFailure errs -> mempty
       FormMissing -> mempty
+
+-- | Since 1.4.4.2
 instance Traversable FormResult where
     traverse f r = case r of
       FormSuccess a -> fmap FormSuccess (f a)

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,5 +1,5 @@
 name:            yesod-form
-version:         1.4.4.1
+version:         1.4.4.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This will let users operate on a `FormResult` with a bunch of useful combinators. In particular, I'm thinking of `forM_`, since when handling a `FormResult`, I often write:

    case res of
        FormSuccess myData -> do
          ...
        _ -> return ()

Instead, this let's people write:

    forM_ res $ \myData -> do
        ...

I'm 99% sure that the instances I've provided are law-abiding, but if anyone wants to confirm that for me, I would appreciate it.