### PR TITLE
urlParamRenderOverride method for Yesod class

### DIFF
--- a/yesod-core/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/Yesod/Core/Internal/Run.hs
@@ -376,7 +376,7 @@ yesodRender y ar url params =
     fromMaybe
         (joinPath y ar ps
           $ params ++ params')
-        (urlRenderOverride y url)
+        (urlParamRenderOverride y url params)
   where
     (ps, params') = renderRoute url
 

--- a/yesod-static/Yesod/EmbeddedStatic.hs
+++ b/yesod-static/Yesod/EmbeddedStatic.hs
@@ -33,7 +33,7 @@
 -- contains the created 'EmbeddedStatic'.
 --
 -- It is recommended that you serve static resources from a separate domain to save time
--- on transmitting cookies.  You can use 'urlRenderOverride' to do so, by redirecting
+-- on transmitting cookies.  You can use 'urlParamRenderOverride' to do so, by redirecting
 -- routes to this subsite to a different domain (but the same path) and then pointing the
 -- alternative domain to this server.  In addition, you might consider using a reverse
 -- proxy like varnish or squid to cache the static content, but the embedded content in

--- a/yesod-static/Yesod/Static.hs
+++ b/yesod-static/Yesod/Static.hs
@@ -19,7 +19,7 @@
 --
 -- In fact, in an ideal setup you'll serve your static files from
 -- a separate domain name to save time on transmitting
--- cookies. In that case, you may wish to use 'urlRenderOverride'
+-- cookies. In that case, you may wish to use 'urlParamRenderOverride'
 -- to redirect requests to this subsite to a separate domain
 -- name.
 --


### PR DESCRIPTION
This method replaces urlRenderOverride because the latter lacks support for query string.

While it is possible to keep API and just fix the yesodRender to add params to the result of urlRenderOverride, this solution would be incomplete in user control over query string and possibly ineffective in terms of performance. So I decided to add a new method, make that fix a default definition for it to keep thing backward compatible, and deprecate urlRenderOverride.

The fix is inside yesod-core but the patch also touches haddocks in yesod-static, replacing the name of method.