### PR TITLE
Cleanup of yesod-core code

### DIFF
--- a/yesod-core/Yesod/Core.hs
+++ b/yesod-core/Yesod/Core.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -134,11 +133,10 @@ import Text.Blaze.Html (Html, toHtml, preEscapedToMarkup)
 import Control.Monad.Logger
 import Control.Monad.Trans.Class (MonadTrans (..))
 import Yesod.Core.Internal.Session
-import Yesod.Core.Internal.Run (yesodRunner)
+import Yesod.Core.Internal.Run (yesodRunner, yesodRender)
 import Yesod.Core.Class.Yesod
 import Yesod.Core.Class.Dispatch
 import Yesod.Core.Class.Breadcrumbs
-import Yesod.Core.Internal.Run (yesodRender)
 import qualified Yesod.Core.Internal.Run
 import qualified Paths_yesod_core
 import Data.Version (showVersion)

--- a/yesod-core/Yesod/Core/Class/Dispatch.hs
+++ b/yesod-core/Yesod/Core/Class/Dispatch.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts  #-}
@@ -25,10 +24,9 @@ class YesodSubDispatch sub m where
                      -> W.Application
 
 instance YesodSubDispatch WaiSubsite master where
-    yesodSubDispatch YesodSubRunnerEnv {..} req =
-        app req
+    yesodSubDispatch YesodSubRunnerEnv {..} = app
       where
-        WaiSubsite app = ysreGetSub $ yreSite $ ysreParentEnv
+        WaiSubsite app = ysreGetSub $ yreSite ysreParentEnv
 
 -- | A helper function for creating YesodSubDispatch instances, used by the
 -- internal generated code. This function has been exported since 1.4.11.

--- a/yesod-core/Yesod/Core/Content.hs
+++ b/yesod-core/Yesod/Core/Content.hs
@@ -53,8 +53,6 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import Data.Text.Lazy (Text, pack)
 import qualified Data.Text as T
-import Control.Monad (liftM)
-
 import Blaze.ByteString.Builder (Builder, fromByteString, fromLazyByteString)
 #if __GLASGOW_HASKELL__ < 710
 import Data.Monoid (mempty)
@@ -62,6 +60,7 @@ import Data.Monoid (mempty)
 import Text.Hamlet (Html)
 import Text.Blaze.Html.Renderer.Utf8 (renderHtmlBuilder)
 import Data.Conduit (Source, Flush (Chunk), ResumableSource, mapOutput)
+import Control.Monad (liftM)
 import Control.Monad.Trans.Resource (ResourceT)
 import Data.Conduit.Internal (ResumableSource (ResumableSource))
 import qualified Data.Conduit.Internal as CI

--- a/yesod-core/Yesod/Core/Dispatch.hs
+++ b/yesod-core/Yesod/Core/Dispatch.hs
@@ -85,7 +85,7 @@ toWaiAppPlain site = do
     sb <- makeSessionBackend site
     gen <- MWC.createSystemRandom
     getMaxExpires <- getGetMaxExpires
-    return $ toWaiAppYre $ YesodRunnerEnv
+    return $ toWaiAppYre YesodRunnerEnv
             { yreLogger = logger
             , yreSite = site
             , yreSessionBackend = sb
@@ -119,8 +119,8 @@ toWaiAppYre yre req =
         dest' =
             if S.null (W.rawQueryString env)
                 then dest
-                else (dest `mappend`
-                     Blaze.ByteString.Builder.fromByteString (W.rawQueryString env))
+                else dest `mappend`
+                     Blaze.ByteString.Builder.fromByteString (W.rawQueryString env)
 
 -- | Same as 'toWaiAppPlain', but provides a default set of middlewares. This
 -- set may change with future releases, but currently covers:
@@ -184,7 +184,7 @@ warp port site = do
                     $(qLocation >>= liftLoc)
                     "yesod-core"
                     LevelError
-                    (toLogStr $ "Exception from Warp: " ++ show e)) $
+                    (toLogStr $ "Exception from Warp: " ++ show e))
         Network.Wai.Handler.Warp.defaultSettings)
   where
     shouldLog' = Network.Wai.Handler.Warp.defaultShouldDisplayException
@@ -231,7 +231,7 @@ warpEnv :: YesodDispatch site => site -> IO ()
 warpEnv site = do
     env <- getEnvironment
     case lookup "PORT" env of
-        Nothing -> error $ "warpEnv: no PORT environment variable found"
+        Nothing -> error "warpEnv: no PORT environment variable found"
         Just portS ->
             case readMay portS of
                 Nothing -> error $ "warpEnv: invalid PORT environment variable: " ++ show portS

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -568,7 +568,7 @@ getMessages = do
   where
     enlist = pairup . S.split W8._nul
     pairup [] = []
