### PR TITLE
yesod-core needs bytestring >= 0.10

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -26,7 +26,7 @@ library
                    , time                  >= 1.1.4
                    , wai                   >= 3.0
                    , wai-extra             >= 3.0.7
-                   , bytestring            >= 0.9.1.4
+                   , bytestring            >= 0.10
                    , text                  >= 0.7
                    , template-haskell
                    , path-pieces           >= 0.1.2    && < 0.3


### PR DESCRIPTION
```
Yesod/Core/Handler.hs:544:28:
    Not in scope: `L.toStrict'
```

I added a revision to fix the GHC 7.4 build: https://hackage.haskell.org/package/yesod-core-1.4.20.2/revisions/
