### PR TITLE
[yesod] Fix comment for contentTypeTypes & simpler implementation

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.4.37.3
+
+* Fix Haddock comment & simplify implementation for `contentTypeTypes` [#1476](https://github.com/yesodweb/yesod/issues/1476)
+
 ## 1.4.37.2
 
 * Improve error messages for the CSRF checking functions [#1455](https://github.com/yesodweb/yesod/issues/1455)

--- a/yesod-core/Yesod/Core/Content.hs
+++ b/yesod-core/Yesod/Core/Content.hs
@@ -78,6 +78,7 @@ import Yesod.Core.Types
 import Text.Lucius (Css, renderCss)
 import Text.Julius (Javascript, unJavascript)
 import Data.Word8 (_semicolon, _slash)
+import Control.Arrow (second)
 
 -- | Zero-length enumerator.
 emptyContent :: Content
@@ -228,13 +229,13 @@ typeOctet = "application/octet-stream"
 simpleContentType :: ContentType -> ContentType
 simpleContentType = fst . B.break (== _semicolon)
 
--- Give just the media types as a pair.
+-- | Give just the media types as a pair.
+--
 -- For example, \"text/html; charset=utf-8\" returns ("text", "html")
 contentTypeTypes :: ContentType -> (B.ByteString, B.ByteString)
-contentTypeTypes ct = (main, fst $ B.break (== _semicolon) (tailEmpty sub))
+contentTypeTypes = second tailEmpty . B.break (== _slash) . simpleContentType
   where
     tailEmpty x = if B.null x then "" else B.tail x
-    (main, sub) = B.break (== _slash) ct
 
 instance HasContentType a => HasContentType (DontFullyEvaluate a) where
     getContentType = getContentType . liftM unDontFullyEvaluate

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.4.37.2
+version:         1.4.37.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
In the implementation of `contentTypeTypes` there is no need to repeat the logic from `simpleContentType` which is defined just above it.

----

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
