### PR TITLE
Add support to for mapping static unfingerprinted files to their fingerprinted equivalents

### DIFF
--- a/yesod-static/ChangeLog.md
+++ b/yesod-static/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.5.3
+
+* Add `staticFilesMap` function
+* Add `staticFilesMergeMap` function
+
 ## 1.5.2
 
 * Fix test case for CRLF line endings

--- a/yesod-static/Yesod/Static.hs
+++ b/yesod-static/Yesod/Static.hs
@@ -276,8 +276,10 @@ staticFilesList dir fs =
 publicFiles :: FilePath -> Q [Dec]
 publicFiles dir = mkStaticFiles' dir False
 
--- | Similar to 'staticFilesList', but takes a manifest mapping
+-- | Similar to 'staticFilesList', but takes a mapping of
 -- unmunged names to fingerprinted file names.
+--
+-- @since 1.5.3
 staticFilesMap :: FilePath -> M.Map FilePath FilePath -> Q [Dec]
 staticFilesMap fp m = mkStaticFilesList' fp (map splitBoth mapList) True
   where
@@ -289,6 +291,11 @@ staticFilesMap fp m = mkStaticFilesList' fp (map splitBoth mapList) True
         let (a, b) = break (== '/') x
          in a : split (drop 1 b)
 
+-- | Similar to 'staticFilesMergeMap', but also generates identifiers
+-- for all files in the specified directory that don't have a
+-- fingerprinted version.
+--
+-- @since 1.5.3
 staticFilesMergeMap :: FilePath -> M.Map FilePath FilePath -> Q [Dec]
 staticFilesMergeMap fp m = do
   fs <- qRunIO $ getFileListPieces fp
@@ -305,6 +312,9 @@ staticFilesMergeMap fp m = do
     split x =
         let (a, b) = break (== '/') x
          in a : split (drop 1 b)
+    -- We want to keep mappings for all files that are pre-fingerprinted,
+    -- so this function checks against all of the existing fingerprinted files and
+    -- only inserts a new mapping if it's not a fingerprinted file.
     checkedInsert
       :: M.Map FilePath FilePath -- inverted dictionary
       -> M.Map FilePath FilePath -- accumulating state

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -1,5 +1,5 @@
 name:            yesod-static
-version:         1.5.2
+version:         1.5.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I am using tool that performs its own fingerprinting and minification on assets, and then outputs them with fingerprinted filenames. It gives me a JSON file that provides a map of the original names to the fingerprinted version:

``` json
{
  "assets": {
    "android-chrome-192x192.png": "android-chrome-192x192-2ddc9ac1570fa3f6957a411fc51e020c.png",
    "apple-touch-icon.png": "apple-touch-icon-3996d5d20ad160e500d50833089e5b8a.png",
    "assets/fe.css": "assets/fe-8b6d4eefc19bb4c381863bb450b25421.css",
    "assets/fe.js": "assets/fe-e87002425a34e309f953a1af6aef69a0.js",
    "assets/vendor.js": "assets/vendor-d14bd0cbc083d0ab6dd38383d6e5c21c.js",
    "browserconfig.xml": "browserconfig-80360e01e59c8d6214b948d20690c0eb.xml",
    "crossdomain.xml": "crossdomain-9dd26dbc8f3f9a8a342d067335315a63.xml",
    "js/vendor/whatinput.js": "js/vendor/whatinput-30ebdb8fcf403494921a58548eb7a838.js",
    "logo.svg": "logo-7bc4aefb158dc83a902382ad6e1eace0.svg",
    "text-logo.svg": "text-logo-75fc434190f5bc2dc34d06934a50e2ed.svg"
  },
  "prepend": ""
}
```

The fact that the tool performs its own fingerprinting means that the spliced identifier names are not stable, which makes using this tool essentially impossible with Yesod unless I give up compile-time safety. 

This PR adds a few functions to yesod-static that allow providing a map of the original `FilePath` to the fingerprinted `FilePath`, and the original `FilePath` is used to generate the Haskell identifier names. There's also a variant that generates declarations for all files not aliased in the provided dictionary called `staticFilesMergeMap`.

Potential follow-up work would be teaching yesod-static to do long-term caching of these pre-fingerprinted files without including an ETag query param, since pre-fingerprinting makes that redundant.

The current PR is a bit rough around the edges, but looking for feedback on the base idea before proceeding further.