### PR TITLE
Allow subsites within hierarchical routes

### DIFF
--- a/yesod-core/Yesod/Routes/TH/Dispatch.hs
+++ b/yesod-core/Yesod/Routes/TH/Dispatch.hs
@@ -176,11 +176,12 @@ mkDispatchClause MkDispatchSettings {..} resources = do
                     subDispatcherE <- mdsSubDispatcher
                     runHandlerE <- mdsRunHandler
                     sub <- newName "sub"
+                    sroute <- newName "sroute"
                     let sub2 = LamE [VarP sub]
                             (foldl' (\a b -> a `AppE` b) (VarE (mkName getSub) `AppE` VarE sub) dyns)
                     let reqExp' = setPathInfoE `AppE` VarE restPath `AppE` reqExp
                         route' = foldl' AppE (ConE (mkName name)) dyns
-                        route = foldr AppE route' extraCons
+                        route = LamE [VarP sroute] $ foldr AppE (AppE route' $ VarE sroute) extraCons
                         exp = subDispatcherE
                             `AppE` runHandlerE
                             `AppE` sub2

--- a/yesod-core/test/YesodCoreTest/WaiSubsite.hs
+++ b/yesod-core/test/YesodCoreTest/WaiSubsite.hs
@@ -15,6 +15,8 @@ data Y = Y
 mkYesod "Y" [parseRoutes|
 / RootR GET
 /sub WaiSubsiteR WaiSubsite getApp
+/nested NestedR:
+  /sub NestedWaiSubsiteR WaiSubsite getApp
 |]
 
 instance Yesod Y
@@ -34,5 +36,10 @@ specs = describe "WaiSubsite" $ do
 
     it "subsite" $ app $ do
       res <- request defaultRequest { pathInfo = ["sub", "foo"] }
+      assertStatus 200 res
+      assertBodyContains "WAI" res
+
+    it "nested subsite" $ app $ do
+      res <- request defaultRequest { pathInfo = ["nested", "sub", "foo"] }
       assertStatus 200 res
       assertBodyContains "WAI" res


### PR DESCRIPTION
This allows subsites to work within hierarchical routes like so -

    /sub SubR:
      /hello HelloSubR HelloSubRoute getHelloSubRoute

`HelloSubR` takes the subsite route as an argument which needs to be folded through the parent route constructors. Not doing so is definitely a bug, regardless of whether hierarchical subsites are supported.
