### PR TITLE
Have the yesod-auth login form use a CSRF token

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.13
+
+* Add a CSRF token to the login form from `Yesod.Auth.Hardcoded`, making it compatible with the CSRF middleware [#1161](https://github.com/yesodweb/yesod/pull/1161)
+
 ## 1.4.12
 
 * Deprecated Yesod.Auth.GoogleEmail

--- a/yesod-auth/Yesod/Auth/Hardcoded.hs
+++ b/yesod-auth/Yesod/Auth/Hardcoded.hs
@@ -162,12 +162,11 @@ authHardcoded =
     dispatch _ _ = notFound
     loginWidget toMaster = do
       request <- getRequest
-      let tokenKey = ("_token" :: Text) -- This value taken from yesod-form's postHelper. Not ideal that it's hard-coded in two places.
       [whamlet|
         $newline never
         <form method="post" action="@{toMaster loginR}">
           $maybe t <- reqToken request
-            <input type=hidden name=#{tokenKey} value=#{t}>
+            <input type=hidden name=#{defaultCsrfParamName} value=#{t}>
           <table>
             <tr>
               <th>_{Msg.UserName}

--- a/yesod-auth/Yesod/Auth/Hardcoded.hs
+++ b/yesod-auth/Yesod/Auth/Hardcoded.hs
@@ -160,10 +160,14 @@ authHardcoded =
   where
     dispatch "POST" ["login"] = postLoginR >>= sendResponse
     dispatch _ _ = notFound
-    loginWidget toMaster =
+    loginWidget toMaster = do
+      request <- getRequest
+      let tokenKey = ("_token" :: Text) -- This value taken from yesod-form's postHelper. Not ideal that it's hard-coded in two places.
       [whamlet|
         $newline never
         <form method="post" action="@{toMaster loginR}">
+          $maybe t <- reqToken request
+            <input type=hidden name=#{tokenKey} value=#{t}>
           <table>
             <tr>
               <th>_{Msg.UserName}

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.4.12
+version:         1.4.13
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin
@@ -23,7 +23,7 @@ library
     build-depends:   base                    >= 4         && < 5
                    , authenticate            >= 1.3
                    , bytestring              >= 0.9.1.4
-                   , yesod-core              >= 1.4       && < 1.5
+                   , yesod-core              >= 1.4.14    && < 1.5
                    , wai                     >= 1.4
                    , template-haskell
                    , base16-bytestring

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -59,6 +59,7 @@ import Text.Blaze (Markup, toMarkup)
 #define Html Markup
 #define toHtml toMarkup
 import Yesod.Core
+import Yesod.Core.Handler (defaultCsrfParamName)
 import Network.Wai (requestMethod)
 import Text.Hamlet (shamlet)
 import Data.Monoid (mempty)
@@ -213,7 +214,7 @@ postHelper  :: (MonadHandler m, RenderMessage (HandlerSite m) FormMessage)
             -> m ((FormResult a, xml), Enctype)
 postHelper form env = do
     req <- getRequest
-    let tokenKey = "_token"
+    let tokenKey = defaultCsrfParamName
     let token =
             case reqToken req of
                 Nothing -> mempty

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -20,7 +20,7 @@ flag network-uri
 
 library
     build-depends:   base                  >= 4        && < 5
-                   , yesod-core            >= 1.4      && < 1.5
+                   , yesod-core            >= 1.4.14   && < 1.5
                    , yesod-persistent      >= 1.4      && < 1.5
                    , time                  >= 1.1.4
                    , shakespeare           >= 2.0


### PR DESCRIPTION
Closes #1159

Based on reading this [StackOverflow Post](http://stackoverflow.com/questions/6412813/do-login-forms-need-tokens-against-csrf-attacks) and skimming [this paper](http://seclab.stanford.edu/websec/csrf/csrf.pdf), using CSRF protection on login forms protects against a vulnerability where an attacker submits their own username/password in the login form. Later, the user uses the real site, but doesn't realize they're logged in as the attacker. This creates vulnerabilities like:

1. If the site logs the user's activity for them (e.g. recently watched videos on YouTube, previous searches on Google), the attacker can see this information by logging in. This allows the attacker to track/spy on the user.
2. The user adds sensitive information to the account, like credit card information, the attacker can login and potentially steal that information or use it on the site.

I don't think this vulnerability applies to the `Yesod.Auth.Hardcoded` plugin because the attacker couldn't create an account of their own.

However:

* If I understand the example in `Yesod.Auth.Hardcoded`, one use case is to share one login form that works for both the Hardcoded plugin as well as normal database-backed username/password login, in which case having a CSRF token makes sense
* I don't see a downside to having the CSRF token there
* It makes the Hardcoded plugin work with the CSRF middleware

Does this sound like the right solution?