### PR TITLE
Fix references to ‘Yesod.Core.Handler’

### DIFF
--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -427,7 +427,7 @@ defaultCsrfCheckMiddleware handler = do
 -- | Looks up the CSRF token from the request headers or POST parameters. If the value doesn't match the token stored in the session,
 -- this function throws a 'PermissionDenied' error.
 --
--- For details, see the "AJAX CSRF protection" section of 'Yesod.Core.Handler'.
+-- For details, see the "AJAX CSRF protection" section of "Yesod.Core.Handler".
 --
 -- Since 1.4.14
 csrfCheckMiddleware :: Yesod site
@@ -449,15 +449,15 @@ defaultCsrfSetCookieMiddleware handler = csrfSetCookieMiddleware handler (def { 
 
 -- | Takes a 'SetCookie' and overrides its value with a CSRF token, then sets the cookie. See 'setCsrfCookieWithCookie'.
 --
--- For details, see the "AJAX CSRF protection" section of 'Yesod.Core.Handler'.
+-- For details, see the "AJAX CSRF protection" section of "Yesod.Core.Handler".
 --
 -- Since 1.4.14
 csrfSetCookieMiddleware :: Yesod site => HandlerT site IO res -> SetCookie -> HandlerT site IO res
 csrfSetCookieMiddleware handler cookie = setCsrfCookieWithCookie cookie >> handler
 
--- | Calls 'defaultCsrfSetCookieMiddleware' and 'defaultCsrfCheckMiddleware'. Use this midle 
+-- | Calls 'defaultCsrfSetCookieMiddleware' and 'defaultCsrfCheckMiddleware'.
 --
--- For details, see the "AJAX CSRF protection" section of 'Yesod.Core.Handler'.
+-- For details, see the "AJAX CSRF protection" section of "Yesod.Core.Handler".
 --
 -- Since 1.4.14
 defaultCsrfMiddleware :: Yesod site => HandlerT site IO res -> HandlerT site IO res
@@ -669,9 +669,9 @@ asyncHelper render scripts jscript jsLoc =
 
 -- | Default formatting for log messages. When you use
 -- the template haskell logging functions for to log with information
--- about the source location, that information will be appended to 
--- the end of the log. When you use the non-TH logging functions, 
--- like 'logDebugN', this function does not include source 
+-- about the source location, that information will be appended to
+-- the end of the log. When you use the non-TH logging functions,
+-- like 'logDebugN', this function does not include source
 -- information. This currently works by checking to see if the
 -- package name is the string \"\<unknown\>\". This is a hack,
 -- but it removes some of the visual clutter from non-TH logs.
@@ -686,22 +686,22 @@ formatLogMessage :: IO ZonedDate
 formatLogMessage getdate loc src level msg = do
     now <- getdate
     return $ mempty
-        `mappend` toLogStr now 
-        `mappend` " [" 
+        `mappend` toLogStr now
+        `mappend` " ["
         `mappend` (case level of
             LevelOther t -> toLogStr t
-            _ -> toLogStr $ drop 5 $ show level) 
+            _ -> toLogStr $ drop 5 $ show level)
         `mappend` (if T.null src
             then mempty
-            else "#" `mappend` toLogStr src) 
-        `mappend` "] " 
-        `mappend` msg 
+            else "#" `mappend` toLogStr src)
+        `mappend` "] "
+        `mappend` msg
         `mappend` sourceSuffix
         `mappend` "\n"
-    where 
+    where
     sourceSuffix = if loc_package loc == "<unknown>" then "" else mempty
-        `mappend` " @(" 
-        `mappend` toLogStr (fileLocationToString loc) 
+        `mappend` " @("
+        `mappend` toLogStr (fileLocationToString loc)
         `mappend` ")"
 
 -- | Customize the cookies used by the session backend.  You may

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -322,7 +322,7 @@ askHandlerEnv = liftHandlerT $ HandlerT $ return . handlerEnv
 getYesod :: MonadHandler m => m (HandlerSite m)
 getYesod = rheSite `liftM` askHandlerEnv
 
--- | Get a specific component of the master site application argument. 
+-- | Get a specific component of the master site application argument.
 --   Analogous to the 'gets' function for operating on 'StateT'.
 getsYesod :: MonadHandler m => (HandlerSite m -> a) -> m a
 getsYesod f = (f . rheSite) `liftM` askHandlerEnv
@@ -1301,8 +1301,8 @@ stripHandlerT (HandlerT f) getSub toMaster newRoute = HandlerT $ \hd -> do
         }
 
 -- $ajaxCSRFOverview