-    pairup [x] = []
+    pairup [_] = []
     pairup (s:v:xs) = (decode s, preEscapedToHtml (decode v)) : pairup xs
     decode = decodeUtf8With lenientDecode
 

--- a/yesod-core/Yesod/Core/Internal/Session.hs
+++ b/yesod-core/Yesod/Core/Internal/Session.hs
@@ -61,7 +61,7 @@ clientSessionDateCacher validity = do
       , updateFreq   = 10000000 -- 10s
       }
 
-    return $! (getClientSessionDateCache, return ())
+    return (getClientSessionDateCache, return ())
   where
     getUpdated = do
       now <- getCurrentTime

--- a/yesod-core/Yesod/Core/Internal/Session.hs
+++ b/yesod-core/Yesod/Core/Internal/Session.hs
@@ -11,11 +11,9 @@ import qualified Web.ClientSession as CS
 import Data.Serialize
 import Data.Time
 import Data.ByteString (ByteString)
-import Control.Concurrent (forkIO, killThread, threadDelay)
-import Control.Monad (forever, guard)
+import Control.Monad (guard)
 import Yesod.Core.Types
 import Yesod.Core.Internal.Util
-import qualified Data.IORef as I
 import Control.AutoUpdate
 
 encodeClientSession :: CS.Key

--- a/yesod-core/Yesod/Core/Internal/Util.hs
+++ b/yesod-core/Yesod/Core/Internal/Util.hs
@@ -14,8 +14,6 @@ import qualified Data.Text      as T
 import           Data.Time      (Day (ModifiedJulianDay, toModifiedJulianDay),
                                  DiffTime, UTCTime (..), formatTime,
                                  getCurrentTime, addUTCTime)
-import           Control.Monad  (liftM)
-
 #if MIN_VERSION_time(1,5,0)
 import           Data.Time      (defaultTimeLocale)
 #else
@@ -58,4 +56,4 @@ formatRFC822 = T.pack . formatTime defaultTimeLocale "%a, %d %b %Y %H:%M:%S %z"
 date on a resource that never expires. See RFC 2616 section 14.21 for details.
 -}
 getCurrentMaxExpiresRFC1123 :: IO T.Text
-getCurrentMaxExpiresRFC1123 = liftM (formatRFC1123 . addUTCTime (60*60*24*365)) getCurrentTime
+getCurrentMaxExpiresRFC1123 = fmap (formatRFC1123 . addUTCTime (60*60*24*365)) getCurrentTime

