### PR TITLE
Derive Show instances for route data structures

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+* Derive a `Show` instance for `ResourceTree` and `FlatResource` [#1492](https://github.com/yesodweb/yesod/pull/1492)
+	* Some third party packages, like `yesod-routes-flow` derive their own `Show` instance, and this will break those packages.
+
 ## 1.6.1
 
 * Add a `Semigroup LiteApp` instance, and explicitly define `(<>)` in the

--- a/yesod-core/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/Yesod/Routes/TH/Types.hs
@@ -21,7 +21,7 @@ import Language.Haskell.TH.Syntax
 data ResourceTree typ
     = ResourceLeaf (Resource typ)
     | ResourceParent String CheckOverlap [Piece typ] [ResourceTree typ]
-    deriving Functor
+    deriving (Show, Functor)
 
 resourceTreePieces :: ResourceTree typ -> [Piece typ]
 resourceTreePieces (ResourceLeaf r) = resourcePieces r
@@ -90,7 +90,7 @@ data FlatResource a = FlatResource
     , frPieces :: [Piece a]
     , frDispatch :: Dispatch a
     , frCheck :: Bool
-    }
+    } deriving (Show)
 
 flatten :: [ResourceTree a] -> [FlatResource a]
 flatten =

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.1
+version:         1.6.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
* It's very helpful to have a Show instance for debugging and development
* Currently third party packages are deriving this instance themselves which is not ideal.
    * http://hackage.haskell.org/package/yesod-routes-flow-2.0/docs/src/Yesod-Routes-Flow-Generator.html
    * http://hackage.haskell.org/package/yesod-routes-typescript-0.3.0.0/docs/src/Yesod-Routes-Typescript-Generator.html
    * This change would break those packages, which isn't great
         * At least the typescript one is broken anyway

I haven't looked into this much, but if someone knows offhand, what is the use case for `Piece` and `Dispatch` being parametrized data types? It seems like they would most always be `String`?

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
