### PR TITLE
Provide CSRF token in Dummy login form

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.13.1
+
+* Add CSRF token to login form from `Yesod.Auth.Dummy` [#1205](https://github.com/yesodweb/yesod/pull/1205)
+
 ## 1.4.13
 
 * Add a CSRF token to the login form from `Yesod.Auth.Hardcoded`, making it compatible with the CSRF middleware [#1161](https://github.com/yesodweb/yesod/pull/1161)

--- a/yesod-auth/Yesod/Auth/Dummy.hs
+++ b/yesod-auth/Yesod/Auth/Dummy.hs
@@ -20,10 +20,13 @@ authDummy =
         lift $ setCredsRedirect $ Creds "dummy" ident []
     dispatch _ _ = notFound
     url = PluginR "dummy" []
-    login authToMaster =
+    login authToMaster = do
+        request <- getRequest
         toWidget [hamlet|
 $newline never
 <form method="post" action="@{authToMaster url}">
+    $maybe t <- reqToken request
+        <input type=hidden name=#{defaultCsrfParamName} value=#{t}>
     Your new identifier is: #
     <input type="text" name="ident">
     <input type="submit" value="Dummy Login">

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.4.13
+version:         1.4.13.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
Similar to #1159 which added CSRF support for Yesod.Auth.Hardcoded, this change applies it to Yesod.Auth.Dummy.