### PR TITLE
Don't keep partial autogen file when exception occurs

### DIFF
--- a/yesod/ChangeLog.md
+++ b/yesod/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.3.1
+
+*  Handle exceptions while writing a file in `addStaticContentExternal`
+
 ## 1.4.3
 
 * Switch to `Data.Yaml.Config`

--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -17,8 +17,9 @@ module Yesod.Default.Util
 import qualified Data.ByteString.Lazy as L
 import Data.Text (Text, pack, unpack)
 import Yesod.Core -- purposely using complete import so that Haddock will see addStaticContent
+import Control.Exception (onException)
 import Control.Monad (when, unless)
-import System.Directory (doesFileExist, createDirectoryIfMissing)
+import System.Directory (doesFileExist, createDirectoryIfMissing, removeFile)
 import Language.Haskell.TH.Syntax
 import Text.Lucius (luciusFile, luciusFileReload)
 import Text.Julius (juliusFile, juliusFileReload)
@@ -43,7 +44,7 @@ addStaticContentExternal
 addStaticContentExternal minify hash staticDir toRoute ext' _ content = do
     liftIO $ createDirectoryIfMissing True statictmp
     exists <- liftIO $ doesFileExist fn'
-    unless exists $ liftIO $ L.writeFile fn' content'
+    unless exists $ liftIO $ L.writeFile fn' content' `onException` remove fn'
     return $ Just $ Right (toRoute ["tmp", pack fn], [])
   where
     fn, statictmp, fn' :: FilePath
@@ -52,6 +53,7 @@ addStaticContentExternal minify hash staticDir toRoute ext' _ content = do
     fn = hash content ++ '.' : unpack ext'
     statictmp = staticDir ++ "/tmp/"
     fn' = statictmp ++ fn
+    remove f = doesFileExist f >>= \x -> when x $ removeFile f
 
     content' :: L.ByteString
     content'

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -1,5 +1,5 @@
 name:            yesod
-version:         1.4.3
+version:         1.4.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -40,7 +40,9 @@ library
                    , bytestring
                    , monad-logger
                    , fast-logger
-                   , conduit-extra
+                   , conduit
+                   , conduit-extra             >= 1.1.14
+                   , resourcet
                    , shakespeare
                    , streaming-commons
                    , wai-logger


### PR DESCRIPTION
The problem is this: an (async) exception occurring while an autogen file was being written resulted in an incomplete file being left behind.  When it was checked again - even after rebuilding the code - the hash matched and the partial content was served.  The solution is simply to delete the file on any exception.

#1291 had rather odd symptoms because of this, presumably because of something like a ctrl-C while minifying was taking a ridiculous time to complete.