### PR TITLE
Update `mkYesodWith` and refactor so that `mkYesod` uses the context parser

### DIFF
--- a/yesod-core/Yesod/Core/Internal/TH.hs
+++ b/yesod-core/Yesod/Core/Internal/TH.hs
@@ -32,17 +32,23 @@ import Yesod.Core.Class.Dispatch
 import Yesod.Core.Internal.Run
 
 -- | Generates URL datatype and site function for the given 'Resource's. This
--- is used for creating sites, /not/ subsites. See 'mkYesodSub' for the latter.
+-- is used for creating sites, /not/ subsites. See 'mkYesodSubData' and 'mkYesodSubDispatch' for the latter.
 -- Use 'parseRoutes' to create the 'Resource's.
+--
+-- Contexts and type variables in the name of the datatype are parsed. 
+-- For example, a datatype @App a@ with typeclass constraint @MyClass a@ can be written as @\"(MyClass a) => App a\"@.
 mkYesod :: String -- ^ name of the argument datatype
         -> [ResourceTree String]
         -> Q [Dec]
 mkYesod name = fmap (uncurry (++)) . mkYesodWithParser name False return
 
-{-# DEPRECATED mkYesodWith "Contexts and type variables are now parsed from the name. (https://github.com/yesodweb/yesod/pull/1366)" #-}
-mkYesodWith :: [[String]]
-            -> String
-            -> [String]
+{-# DEPRECATED mkYesodWith "Contexts and type variables are now parsed from the name in `mkYesod`. <https://github.com/yesodweb/yesod/pull/1366>" #-}
+-- | Similar to 'mkYesod', except contexts and type variables are not parsed. 
+-- Instead, they are explicitly provided. 
+-- You can write @(MyClass a) => App a@ with @mkYesodWith [[\"MyClass\",\"a\"]] \"App\" [\"a\"] ...@.
+mkYesodWith :: [[String]] -- ^ list of contexts
+            -> String -- ^ name of the argument datatype
+            -> [String] -- ^ list of type variables
             -> [ResourceTree String]
             -> Q [Dec]
 mkYesodWith cxts name args = fmap (uncurry (++)) . mkYesodGeneral cxts name args False return

--- a/yesod-core/Yesod/Routes/TH/ParseRoute.hs
+++ b/yesod-core/Yesod/Routes/TH/ParseRoute.hs
@@ -3,7 +3,6 @@
 module Yesod.Routes.TH.ParseRoute
     ( -- ** ParseRoute
       mkParseRouteInstance
-    , mkParseRouteInstance'
     ) where
 
 import Yesod.Routes.TH.Types
@@ -12,11 +11,8 @@ import Data.Text (Text)
 import Yesod.Routes.Class
 import Yesod.Routes.TH.Dispatch
 
-mkParseRouteInstance :: Type -> [ResourceTree a] -> Q Dec
-mkParseRouteInstance = mkParseRouteInstance' []
-
-mkParseRouteInstance' :: Cxt -> Type -> [ResourceTree a] -> Q Dec
-mkParseRouteInstance' cxt typ ress = do
+mkParseRouteInstance :: Cxt -> Type -> [ResourceTree a] -> Q Dec
+mkParseRouteInstance cxt typ ress = do
     cls <- mkDispatchClause
         MkDispatchSettings
             { mdsRunHandler = [|\_ _ x _ -> x|]

--- a/yesod-core/Yesod/Routes/TH/RenderRoute.hs
+++ b/yesod-core/Yesod/Routes/TH/RenderRoute.hs
@@ -2,7 +2,6 @@
 module Yesod.Routes.TH.RenderRoute
     ( -- ** RenderRoute
       mkRenderRouteInstance
-    , mkRenderRouteInstance'
     , mkRouteCons
     , mkRenderRouteClauses
     ) where
@@ -148,14 +147,8 @@ mkRenderRouteClauses =
 -- This includes both the 'Route' associated type and the
 -- 'renderRoute' method.  This function uses both 'mkRouteCons' and
 -- 'mkRenderRouteClasses'.
-mkRenderRouteInstance :: Type -> [ResourceTree Type] -> Q [Dec]
-mkRenderRouteInstance = mkRenderRouteInstance' []
-
--- | A more general version of 'mkRenderRouteInstance' which takes an
--- additional context.
-
-mkRenderRouteInstance' :: Cxt -> Type -> [ResourceTree Type] -> Q [Dec]
-mkRenderRouteInstance' cxt typ ress = do
+mkRenderRouteInstance :: Cxt -> Type -> [ResourceTree Type] -> Q [Dec]
+mkRenderRouteInstance cxt typ ress = do
     cls <- mkRenderRouteClauses ress
     (cons, decs) <- mkRouteCons ress
 #if MIN_VERSION_template_haskell(2,12,0)

--- a/yesod-core/Yesod/Routes/TH/RouteAttrs.hs
+++ b/yesod-core/Yesod/Routes/TH/RouteAttrs.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE RecordWildCards #-}
 module Yesod.Routes.TH.RouteAttrs
     ( mkRouteAttrsInstance
-    , mkRouteAttrsInstance'
     ) where
 
 import Yesod.Routes.TH.Types
@@ -15,11 +14,8 @@ import Data.Text (pack)
 import Control.Applicative ((<$>))
 #endif
 
-mkRouteAttrsInstance :: Type -> [ResourceTree a] -> Q Dec
-mkRouteAttrsInstance = mkRouteAttrsInstance' []
-
-mkRouteAttrsInstance' :: Cxt -> Type -> [ResourceTree a] -> Q Dec
-mkRouteAttrsInstance' cxt typ ress = do
+mkRouteAttrsInstance :: Cxt -> Type -> [ResourceTree a] -> Q Dec
+mkRouteAttrsInstance cxt typ ress = do
     clauses <- mapM (goTree id) ress
     return $ instanceD cxt (ConT ''RouteAttrs `AppT` typ)
         [ FunD 'routeAttrs $ concat clauses

--- a/yesod-core/test/Hierarchy.hs
+++ b/yesod-core/test/Hierarchy.hs
@@ -113,9 +113,9 @@ do
 --  /#Int TrailingIntR GET
 |]
 
-    rrinst <- mkRenderRouteInstance (ConT ''Hierarchy) $ map (fmap parseType) resources
-    rainst <- mkRouteAttrsInstance (ConT ''Hierarchy) $ map (fmap parseType) resources
-    prinst <- mkParseRouteInstance (ConT ''Hierarchy) $ map (fmap parseType) resources
+    rrinst <- mkRenderRouteInstance [] (ConT ''Hierarchy) $ map (fmap parseType) resources
+    rainst <- mkRouteAttrsInstance [] (ConT ''Hierarchy) $ map (fmap parseType) resources
+    prinst <- mkParseRouteInstance [] (ConT ''Hierarchy) $ map (fmap parseType) resources
     dispatch <- mkDispatchClause MkDispatchSettings
         { mdsRunHandler = [|runHandler|]
         , mdsSubDispatcher = [|subDispatch|]

--- a/yesod-core/test/RouteSpec.hs
+++ b/yesod-core/test/RouteSpec.hs
@@ -80,9 +80,9 @@ do
             [ ResourceLeaf $ Resource "ChildR" [] (Methods Nothing ["GET"]) ["child"] True
             ]
         ress = resParent : resLeaves
-    rrinst <- mkRenderRouteInstance (ConT ''MyApp) ress
-    rainst <- mkRouteAttrsInstance (ConT ''MyApp) ress
-    prinst <- mkParseRouteInstance (ConT ''MyApp) ress
+    rrinst <- mkRenderRouteInstance [] (ConT ''MyApp) ress
+    rainst <- mkRouteAttrsInstance [] (ConT ''MyApp) ress
+    prinst <- mkParseRouteInstance [] (ConT ''MyApp) ress
     dispatch <- mkDispatchClause MkDispatchSettings
         { mdsRunHandler = [|runHandler|]
         , mdsSubDispatcher = [|subDispatch dispatcher|]


### PR DESCRIPTION
Since it looks like you're planning on introducing breaking changes, it seems like a good time for this. This PR is breaking since it updates the type of `mkYesodWith` to separate the list of contexts from the list of type arguments. This makes `mkYesodWith` more general since you can now have multiple arguments for contexts. For example:

```
data Foo a b = Foo a b

class Bar a b where
  ...

mkYesodWith [["Bar", "a", "b"]] "Foo" ["a", "b"] ...
```

This should generate something like:

```
instance Bar a b => YesodDispatch (Foo a b) where
    ...
```

I also updated `mkYesod` to use the context parser and deprecated `mkYesodWith` since you should be able to get the same functionality from `mkYesod` now. Let me know if you don't want to deprecate this. 

`mkYesodWith` was originally introduced in #1055. @Daniel-Diaz, does this look good to you? 

This should finish #1365.

After submitting your PR:

- [ ] Bumped the version number
- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)