### PR TITLE
Document recommended usage of the CSRF middleware

### DIFF
--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -454,6 +454,18 @@ csrfSetCookieMiddleware handler cookie = setCsrfCookieWithCookie cookie >> handl
 --
 -- For details, see the "AJAX CSRF protection" section of "Yesod.Core.Handler".
 --
+-- You can add this chain this middleware together with other middleware like so:
+--
+-- @
+-- 'yesodMiddleware' = 'defaultYesodMiddleware' . 'defaultCsrfMiddleware'
+-- @
+--
+-- or:
+--
+-- @
+-- 'yesodMiddleware' app = 'defaultYesodMiddleware' $ 'defaultCsrfMiddleware' $ app
+-- @
+--
 -- Since 1.4.14
 defaultCsrfMiddleware :: Yesod site => HandlerT site IO res -> HandlerT site IO res
 defaultCsrfMiddleware = defaultCsrfSetCookieMiddleware . defaultCsrfCheckMiddleware


### PR DESCRIPTION
Closes #1246 

This PR isn't explicit about the CSRF middleware not providing the authorization checks—thoughts on if that's necessary? I mainly wanted to give out a code snippet that people could copy and paste in, and imply it's meant to be chained together with `defaultYesodMiddleware`.

I also think this PR will help significantly: https://github.com/yesodweb/yesod-scaffold/pull/127


![image](https://cloud.githubusercontent.com/assets/1274145/16844110/aaa730f4-4998-11e6-8f09-ec60c76bfeb2.png)
