### PR TITLE
Allow for a  custom Email login widget

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -3,6 +3,7 @@
 * Add Show instance for user credentials `Creds`
 * Export pid type for identifying plugin
 * Fix warnings
+* Allow for a custom Email Login DOM with `emailLoginHandler`
 
 ## 1.4.16
 

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -298,7 +298,7 @@ class ( YesodAuth site
     -- Default: 'defaultEmailLoginHandler'.
     --
     -- @since: 1.2.6
-    emailLoginHandler :: YesodAuthEmail master => (Route Auth -> Route master) -> WidgetT master IO ()
+    emailLoginHandler :: (Route Auth -> Route site) -> WidgetT site IO ()
     emailLoginHandler = defaultEmailLoginHandler
 
 
@@ -534,7 +534,7 @@ defaultForgotPasswordHandler = do
   where
     forgotPasswordForm extra = do
         (emailRes, emailView) <- mreq emailField emailSettings Nothing
-    
+
         let forgotPasswordRes = ForgotPasswordForm <$> emailRes
         let widget = do
             [whamlet|

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -297,7 +297,7 @@ class ( YesodAuth site
     --
     -- Default: 'defaultEmailLoginHandler'.
     --
-    -- @since 1.4.11
+    -- @since 1.4.17
     emailLoginHandler :: (Route Auth -> Route site) -> WidgetT site IO ()
     emailLoginHandler = defaultEmailLoginHandler
 
@@ -360,7 +360,7 @@ getRegisterR = registerHandler
 
 -- | Default implementation of 'emailLoginHandler'.
 --
--- @since 1.2.6
+-- @since 1.4.17
 defaultEmailLoginHandler :: YesodAuthEmail master => (Route Auth -> Route master) -> WidgetT master IO ()
 defaultEmailLoginHandler toParent = do
         (widget, enctype) <- liftWidgetT $ generateFormPost loginForm

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -297,7 +297,7 @@ class ( YesodAuth site
     --
     -- Default: 'defaultEmailLoginHandler'.
     --
-    -- @since: 1.2.6
+    -- @since 1.4.11
     emailLoginHandler :: (Route Auth -> Route site) -> WidgetT site IO ()
     emailLoginHandler = defaultEmailLoginHandler
 

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -106,6 +106,7 @@ module Yesod.Auth.Email
     , loginLinkKey
     , setLoginLinkKey
      -- * Default handlers
+    , defaultEmailLoginHandler
     , defaultRegisterHandler
     , defaultForgotPasswordHandler
     , defaultSetPasswordHandler
@@ -290,6 +291,17 @@ class ( YesodAuth site
     normalizeEmailAddress :: site -> Text -> Text
     normalizeEmailAddress _ = TS.toLower
 
+    -- | Handler called to render the login page.
+    -- The default works fine, but you may want to override it in
+    -- order to have a different DOM.
+    --
+    -- Default: 'defaultEmailLoginHandler'.
+    --
+    -- @since: 1.2.6
+    emailLoginHandler :: YesodAuthEmail master => (Route Auth -> Route master) -> WidgetT master IO ()
+    emailLoginHandler = defaultEmailLoginHandler
+
+
     -- | Handler called to render the registration page.  The
     -- default works fine, but you may want to override it in
     -- order to have a different DOM.
@@ -346,8 +358,11 @@ authEmail =
 getRegisterR :: YesodAuthEmail master => HandlerT Auth (HandlerT master IO) Html
 getRegisterR = registerHandler
 
-emailLoginHandler :: YesodAuthEmail master => (Route Auth -> Route master) -> WidgetT master IO ()
-emailLoginHandler toParent = do
+-- | Default implementation of 'emailLoginHandler'.
+--
+-- @since 1.2.6
+defaultEmailLoginHandler :: YesodAuthEmail master => (Route Auth -> Route master) -> WidgetT master IO ()
+defaultEmailLoginHandler toParent = do
         (widget, enctype) <- liftWidgetT $ generateFormPost loginForm
 
         [whamlet|
@@ -402,6 +417,7 @@ emailLoginHandler toParent = do
         langs <- languages
         master <- getYesod
         return $ renderAuthMessage master langs msg
+
 -- | Default implementation of 'registerHandler'.
 --
 -- @since 1.2.6


### PR DESCRIPTION
I needed to have custom CSS for the Email login page, but the email login widget seems to be hard coded in yesod-auth-email and doesn't export the `defaut...Handler` function that register, forgot password and set password do (https://www.stackage.org/haddock/lts-7.19/yesod-auth-1.4.16/Yesod-Auth-Email.html#g:5).

So I added and exported a `defaultEmailLoginHandler`, that will allow the user to define a custom one, and thus change the login widget. **But** this is probably dumb as it isn't like the other functions: it doesn't produce a Handler, but a Widget and it takes the `toParent` function as argument.

Should only the names be adjusted to reflect what is actually going on (and the documentation as well) ? or is there a (sane) way to actually make it work as the other `default...Handler` functions?

Edit: This is related to this stackoverflow question: http://stackoverflow.com/questions/42015869/custom-widget-for-email-login-in-yesod?noredirect=1#comment71234149_42015869