### PR TITLE
Add insert400 and insert400_

### DIFF
--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.1.0
+
+* add `insert400` and `insert400_`
+
 ## 1.4.0.6
 
 * persistent-2.6

--- a/yesod-persistent/Yesod/Persist/Core.hs
+++ b/yesod-persistent/Yesod/Persist/Core.hs
@@ -168,9 +168,17 @@ getBy404 key = do
 -- | Create a new record in the database, returning an automatically
 -- created key, or raise a 400 bad request if a uniqueness constraint
 -- is violated.
-insert400 :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend record backend)
-          => record
-          -> ReaderT backend m (Key record)
+--
+-- @since 1.4.1
+#if MIN_VERSION_persistent(2,5,0)
+insert400 :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend val backend)
+          => val
+          -> ReaderT backend m (Key val)
+#else
+insert400 :: (MonadIO m, PersistUniqueWrite (PersistEntityBackend val), PersistEntity val)
+          => val
+          -> ReaderT (PersistEntityBackend val) m (Key val)
+#endif
 insert400 datum = do
     conflict <- checkUnique datum
     case conflict of
@@ -179,9 +187,17 @@ insert400 datum = do
         Nothing -> insert datum
 
 -- | Same as 'insert400', but doesn’t return a key.
-insert400_ :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend record backend)
-           => record
+--
+-- @since 1.4.1
+#if MIN_VERSION_persistent(2,5,0)
+insert400_ :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend val backend)
+           => val
            -> ReaderT backend m ()
+#else
+insert400_ :: (MonadIO m, PersistUniqueWrite (PersistEntityBackend val), PersistEntity val)
+           => val
+           -> ReaderT (PersistEntityBackend val) m ()
+#endif
 insert400_ datum = insert400 datum >> return ()
 
 -- | Should be equivalent to @lift . notFound@, but there's an apparent bug in

--- a/yesod-persistent/Yesod/Persist/Core.hs
+++ b/yesod-persistent/Yesod/Persist/Core.hs
@@ -18,6 +18,8 @@ module Yesod.Persist.Core
     , YesodDB
     , get404
     , getBy404
+    , insert400
+    , insert400_
     ) where
 
 import Database.Persist
@@ -163,7 +165,30 @@ getBy404 key = do
         Nothing -> notFound'
         Just res -> return res
 
+-- | Create a new record in the database, returning an automatically
+-- created key, or raise a 400 bad request if a uniqueness constraint
+-- is violated.
+insert400 :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend record backend)
+          => record
+          -> ReaderT backend m (Key record)
+insert400 datum = do
+    conflict <- checkUnique datum
+    case conflict of
+        Just unique ->
+            badRequest' $ map (unHaskellName . fst) $ persistUniqueToFieldNames unique
+        Nothing -> insert datum
+
+-- | Same as 'insert400', but doesn’t return a key.
+insert400_ :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend record backend)
+           => record
+           -> ReaderT backend m ()
+insert400_ datum = insert400 datum >> return ()
+
 -- | Should be equivalent to @lift . notFound@, but there's an apparent bug in
 -- GHC 7.4.2 that leads to segfaults. This is a workaround.
 notFound' :: MonadIO m => m a
 notFound' = liftIO $ throwIO $ HCError NotFound
+
+-- | Constructed like 'notFound'', and for the same reasons.
+badRequest' :: MonadIO m => Texts -> m a
+badRequest' = liftIO . throwIO . HCError . InvalidArgs

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -1,5 +1,5 @@
 name:            yesod-persistent
-version:         1.4.0.6
+version:         1.4.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
In yesod-persistent, add insert companion functions similar to get404, which: 

  * work like insert and insert_ when on the golden path
  * in the case of a uniqueness constraint violation, shortcircuit the handler to return a 400 Bad Request specifying the columns in the violated constraint
