### PR TITLE
fixed: yesod-form: textareaField: writeHtmlEscapedChar: convert "\r\n" to "<br>" closed #1354

### DIFF
--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.13
+
+* Fixed `textareaField` `writeHtmlEscapedChar` trim "\r"
+
 ## 1.4.12
 
 * Password field does not remember its previous value

--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -106,6 +106,10 @@ import Data.Attoparsec.Text (Parser, char, string, digit, skipSpace, endOfInput,
 
 import Yesod.Persist.Core
 
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
+
 defaultFormMessage :: FormMessage -> Text
 defaultFormMessage = englishFormMessage
 

--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -226,6 +226,7 @@ instance ToHtml Textarea where
         . unTextarea
       where
         -- Taken from blaze-builder and modified with newline handling.
+        writeHtmlEscapedChar '\r' = mempty
         writeHtmlEscapedChar '\n' = writeByteString "<br>"
         writeHtmlEscapedChar c    = B.writeHtmlEscapedChar c
 

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,5 +1,5 @@
 name:            yesod-form
-version:         1.4.12
+version:         1.4.13
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
fix #1354 .
I think solution to trim "\r".