### PR TITLE
change OAuth Twitter ID, screen_name → user_id

### DIFF
--- a/yesod-auth-oauth/Yesod/Auth/OAuth.hs
+++ b/yesod-auth-oauth/Yesod/Auth/OAuth.hs
@@ -103,7 +103,7 @@ authTwitter key secret = authOAuth
                           , oauthConsumerSecret  = secret
                           , oauthVersion         = OAuth10a
                           })
-                (mkExtractCreds "twitter" "screen_name")
+                (mkExtractCreds "twitter" "user_id")
 
 twitterUrl :: AuthRoute
 twitterUrl = oauthUrl "twitter"

--- a/yesod-auth-oauth/Yesod/Auth/OAuth.hs
+++ b/yesod-auth-oauth/Yesod/Auth/OAuth.hs
@@ -5,7 +5,6 @@ module Yesod.Auth.OAuth
     , oauthUrl
     , authTwitter
     , twitterUrl
-    , twitterId
     , authTumblr
     , tumblrUrl
     , module Web.Authenticate.OAuth
@@ -108,25 +107,6 @@ authTwitter key secret = authOAuth
 
 twitterUrl :: AuthRoute
 twitterUrl = oauthUrl "twitter"
-
--- | Gets Twitter ID (/user_id/) from @Creds@.
---
--- Never use @credsIdent@ for Twitter OAuth. @credsIdent@ returns /screen_name/, which shouldn't be used for authentication.
--- /screen_name/ is text like /foo/ of /\@foo/ which is unique but __mutable__. So /screen_name/ cannot authenticate users.
--- /user_id/ is integer which is unique and __immutable__. So you should use this for authentication.
---
--- Because of compatibility, @credsIdent@ returns /screen_name/ yet.
---
--- Since 1.4.x.x
-twitterId :: Yesod m => Creds m -> Text
-twitterId creds =
-    let
-        key   = "user_id"
-        extra = credsExtra creds
-    in
-        case lookup key extra of
-            Just uId -> uId
-            Nothing  -> throw $ CredentialError ("key not found: " ++ (T.unpack key)) (Credential $ map (encodeUtf8 *** encodeUtf8) extra)
 
 authTumblr :: YesodAuth m
             => ByteString -- ^ Consumer Key

--- a/yesod-auth-oauth/Yesod/Auth/OAuth.hs
+++ b/yesod-auth-oauth/Yesod/Auth/OAuth.hs
@@ -103,7 +103,7 @@ authTwitter key secret = authOAuth
                           , oauthConsumerSecret  = secret
                           , oauthVersion         = OAuth10a
                           })
-                (mkExtractCreds "twitter" "user_id")
+                (mkExtractCreds "twitter" "screen_name")
 
 twitterUrl :: AuthRoute
 twitterUrl = oauthUrl "twitter"

--- a/yesod-auth-oauth/Yesod/Auth/OAuth.hs
+++ b/yesod-auth-oauth/Yesod/Auth/OAuth.hs
@@ -5,6 +5,7 @@ module Yesod.Auth.OAuth
     , oauthUrl
     , authTwitter
     , twitterUrl
+    , twitterId
     , authTumblr
     , tumblrUrl
     , module Web.Authenticate.OAuth
@@ -107,6 +108,25 @@ authTwitter key secret = authOAuth
 
 twitterUrl :: AuthRoute
 twitterUrl = oauthUrl "twitter"
+
+-- | Gets Twitter ID (/user_id/) from @Creds@.
+--
+-- Never use @credsIdent@ for Twitter OAuth. @credsIdent@ returns /screen_name/, which shouldn't be used for authentication.
+-- /screen_name/ is text like /foo/ of /\@foo/ which is unique but __mutable__. So /screen_name/ cannot authenticate users.
+-- /user_id/ is integer which is unique and __immutable__. So you should use this for authentication.
+--
+-- Because of compatibility, @credsIdent@ returns /screen_name/ yet.
+--
+-- Since 1.4.x.x
+twitterId :: Yesod m => Creds m -> Text
+twitterId creds =
+    let
+        key   = "user_id"
+        extra = credsExtra creds
+    in
+        case lookup key extra of
+            Just uId -> uId
+            Nothing  -> throw $ CredentialError ("key not found: " ++ (T.unpack key)) (Credential $ map (encodeUtf8 *** encodeUtf8) extra)
 
 authTumblr :: YesodAuth m
             => ByteString -- ^ Consumer Key


### PR DESCRIPTION
When using Twitter OAuth, [`credsIdent`](http://hackage.haskell.org/package/yesod-auth-1.4.12/docs/Yesod-Auth.html#v:credsIdent) returns *screen_name*. Twitter's *screen_name* is not good to use as ID because it is mutable.

The best way to identify Twitter account is to use *user_id*. *user_id* is immutable.

This change may request to change some user codes.

see: [Changing your username | Twitter Help Center](https://support.twitter.com/articles/14609) (username means *screen_name* here.)

Twitter OAuth [`credsExtra`](http://hackage.haskell.org/package/yesod-auth-1.4.12/docs/Yesod-Auth.html#v:credsExtra) is below.

```haskell
[ ("oauth_token", "foo")
, ("oauth_token_secret", "bar")
, ("user_id", "9820592")
, ("screen_name", "kakkun61")
, ("x_auth_expires", "0")
]
```