### PR TITLE
fixed: yesod-test: addToken_ forget to insert space to css query

### DIFF
--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -577,7 +577,7 @@ fileByLabel label path mime = do
 -- >   addToken_ "#formID"
 addToken_ :: Query -> RequestBuilder site ()
 addToken_ scope = do
-  matches <- htmlQuery' rbdResponse ["Tried to get CSRF token with addToken'"] $ scope <> "input[name=_token][type=hidden][value]"
+  matches <- htmlQuery' rbdResponse ["Tried to get CSRF token with addToken'"] $ scope <> " input[name=_token][type=hidden][value]"
   case matches of
     [] -> failure $ "No CSRF token found in the current page"
     element:[] -> addPostParam "_token" $ head $ attribute "value" $ parseHTML element


### PR DESCRIPTION
addToken_ example code is

~~~hs
  addToken_ "#formID"
~~~

But, `addToken_ "#formId"` creating css query `"#formIDinput[name=_token][type=hidden][value]"`.
I inserted space.