### PR TITLE
extend docs of defaultMaybeAuthId

### DIFF
--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -243,7 +243,8 @@ credsKey = "_ID"
 -- | Retrieves user credentials from the session, if user is authenticated.
 --
 -- This function does /not/ confirm that the credentials are valid, see
--- 'maybeAuthIdRaw' for more information.
+-- 'maybeAuthIdRaw' for more information. Also does a database request
+-- to make sure that the account is still in the database and valid.
 --
 -- Since 1.1.2
 defaultMaybeAuthId

--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -243,8 +243,8 @@ credsKey = "_ID"
 -- | Retrieves user credentials from the session, if user is authenticated.
 --
 -- This function does /not/ confirm that the credentials are valid, see
--- 'maybeAuthIdRaw' for more information. Also does a database request
--- to make sure that the account is still in the database and valid.
+-- 'maybeAuthIdRaw' for more information. The first call in a request
+-- does a database request to make sure that the account is still in the database.
 --
 -- Since 1.1.2
 defaultMaybeAuthId


### PR DESCRIPTION
make more explicit that on each call a database access is done. This can be of relevance and sometimes redundant with other Handler functionality