### PR TITLE
Minor doc patch - sendStatusJSON is since 1.4.18

### DIFF
--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -580,6 +580,8 @@ sendResponseStatus s = handlerError . HCContent s . toTypedContent
 
 -- | Bypass remaining handler code and output the given JSON with the given
 -- status code.
+-- 
+-- Since 1.4.18
 sendStatusJSON :: (MonadHandler m, ToJSON c) => H.Status -> c -> m a
 sendStatusJSON s v = sendResponseStatus s (toJSON v)
 


### PR DESCRIPTION
I'm sure this is trivially obvious. :-)

Commit 6a60dac introduced `sendStatusJSON` on Nov 25, 2015; yesod-core 1.4.18 was uploaded to hackage on Dec 17.