### PR TITLE
Fixed registerHandler CSRF issue

### DIFF
--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -301,13 +301,13 @@ getRegisterR = registerHandler
 -- Since: 1.2.6
 defaultRegisterHandler :: YesodAuthEmail master => AuthHandler master Html
 defaultRegisterHandler = do
-    ((f,widget),e) <- lift $ runFormPost registrationForm
+    ((_,widget),enctype) <- lift $ runFormPost registrationForm
     toParentRoute <- getRouteToParent
     lift $ authLayout $ do
         setTitleI Msg.RegisterLong
         [whamlet|
             <p>_{Msg.EnterEmail}
-            <form method="post" action="@{toParentRoute registerR}">
+            <form method="post" action="@{toParentRoute registerR}" enctype=#{enctype}>
                 <div id="registerForm">
                     ^{widget}
                 <button .btn>_{Msg.Register}

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -322,7 +322,7 @@ defaultRegisterHandler = do
                 fsAttrs = []
             }
 
-            (emailRes, emailView) <- mreq textField emailSettings Nothing
+            (emailRes, emailView) <- mreq emailField emailSettings Nothing
 
             let userRes = UserForm <$> emailRes
             let widget = do

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -315,8 +315,8 @@ defaultRegisterHandler = do
     where
         registrationForm extra = do
             let emailSettings = FieldSettings {
-                fsLabel = "Email" ,
                 fsTooltip = Nothing ,
+                fsLabel = SomeMessage Msg.Email,
                 fsId = Just "email",
                 fsName = Just "email",
                 fsAttrs = []

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -315,8 +315,8 @@ defaultRegisterHandler = do
     where
         registrationForm extra = do
             let emailSettings = FieldSettings {
-                fsTooltip = Nothing ,
                 fsLabel = SomeMessage Msg.Email,
+                fsTooltip = Nothing,
                 fsId = Just "email",
                 fsName = Just "email",
                 fsAttrs = []

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -319,7 +319,7 @@ defaultRegisterHandler = do
                 fsTooltip = Nothing,
                 fsId = Just "email",
                 fsName = Just "email",
-                fsAttrs = []
+                fsAttrs = [("autofocus", "")]
             }
 
             (emailRes, emailView) <- mreq emailField emailSettings Nothing

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -107,6 +107,8 @@ data EmailCreds site = EmailCreds
     , emailCredsEmail  :: Email
     }
 
+data UserForm = UserForm { email :: Text }
+
 class ( YesodAuth site
       , PathPiece (AuthEmailId site)
       , (RenderMessage site Msg.AuthMessage)
@@ -299,18 +301,37 @@ getRegisterR = registerHandler
 -- Since: 1.2.6
 defaultRegisterHandler :: YesodAuthEmail master => AuthHandler master Html
 defaultRegisterHandler = do
-    email <- newIdent
-    tp <- getRouteToParent
+    ((f,widget),e) <- lift $ runFormPost registrationForm
+    toParentRoute <- getRouteToParent
     lift $ authLayout $ do
         setTitleI Msg.RegisterLong
         [whamlet|
             <p>_{Msg.EnterEmail}
-            <form method="post" action="@{tp registerR}">
+            <form method="post" action="@{toParentRoute registerR}">
                 <div id="registerForm">
-                    <label for=#{email}>_{Msg.Email}:
-                    <input ##{email} type="email" name="email" width="150" autofocus>
+                    ^{widget}
                 <button .btn>_{Msg.Register}
         |]
+    where
+        registrationForm extra = do
+            let emailSettings = FieldSettings {
+                fsLabel = "Email" ,
+                fsTooltip = Nothing ,
+                fsId = Just "email",
+                fsName = Just "email",
+                fsAttrs = []
+            }
+
+            (emailRes, emailView) <- mreq textField emailSettings Nothing
+
+            let userRes = UserForm <$> emailRes
+            let widget = do
+                [whamlet|
+                    #{extra}
+                    ^{fvInput emailView}
+                |]
+
+            return (userRes, widget)
 
 registerHelper :: YesodAuthEmail master
                => Bool -- ^ allow usernames?


### PR DESCRIPTION
The default register handler for email authentication didn't provide a
CSRF token. I provided one by using a monadic form helper.

Should fix #1164