--- When a user has authenticated with your site, all requests made from the browser to your server will include the session information that you use to verify that the user is logged in. 
--- Unfortunately, this allows attackers to make unwanted requests on behalf of the user by e.g. submitting an HTTP request to your site when the user visits theirs. 
+-- When a user has authenticated with your site, all requests made from the browser to your server will include the session information that you use to verify that the user is logged in.
+-- Unfortunately, this allows attackers to make unwanted requests on behalf of the user by e.g. submitting an HTTP request to your site when the user visits theirs.
 -- This is known as a <https://en.wikipedia.org/wiki/Cross-site_request_forgery Cross Site Request Forgery> (CSRF) attack.
 --
 -- To combat this attack, you need a way to verify that the request is valid.
@@ -1315,24 +1315,24 @@ stripHandlerT (HandlerT f) getSub toMaster newRoute = HandlerT $ \hd -> do
 --
 -- (2) Yesod can store the CSRF token in a cookie which is accessible by Javascript. Requests made by Javascript can lookup this cookie and add it as a header to requests. The server then checks the token in the header against the one in the encrypted session.
 --
--- The form-based approach has the advantage of working for users with Javascript disabled, while adding the token to the headers with Javascript allows things like submitting JSON or binary data in AJAX requests. Yesod supports checking for a CSRF token in either the POST parameters of the form ('checkCsrfHeaderNamed'), the headers ('checkCsrfHeaderNamed'), or both options ('checkCsrfHeaderOrParam').
+-- The form-based approach has the advantage of working for users with Javascript disabled, while adding the token to the headers with Javascript allows things like submitting JSON or binary data in AJAX requests. Yesod supports checking for a CSRF token in either the POST parameters of the form ('checkCsrfParamNamed'), the headers ('checkCsrfHeaderNamed'), or both options ('checkCsrfHeaderOrParam').
 --
 -- The easiest way to check both sources is to add the 'defaultCsrfMiddleware' to your Yesod Middleware.
 
 -- | The default cookie name for the CSRF token ("XSRF-TOKEN").
--- 
+--
 -- Since 1.4.14
 defaultCsrfCookieName :: S8.ByteString
 defaultCsrfCookieName = "XSRF-TOKEN"
 
 -- | Sets a cookie with a CSRF token, using 'defaultCsrfCookieName' for the cookie name.
--- 
+--
 -- Since 1.4.14
 setCsrfCookie :: MonadHandler m => m ()
 setCsrfCookie = setCsrfCookieWithCookie def { setCookieName = defaultCsrfCookieName }
 
 -- | Takes a 'SetCookie' and overrides its value with a CSRF token, then sets the cookie.
--- 
+--
 -- Since 1.4.14
 setCsrfCookieWithCookie :: MonadHandler m => SetCookie -> m ()
 setCsrfCookieWithCookie cookie  = do
@@ -1340,14 +1340,14 @@ setCsrfCookieWithCookie cookie  = do
     Fold.forM_ mCsrfToken (\token -> setCookie $ cookie { setCookieValue = encodeUtf8 token })
 
 -- | The default header name for the CSRF token ("X-XSRF-TOKEN").
--- 
+--
 -- Since 1.4.14
 defaultCsrfHeaderName :: CI S8.ByteString
 defaultCsrfHeaderName = "X-XSRF-TOKEN"
 
 -- | Takes a header name to lookup a CSRF token. If the value doesn't match the token stored in the session,
 -- this function throws a 'PermissionDenied' error.
--- 
+--
 -- Since 1.4.14
 checkCsrfHeaderNamed :: MonadHandler m => CI S8.ByteString -> m ()
 checkCsrfHeaderNamed headerName = do
@@ -1355,7 +1355,7 @@ checkCsrfHeaderNamed headerName = do
   unless valid (permissionDenied csrfErrorMessage)
 
 -- | Takes a header name to lookup a CSRF token, and returns whether the value matches the token stored in the session.
--- 
+--
 -- Since 1.4.14
 hasValidCsrfHeaderNamed :: MonadHandler m => CI S8.ByteString -> m Bool
 hasValidCsrfHeaderNamed headerName = do


### PR DESCRIPTION
The links don't work:

http://haddock.stackage.org/nightly-2015-12-11/yesod-core-1.4.17/Yesod-Core.html#v:Handler

because Haddock's syntax for module references is double quotes `"Yesod.Core.Handler"`. Also I removed the incomplete phrase “Use this midle”.

Note that Emacs eliminated trailing whitespace. I committed that too, because trailing whitespace is nothing good.
