### PR TITLE
Add assertNotEq

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.5.6
+
+* Add assertNotEq.
+[#1375](https://github.com/yesodweb/yesod/pull/1375)
+
 ## 1.5.5
 
 * Fix warnings

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -86,6 +86,7 @@ module Yesod.Test
 
     -- * Assertions
     , assertEqual
+    , assertNotEq
     , assertEqualNoShow
     , assertEq
 
@@ -334,6 +335,17 @@ assertEq m a b =
   where msg = "Assertion: " ++ m ++ "\n" ++
               "First argument:  " ++ ppShow a ++ "\n" ++
               "Second argument: " ++ ppShow b ++ "\n"
+
+-- | Asserts that the two given values are not equal.
+--
+-- In case they are equal, error mesasge includes the values.
+--
+-- @since 1.5.6
+assertNotEq :: (Eq a, Show a) => String -> a -> a -> YesodExample site ()
+assertNotEq m a b =
+  liftIO $ HUnit.assertBool msg (a /= b)
+  where msg = "Assertion: " ++ m ++ "\n" ++
+              "Both arguments:  " ++ ppShow a ++ "\n"
 
 {-# DEPRECATED assertEqual "Use assertEq instead" #-}
 assertEqual :: (Eq a) => String -> a -> a -> YesodExample site ()

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.5.5
+version:            1.5.6
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
Allow asserting values are _not_ equal, instead of doing something like `assertEq "Values are different" ("1" /= "2") True`