### PR TITLE
Extend `YesodAuthEmail` to support extensible password hashing

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.4.20
+
+* Extend `YesodAuthEmail` to support extensible password hashing via
+  `hashAndSaltPassword` and `verifyPassword` functions
+
 ## 1.4.19
 
 * Adjust English localization to distinguish between "log in" (verb) and "login" (noun)

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.4.19
+version:         1.4.20
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
## Commit Log

This change introduces `hashAndSaltPassword` and `verifyPassword` to the
`YesodAuthEmail` type class, allowing users to implement their own hashing
schemes (i.e. to provide compatibility with an existing database). It also
updates the default handlers to use these new functions when appropriate. The
functions have default implementation such that behavior for legacy applications
should not change.

## Notes

### Prior Art

The only other discussion about offering extensible password hashing was found in [this email list thread](https://groups.google.com/forum/#!topic/yesodweb/dqZDA18Qjy8). It didn't seem to come to a conclusion, though there have been others asking about this functionality.

### Regressions

There are currently no tests in the `yesod-auth` project so there was nothing to measure a regression against. I am, however, successful in using in a project I'm currently working on that requires integration with a legacy database.

### Steps to Reproduce (stack)

Clone this revision locally and add the `yesod/yesod-auth` folder to your `packages` list in your `stack.yaml`. Build your project using `YesodAuthEmail` and the behavior should be no different from v1.4.19.

Should you choose to implement an alternative password hashing, provide definitions for `hashAndSaltPassword` and `verifyPassword`.

### Miscellanea

Happy to rename or reformat any functions, I'm not married to anything here. 