### PR TITLE
yesod-websockets: add `webSocketsOptions` `webSocketsOptionsWith`

### DIFF
--- a/yesod-websockets/ChangeLog.md
+++ b/yesod-websockets/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.2.5
+
+* Allow to start websockets with custom ConnectionOptions with `webSocketsOptions` and `webSocketsOptionsWith`
+
 ## 0.2.4.1
 
 * Support for websockets 0.10

--- a/yesod-websockets/yesod-websockets.cabal
+++ b/yesod-websockets/yesod-websockets.cabal
@@ -1,5 +1,5 @@
 name:                yesod-websockets
-version:             0.2.4.1
+version:             0.2.5
 synopsis:            WebSockets support for Yesod
 description:         WebSockets support for Yesod
 homepage:            https://github.com/yesodweb/yesod


### PR DESCRIPTION
A stab at https://github.com/yesodweb/yesod/issues/1337 
The rationale for this change is not immediately obvious. However, it allows using some underlying options of the low level `websockets` library (eg.: https://github.com/jaspervdj/websockets/pull/130 once is merged)