### PR TITLE
Minor auth tweaks

### DIFF
--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -549,7 +549,7 @@ saltLength = 5
 -- | Salt a password with a randomly generated salt.
 saltPass :: Text -> IO Text
 saltPass = fmap (decodeUtf8With lenientDecode)
-         . flip PS.makePassword 14
+         . flip PS.makePassword 16
          . encodeUtf8
 
 saltPass' :: String -> String -> String

--- a/yesod-auth/Yesod/PasswordStore.hs
+++ b/yesod-auth/Yesod/PasswordStore.hs
@@ -38,7 +38,7 @@
 -- > >>> makePassword "hunter2" 14
 -- > "sha256|14|Zo4LdZGrv/HYNAUG3q8WcA==|zKjbHZoTpuPLp1lh6ATolWGIKjhXvY4TysuKvqtNFyk="
 --
--- This will hash the password @\"hunter2\"@, with strength 12, which is a good
+-- This will hash the password @\"hunter2\"@, with strength 14, which is a good
 -- default value. The strength here determines how long the hashing will
 -- take. When doing the hashing, we iterate the SHA256 hash function
 -- @2^strength@ times, so increasing the strength by 1 makes the hashing take


### PR DESCRIPTION
This fixes a typo and bumps password strength to compensate 2 years. Value 16 is based on file `PasswordStore.hs` which I suppose was originally written in 2011 and proposed password strength back then was 12. In 2013 proposed strength was 14, so extrapolating this linearly (linearly with respect to “strength” value, and exponentially with respect to computational speeds) we get 16 in 2015, which is close to its end. 16 should be good enough, but I'm not an expert in this area.