--- a/yesod-core/Yesod/Routes/TH.hs
+++ b/yesod-core/Yesod/Routes/TH.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TemplateHaskell #-}
 module Yesod.Routes.TH
     ( module Yesod.Routes.TH.Types
       -- * Functions

--- a/yesod-core/Yesod/Routes/TH/RenderRoute.hs
+++ b/yesod-core/Yesod/Routes/TH/RenderRoute.hs
@@ -55,7 +55,7 @@ mkRouteCons rttypes =
       where
         con = NormalC (mkName name)
             $ map (\x -> (notStrict, x))
-            $ concat [singles, [ConT $ mkName name]]
+            $ singles ++ [ConT $ mkName name]
 
         singles = concatMap toSingle pieces
         toSingle Static{} = []
@@ -99,7 +99,7 @@ mkRenderRouteClauses =
         dyns <- replicateM cnt $ newName "dyn"
         sub <-
             case resourceDispatch res of
-                Subsite{} -> fmap return $ newName "sub"
+                Subsite{} -> return <$> newName "sub"
                 _ -> return []
         let pat = ConP (mkName $ resourceName res) $ map VarP $ dyns ++ sub
 
@@ -136,7 +136,7 @@ mkRenderRouteClauses =
     mkPieces _ _ [] _ = []
     mkPieces toText tsp (Static s:ps) dyns = toText s : mkPieces toText tsp ps dyns
     mkPieces toText tsp (Dynamic{}:ps) (d:dyns) = tsp `AppE` VarE d : mkPieces toText tsp ps dyns
-    mkPieces _ _ ((Dynamic _) : _) [] = error "mkPieces 120"
+    mkPieces _ _ (Dynamic _ : _) [] = error "mkPieces 120"
 
 -- | Generate the 'RenderRoute' instance.
 --

--- a/yesod-core/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/Yesod/Routes/TH/Types.hs
@@ -53,11 +53,11 @@ data Piece typ = Static String | Dynamic typ
     deriving Show
 
 instance Functor Piece where
-    fmap _ (Static s) = (Static s)
+    fmap _ (Static s)  = Static s
     fmap f (Dynamic t) = Dynamic (f t)
 
 instance Lift t => Lift (Piece t) where
-    lift (Static s) = [|Static $(lift s)|]
+    lift (Static s)  = [|Static  $(lift s)|]
     lift (Dynamic t) = [|Dynamic $(lift t)|]
 
 data Dispatch typ =

--- a/yesod-core/test/YesodCoreTest/Cache.hs
+++ b/yesod-core/test/YesodCoreTest/Cache.hs
@@ -13,8 +13,6 @@ import Yesod.Core
 import Data.IORef.Lifted
 import Data.Typeable (Typeable)
 import qualified Data.ByteString.Lazy.Char8 as L8
-import Data.Text (Text)
-import Data.Text.Encoding (encodeUtf8)
 
 data C = C
 

--- a/yesod-core/test/YesodCoreTest/ErrorHandling.hs
+++ b/yesod-core/test/YesodCoreTest/ErrorHandling.hs
@@ -9,11 +9,10 @@ import Yesod.Core
 import Test.Hspec
 import Network.Wai
 import Network.Wai.Test
-import Text.Hamlet (hamlet)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.ByteString.Char8 as S8
 import Control.Exception (SomeException, try)
-import Network.HTTP.Types (mkStatus)
+import Network.HTTP.Types (Status, mkStatus)
 import Blaze.ByteString.Builder (Builder, fromByteString, toLazyByteString)
 import Data.Monoid (mconcat)
 import Data.Text (Text, pack)
@@ -40,6 +39,7 @@ mkYesod "App" [parseRoutes|
 /good-builder GoodBuilderR GET
 |]
 
+overrideStatus :: Status
 overrideStatus = mkStatus 15 "OVERRIDE"
 
 instance Yesod App where

--- a/yesod-core/test/YesodCoreTest/InternalRequest.hs
+++ b/yesod-core/test/YesodCoreTest/InternalRequest.hs
@@ -2,10 +2,7 @@
 module YesodCoreTest.InternalRequest (internalRequestTest) where
 
 import Data.List (nub)
-import System.Random (StdGen, mkStdGen)
-
 import Network.Wai as W
-import Network.Wai.Test
 import Yesod.Core.Internal (randomString, parseWaiRequest)
 import Test.Hspec
 import Data.Monoid (mempty)

--- a/yesod-core/test/YesodCoreTest/Links.hs
+++ b/yesod-core/test/YesodCoreTest/Links.hs
@@ -6,7 +6,6 @@ module YesodCoreTest.Links (linksTest, Widget) where
 import Test.Hspec
 
 import Yesod.Core
-import Text.Hamlet
 import Network.Wai
 import Network.Wai.Test
 import Data.Text (Text)

--- a/yesod-core/test/YesodCoreTest/Media.hs
+++ b/yesod-core/test/YesodCoreTest/Media.hs
@@ -8,7 +8,6 @@ import Test.Hspec
 import Yesod.Core
 import Network.Wai
 import Network.Wai.Test
-import Text.Lucius
 import YesodCoreTest.MediaData
 
 mkYesodDispatch "Y" resourcesY

--- a/yesod-core/test/YesodCoreTest/NoOverloadedStringsSub.hs
+++ b/yesod-core/test/YesodCoreTest/NoOverloadedStringsSub.hs
@@ -8,7 +8,6 @@
 module YesodCoreTest.NoOverloadedStringsSub where
 
 import Yesod.Core
-import Network.Wai
 import Yesod.Core.Types
 
 data Subsite = Subsite (forall master. Yesod master => YesodSubRunnerEnv Subsite master (HandlerT master IO) -> Application)

--- a/yesod-core/test/YesodCoreTest/Widget.hs
+++ b/yesod-core/test/YesodCoreTest/Widget.hs
@@ -6,10 +6,6 @@ module YesodCoreTest.Widget (widgetTest) where
 import Test.Hspec
 
 import Yesod.Core
-import Text.Julius
-import Text.Lucius
-import Text.Hamlet
-
 import Network.Wai
 import Network.Wai.Test
 


### PR DESCRIPTION
I've silenced some compiler warnings and added +100 suggestions from `hlint`.

It consists entirely of trivial changes:
- remove redundant parenthesis
- remove redundant import
- fmap instead of liftM
- etc.

All test passing with GHC 8.0.1 and GHC 7.10.3. Not tested with earlier versions.