### PR TITLE
Import DateCacheGetter from date-cache instead of wai-logger

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -16,5 +16,6 @@ packages:
 
 # Needed for LTS 2
 extra-deps:
+- date-cache-0.3.0
 - wai-app-static-3.1.4.1
 - yaml-0.8.17

--- a/yesod-core/Yesod/Core/Types.hs
+++ b/yesod-core/Yesod/Core/Types.hs
@@ -49,7 +49,7 @@ import qualified Network.Wai                        as W
 import qualified Network.Wai.Parse                  as NWP
 import           System.Log.FastLogger              (LogStr, LoggerSet, toLogStr, pushLogStr)
 import qualified System.Random.MWC                  as MWC
-import           Network.Wai.Logger                 (DateCacheGetter)
+import           System.Date.Cache                  (DateCacheGetter)
 import           Text.Blaze.Html                    (Html, toHtml)
 import           Text.Hamlet                        (HtmlUrl)
 import           Text.Julius                        (JavascriptUrl)

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -51,6 +51,7 @@ library
                    , aeson                 >= 0.5
                    , fast-logger           >= 2.2
                    , wai-logger            >= 0.2
+                   , date-cache
                    , monad-logger          >= 0.3.1    && < 0.4
                    , conduit               >= 1.2
                    , resourcet             >= 0.4.9    && < 1.2


### PR DESCRIPTION
`DateCacheGetter` was removed from latest wai-logger.

Fixes #1214