### PR TITLE
Add default text/plain error formatting

### DIFF
--- a/yesod-core/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/Yesod/Core/Class/Yesod.hs
@@ -627,81 +627,102 @@ widgetToPageContent w = do
 
 -- | The default error handler for 'errorHandler'.
 defaultErrorHandler :: Yesod site => ErrorResponse -> HandlerT site IO TypedContent
-defaultErrorHandler NotFound = selectRep $ do
-    provideRep $ defaultLayout $ do
-        r <- waiRequest
-        let path' = TE.decodeUtf8With TEE.lenientDecode $ W.rawPathInfo r
-        setTitle "Not Found"
-        toWidget [hamlet|
-            <h1>Not Found
-            <p>#{path'}
-        |]
-    provideRep $ return $ object ["message" .= ("Not Found" :: Text)]
-
--- For API requests.
--- For a user with a browser,
--- if you specify an authRoute the user will be redirected there and
--- this page will not be shown.
-defaultErrorHandler NotAuthenticated = selectRep $ do
-    provideRep $ defaultLayout $ do
-        setTitle "Not logged in"
-        toWidget [hamlet|
-            <h1>Not logged in
-            <p style="display:none;">Set the authRoute and the user will be redirected there.
-        |]
-
-    provideRep $ do
-        -- 401 *MUST* include a WWW-Authenticate header
-        -- however, there is no standard to indicate a redirection
-        --
-        -- change this to Basic or Digest if you allow those forms of authentications
-        addHeader "WWW-Authenticate" "RedirectJSON realm=\"application\", param=\"authentication_url\""
-
-        -- The client will just use the authentication_url in the JSON
-        site <- getYesod
-        rend <- getUrlRender
-        let apair u = ["authentication_url" .= rend u]
-            content = maybe [] apair (authRoute site)
-        return $ object $ ("message" .= ("Not logged in"::Text)):content
-
-defaultErrorHandler (PermissionDenied msg) = selectRep $ do
-    provideRep $ defaultLayout $ do
-        setTitle "Permission Denied"
-        toWidget [hamlet|
-            <h1>Permission denied
-            <p>#{msg}
-        |]
-    provideRep $
-        return $ object ["message" .= ("Permission Denied. " <> msg)]
-
-defaultErrorHandler (InvalidArgs ia) = selectRep $ do
-    provideRep $ defaultLayout $ do
-        setTitle "Invalid Arguments"
-        toWidget [hamlet|
-            <h1>Invalid Arguments
-            <ul>
-                $forall msg <- ia
-                    <li>#{msg}
-        |]
-    provideRep $ return $ object ["message" .= ("Invalid Arguments" :: Text), "errors" .= ia]
-defaultErrorHandler (InternalError e) = do
-    $logErrorS "yesod-core" e
-    selectRep $ do
+defaultErrorHandler resp = case resp of
+    NotFound -> selectRep $ do
         provideRep $ defaultLayout $ do
-            setTitle "Internal Server Error"
+            r <- waiRequest
+            let path' = TE.decodeUtf8With TEE.lenientDecode $ W.rawPathInfo r
+            setTitle "Not Found"
             toWidget [hamlet|
-                <h1>Internal Server Error
-                <pre>#{e}
+                <h1>Not Found
+                <p>#{path'}
             |]
-        provideRep $ return $ object ["message" .= ("Internal Server Error" :: Text), "error" .= e]
-defaultErrorHandler (BadMethod m) = selectRep $ do
-    provideRep $ defaultLayout $ do
-        setTitle"Bad Method"
-        toWidget [hamlet|
-            <h1>Method Not Supported
-            <p>Method <code>#{S8.unpack m}</code> not supported
-        |]
-    provideRep $ return $ object ["message" .= ("Bad method" :: Text), "method" .= TE.decodeUtf8With TEE.lenientDecode m]
+        simpleErrors "Not Found"
+
+    -- For API requests.
+    -- For a user with a browser,
+    -- if you specify an authRoute the user will be redirected there and
+    -- this page will not be shown.
+    NotAuthenticated -> selectRep $ do
+        provideRep $ defaultLayout $ do
+            setTitle "Not logged in"
+            toWidget [hamlet|
+                <h1>Not logged in
+                <p style="display:none;">Set the authRoute and the user will be redirected there.
+            |]
+
+        provideRep $ do
+            authHeader
+            -- The client will just use the authentication_url in the JSON
+            site <- getYesod
+            rend <- getUrlRender
+            let apair u = ["authentication_url" .= rend u]
+                content = maybe [] apair (authRoute site)
+            return $ object $ ("message" .= errMsg):content
+        provideRep $
+            authHeader >> return errMsg
+        where
+            errMsg :: Text
+            errMsg = "Not logged in"
+            authHeader =
+                -- 401 *MUST* include a WWW-Authenticate header
+                -- however, there is no standard to indicate a redirection
+                --
+                -- change this to Basic or Digest if you allow those forms of authentications
+                addHeader
+                    "WWW-Authenticate"
+                    "RedirectJSON realm=\"application\", param=\"authentication_url\""
+
+    PermissionDenied msg -> selectRep $ do
+        provideRep $ defaultLayout $ do
+            setTitle "Permission Denied"
+            toWidget [hamlet|
+                <h1>Permission denied
+                <p>#{msg}
+            |]
+        simpleErrors $ "Permission Denied. " <> msg
+
+    InvalidArgs ia -> selectRep $ do
+        provideRep $ defaultLayout $ do
+            setTitle "Invalid Arguments"
+            toWidget [hamlet|
+                <h1>Invalid Arguments
+                <ul>
+                    $forall msg <- ia
+                        <li>#{msg}
+            |]
+        simpleErrorsWJson ["errors" .= ia] "Invalid Arguments"
+
+    InternalError e -> do
+        $logErrorS "yesod-core" e
+        selectRep $ do
+            provideRep $ defaultLayout $ do
+                setTitle "Internal Server Error"
+                toWidget [hamlet|
+                    <h1>Internal Server Error
+                    <pre>#{e}
+                |]
+            simpleErrorsWJson ["error" .= e] "Internal Server Error"
+
+    BadMethod m -> selectRep $ do
+        provideRep $ defaultLayout $ do
+            setTitle"Bad Method"
+            toWidget [hamlet|
+                <h1>Method Not Supported
+                <p>Method <code>#{S8.unpack m}</code> not supported
+            |]
+        simpleErrorsWJson
+          ["method" .= TE.decodeUtf8With TEE.lenientDecode m]
+          "Bad method"
+    where
+        -- Have to specify `msg` because of the dreaded monomorphism restriction
+        simpleErrors msg = simpleErrorsWJson [] msg
+        simpleErrorsWJson props errMsg = do
+            provideRep $
+              return $ object $ ["message" .= (errMsg :: Text)] <> props
+            provideRep $
+              return errMsg
+
 
 asyncHelper :: (url -> [x] -> Text)
          -> [Script url]


### PR DESCRIPTION
Closes #622

I refactored `defaultErrorHandler` to be a case statement so I could put the helper functions in a `where` block. If that's bad style or unnecessary change I can get rid of it. Also, I couldn't find any tests for error messages returning the correct `content-type`, so I'd rather ask about that here than try to write my own and end up reinventing the wheel (obviously if there really are no tests for that, I'll be happy to write them).