### PR TITLE
Log a warning when a CSRF error occurs

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.20.1
+
+* Log a warning when a CSRF error occurs [#1200](https://github.com/yesodweb/yesod/pull/1200)
+
 ## 1.4.20
 
 * `addMessage`, `addMessageI`, and `getMessages` functions

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -1458,4 +1458,4 @@ validCsrf Nothing            _param = True
 validCsrf (Just _token)     Nothing = False
 
 csrfErrorMessage :: Text
-csrfErrorMessage = "A valid CSRF token wasn't present in HTTP headers or POST parameters. Check the Yesod.Core.Handler docs of the yesod-core package for details on CSRF protection."
+csrfErrorMessage = "A valid CSRF token wasn't present in HTTP headers or POST parameters. Because the request could have been forged, it's been rejected altogether. Check the Yesod.Core.Handler docs of the yesod-core package for details on CSRF protection."

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.4.20
+version:         1.4.20.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
(Closes #1192)

So, this is a breaking change because it adds the `MonadLogger` constraint to `checkCsrfHeaderOrParam`. However, I find it exceptionally unlikely that would cause issues, since this function is mainly used by higher-level middleware, is pretty new, and would probably be called from a `Handler` that already has logging capabilities.

The current log message is the same as what's returned in the response body:

>    28/Mar/2016:12:15:41 -0700 [Warn#yesod-core] A valid CSRF token wasn't present in HTTP headers or POST parameters. Check the Yesod.Core.Handler docs of the yesod-core package for details on CSRF protection. @(yesod_LSS9gnOrLHV9K8GzIkReQP:Yesod.Core.Handler ./Yesod/Core/Handler.hs:1445:5)

* Thoughts on the error message?
* Thoughts a breaking change being ok?

cc @bitemyapp