### PR TITLE
Give FormResult an Alternative instance

### DIFF
--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.15
+
+* Added `Alternative` instance to `FormResult` to simplify handling pages with multiple forms.
+
 ## 1.4.14
 
 * Added `WForm` to reduce the verbosity using monadic forms.

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,5 +1,5 @@
 name:            yesod-form
-version:         1.4.14
+version:         1.4.15
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I've got a scenario where I have multiple forms on one page. Since only one will ever be submitted at a time it's convenient having an Alternative instance that surfaces errors first, and if there isn't an error, surfaces the first successful form result.