### PR TITLE
Fixing race condition in yesod-bin

### DIFF
--- a/yesod-bin/ChangeLog.md
+++ b/yesod-bin/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.5.2.3
+
+* Fix race condition which leads dev server to stay in compilation mode. [#1380](https://github.com/yesodweb/yesod/issues/1380)
+
 ## 1.5.2.2
 
 * I guess `--no-nix-pure` implies Nix... sigh [#1359](https://github.com/yesodweb/yesod/issues/1359)

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -13,7 +13,6 @@ import           Control.Concurrent                    (threadDelay)
 import           Control.Concurrent.Async              (race_)
 import           Control.Concurrent.STM
 import           Control.Concurrent.MVar
-import System.IO
 import qualified Control.Exception.Safe                as Ex
 import           Control.Monad                         (forever, unless, void,
                                                         when)

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -1,5 +1,5 @@
 name:            yesod-bin
-version:         1.7
+version:         1.5.2.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -18,10 +18,6 @@ extra-source-files:
   refreshing.html
   *.pem
 
-flag debug
-  default: False
-  description: Print debugging info.
-
 executable             yesod
     if os(windows)
         cpp-options:     -DWINDOWS

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -23,8 +23,6 @@ executable             yesod
         cpp-options:     -DWINDOWS
     if os(openbsd)
         ld-options:      -Wl,-zwxneeded
-    if flag(debug)
-      cpp-options: -DDEBUG
 
     build-depends:     base               >= 4.3          && < 5
                      , parsec             >= 2.1          && < 4

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -18,11 +18,17 @@ extra-source-files:
   refreshing.html
   *.pem
 
+flag debug
+  default: False
+  description: Print debugging info.
+
 executable             yesod
     if os(windows)
         cpp-options:     -DWINDOWS
     if os(openbsd)
         ld-options:      -Wl,-zwxneeded
+    if flag(debug)
+      cpp-options: -DDEBUG
 
     build-depends:     base               >= 4.3          && < 5
                      , parsec             >= 2.1          && < 4

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -1,5 +1,5 @@
 name:            yesod-bin
-version:         1.5.2.2
+version:         1.7
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -1,5 +1,5 @@
 name:            yesod
-version:         1.4.5
+version:         1.4.6
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -1,5 +1,5 @@
 name:            yesod
-version:         1.4.6
+version:         1.4.5
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Stack build process emits line even after successful build process
which leads to the overwriting of the appPortVar with -1. This leads
it to a compile mode again. Pressing Return Key and rebuilding it
again makes it go, but that's just a workaround I have to do every now
and then to solve the actual issue.

I'm using a `MVar` based locking solution for fixing the race
condition introduced.

I have been using this patch for around 3 to 4 days in our workplace and we haven't seen any surprising behavior so far.