### PR TITLE
remove postLogoutR

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-* Avoid `redirectToPost` on logout
+* Avoid `redirectToPost` on logout [#1475](https://github.com/yesodweb/yesod/pull/1475)
 
 ## 1.4.21
 

--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,3 +1,7 @@
+## unreleased
+
+* Avoid `redirectToPost` on logout
+
 ## 1.4.21
 
 * Add redirectToCurrent to Yesod.Auth module for controlling setUltDestCurrent in redirectLogin [#1461](https://github.com/yesodweb/yesod/pull/1461)

--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -440,10 +440,9 @@ getLoginR :: AuthHandler master Html
 getLoginR = setUltDestReferer' >> loginHandler
 
 getLogoutR :: AuthHandler master ()
-getLogoutR = setUltDestReferer' >> redirectToPost LogoutR
-
-postLogoutR :: AuthHandler master ()
-postLogoutR = lift $ clearCreds True
+getLogoutR = do
+    setUltDestReferer'
+    lift $ clearCreds True
 
 handlePluginR :: Text -> [Text] -> AuthHandler master TypedContent
 handlePluginR plugin pieces = do

--- a/yesod-auth/Yesod/Auth/Routes.hs
+++ b/yesod-auth/Yesod/Auth/Routes.hs
@@ -16,6 +16,6 @@ data Auth = Auth
 mkYesodSubData "Auth" [parseRoutes|
 /check                 CheckR      GET
 /login                 LoginR      GET
-/logout                LogoutR     GET POST
+/logout                LogoutR     GET
 /page/#Text/*Texts     PluginR
 |]


### PR DESCRIPTION
A colleague was checking a yesod-based website and asked:
> What's the odd interstitial page with a "continue" button when I log out?

A good question! After peering at it for a while, I can't see any reason for the use of `redirectToPost` here, nor even the existence of `postLoginR`.

Checking the history of these lines, they date from the 2010 commit that introduced the `yesod-auth` package. So I suspect this was just fluff in the initial implementation, rather than anything to solve a real world problem.