### PR TITLE
Fix typo breaking some parsers

### DIFF
--- a/yesod-form/Yesod/Form/MassInput.hs
+++ b/yesod-form/Yesod/Form/MassInput.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE CPP#-}
+{-# LANGUAGE CPP #-}
 -- | A module providing a means of creating multiple input forms, such as a
 -- list of 0 or more recipients.
 module Yesod.Form.MassInput


### PR DESCRIPTION
This fixes a parsing error in Intellij-Haskell:

![image](https://user-images.githubusercontent.com/28052643/34299411-c015d8ac-e733-11e7-8425-b0ba230cd25d.png)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

