### PR TITLE
Add error class when help text is an error.

### DIFF
--- a/yesod-form/Yesod/Form/Bootstrap3.hs
+++ b/yesod-form/Yesod/Form/Bootstrap3.hs
@@ -191,7 +191,7 @@ helpWidget view = [whamlet|
     $maybe tt <- fvTooltip view
       <span .help-block>#{tt}
     $maybe err <- fvErrors view
-      <span .help-block>#{err}
+      <span .help-block .error-block>#{err}
 |]
 
 


### PR DESCRIPTION
Does anyone care for this feature?

It doesn't appear as part of the Bootstrap3 spec - http://getbootstrap.com/css/#forms-control-validation - but it does actually appear to be useful.

For example, I have a field which has a permanent tool-tip; explaining what it is. But when someone doesn't fill it out correctly, but the validation only happens on the server, then the error gets sent back as a `help-block` that sits *below* the original help text. It is styled in exactly the same way.

The parent element having the `is-error` class is pretty useless, because if I were to style both of them as errors, it would show the tooltip help text as an error, *as well* as the error, which I don't think is ideal.

Opening this up for comment by way of pull request. Feel free to reject if it's not a good solution for everyone, and I'll just use something like this locally (or feel free to suggest a better way).

Thanks!