### PR TITLE
remove the `--fast` flag from `stack build` executed by `yesod devel`

### DIFF
--- a/yesod-bin/ChangeLog.md
+++ b/yesod-bin/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.5.2.6
+
+* Deleted --fast flag of stack build
+
 ## 1.5.2.5
 
 * Support for `add-handler` when modules are in `src/` directory [#1413](https://github.com/yesodweb/yesod/issues/1413)

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -334,7 +334,6 @@ devel opts passThroughArgs = do
                        $ setStderr createSource
                        $ setDelegateCtlc True $ proc "stack" $
                 [ "build"
-                , "--fast"
                 , "--file-watch"
 
                 -- Indicate the component we want

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -1,5 +1,5 @@
 name:            yesod-bin
-version:         1.5.2.5
+version:         1.5.2.6
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
It is a suggestion to remove the `--fast` flag from `stack build` executed by `yesod devel`.

I am writing an application with the function of uploading files to S3 with yesod.
The size corresponds to about 2GB.

The file is solved to `ByteString`.

Here, when optimization is disabled when building the yesod application, the application crashes using a lot of memory.
Problems will occur with files of about 100MB.

In other words, I went optimize when `yesod devel` but if `stack build --fast` is on,` stack exec -- yesod devel -e --ghc-options="-O2"` can not override `--fast` and optimization will not take effect.

In old yesod, invalidation of optimization at devel was written in cabal files of individual applications, so it was easy to change, but now I have no way to change.

So open the pull request to remove the `--fast` flag.

I think that it is better for the user to be able to select whether to optimize, as in the past.

At least, my application does not work on `yesod devel 'now and I am in trouble.

Please forgive me for reporting the problem now though it is a change 10 months ago.

thanks.