### PR TITLE
 Remove MINIMAL pragma for authHttpManager 

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.2
+
+* Remove MINIMAL praggma for authHttpManager [#1489](https://github.com/yesodweb/yesod/issues/1489)
+
 ## 1.6.1
 
 * Relax a number of type signatures [#1488](https://github.com/yesodweb/yesod/issues/1488)

--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -243,7 +243,7 @@ class (Yesod master, PathPiece (AuthId master), RenderMessage master FormMessage
       man <- authHttpManager
       withRunInIO $ \run -> withResponse req man $ run . inner
 
-    {-# MINIMAL loginDest, logoutDest, (authenticate | getAuthId), authPlugins, authHttpManager #-}
+    {-# MINIMAL loginDest, logoutDest, (authenticate | getAuthId), authPlugins #-}
 
 {-# DEPRECATED getAuthId "Define 'authenticate' instead; 'getAuthId' will be removed in the next major version" #-}
 


### PR DESCRIPTION
Helps in preventing warnings like this:

```
serverside.hs:40:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘authHttpManager’
    • In the instance declaration for ‘YesodAuth App’
   |
40 | instance YesodAuth App where
   |          ^^^^^^^^^^^^^
```

Before submitting your PR, check that you've:

- [ ] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
