### PR TITLE
Fix constraints on get404 and getBy404

### DIFF
--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.3
+
+* Fix overly powerful constraints on get404 and getBy404.
+
 ## 1.4.2
 
 * Fix warnings

--- a/yesod-persistent/Yesod/Persist/Core.hs
+++ b/yesod-persistent/Yesod/Persist/Core.hs
@@ -134,7 +134,7 @@ respondSourceDB ctype = respondSource ctype . runDBSource
 
 -- | Get the given entity by ID, or return a 404 not found if it doesn't exist.
 #if MIN_VERSION_persistent(2,5,0)
-get404 :: (MonadIO m, PersistStore backend, PersistRecordBackend val backend)
+get404 :: (MonadIO m, PersistStoreRead backend, PersistRecordBackend val backend)
        => Key val
        -> ReaderT backend m val
 #else
@@ -151,7 +151,7 @@ get404 key = do
 -- | Get the given entity by unique key, or return a 404 not found if it doesn't
 --   exist.
 #if MIN_VERSION_persistent(2,5,0)
-getBy404 :: (PersistUnique backend, PersistRecordBackend val backend, MonadIO m)
+getBy404 :: (PersistUniqueRead backend, PersistRecordBackend val backend, MonadIO m)
          => Unique val
          -> ReaderT backend m (Entity val)
 #else

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -1,5 +1,5 @@
 name:            yesod-persistent
-version:         1.4.2
+version:         1.4.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
The constraints on `get404` and `getBy404` were overly powerful. They were
constrained by `PersistStore` and `PersistStoreUnique`, which is an alias for
`PersistStoreWrite...`. These only need `PersistStoreRead...` to accomplish
their job.

This change should be backwards compatible.