### PR TITLE
Fix addToken_ needing a trailing space to work.

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.5.1.1
+
+* Fix `addToken_` needing a trailing space and allows multiples spaces in css selector.
+	
 ## 1.5.1.0
 
 * Better error provenance for stuff invoking withResponse' [#1191](https://github.com/yesodweb/yesod/pull/1191)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -577,7 +577,7 @@ fileByLabel label path mime = do
 -- >   addToken_ "#formID"
 addToken_ :: Query -> RequestBuilder site ()
 addToken_ scope = do
-  matches <- htmlQuery' rbdResponse ["Tried to get CSRF token with addToken'"] $ scope <> "input[name=_token][type=hidden][value]"
+  matches <- htmlQuery' rbdResponse ["Tried to get CSRF token with addToken'"] $ scope <> " input[name=_token][type=hidden][value]"
   case matches of
     [] -> failure $ "No CSRF token found in the current page"
     element:[] -> addPostParam "_token" $ head $ attribute "value" $ parseHTML element

--- a/yesod-test/Yesod/Test/CssQuery.hs
+++ b/yesod-test/Yesod/Test/CssQuery.hs
@@ -51,7 +51,7 @@ parseQuery = parseOnly cssQuery
 
 -- Below this line is the Parsec parser for css queries.
 cssQuery :: Parser [[SelectorGroup]]
-cssQuery = many (char ' ') >> sepBy rules (char ',' >> optional (char ' '))
+cssQuery = many (char ' ') >> sepBy rules (char ',' >> many (char ' '))
 
 rules :: Parser [SelectorGroup]
 rules = many $ directChildren <|> deepChildren
@@ -102,4 +102,4 @@ pSquare :: Parser a -> Parser a
 pSquare p = char '[' *> p <* char ']'
 
 pOptionalTrailingSpace :: Parser a -> Parser a
-pOptionalTrailingSpace p = p <* optional (char ' ')
+pOptionalTrailingSpace p = p <* many (char ' ')

--- a/yesod-test/Yesod/Test/CssQuery.hs
+++ b/yesod-test/Yesod/Test/CssQuery.hs
@@ -51,14 +51,14 @@ parseQuery = parseOnly cssQuery
 
 -- Below this line is the Parsec parser for css queries.
 cssQuery :: Parser [[SelectorGroup]]
-cssQuery = sepBy rules (char ',' >> optional (char ' '))
+cssQuery = many (char ' ') >> sepBy rules (char ',' >> optional (char ' '))
 
 rules :: Parser [SelectorGroup]
 rules = many $ directChildren <|> deepChildren
 
 directChildren :: Parser SelectorGroup
 directChildren =
-    string "> " >> DirectChildren <$> pOptionalTrailingSpace parseSelectors
+    string "> " >> (many (char ' ')) >> DirectChildren <$> pOptionalTrailingSpace parseSelectors
 
 deepChildren :: Parser SelectorGroup
 deepChildren = pOptionalTrailingSpace $ DeepChildren <$> parseSelectors

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -140,7 +140,7 @@ main = hspec $ do
                 htmlAnyContain "p" "World"
                 htmlAnyContain "p" "Moon"
                 htmlNoneContain "p" "Sun"
-            yit "CSRF token" $ do
+            yit "finds the CSRF token by css selector" $ do
                 get ("/form" :: Text)
                 statusIs 200
 

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -140,6 +140,18 @@ main = hspec $ do
                 htmlAnyContain "p" "World"
                 htmlAnyContain "p" "Moon"
                 htmlNoneContain "p" "Sun"
+            yit "CSRF token" $ do
+                get ("/form" :: Text)
+                statusIs 200
+
+                request $ do
+                    setMethod "POST"
+                    setUrl ("/form" :: Text)
+                    byLabel "Some Label" "12345"
+                    fileByLabel "Some File" "test/main.hs" "text/plain"
+                    addToken_ "body"
+                statusIs 200
+                bodyEquals "12345"
 
         ydescribe "utf8 paths" $ do
             yit "from path" $ do

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.5.1.0
+version:            1.5.1.1
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
The fix can add spaces in place where none or only one where expected.
The css parser has been modified to remove trailing or multiple spaces.
This might be a bit more lax that official CSS spec.