### PR TITLE
Change the type signature from Text to Verkey

### DIFF
--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -238,7 +238,7 @@ class ( YesodAuth site
     -- | Generate a random alphanumeric string.
     --
     -- @since 1.1.0
-    randomKey :: site -> IO Text
+    randomKey :: site -> IO VerKey
     randomKey _ = Nonce.nonce128urlT defaultNonceGen
 
     -- | Route to send user to after password has been set correctly.


### PR DESCRIPTION
Since the other type signatures of the typeclass has VerKey instead of
Text, it would be better to use VerKey here also to maintain
consistency. Also, IMO this signature is more easy to follow ( I had to
look at source to see how the verification key was generated. )