### PR TITLE
added: fileSourceByteString

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.4
+
+* Add `fileSourceByteString` [#1503](https://github.com/yesodweb/yesod/pull/1503)
+
 ## 1.6.3
 
 * Add missing export for `SubHandlerFor`

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -253,7 +253,8 @@ import           Data.CaseInsensitive (CI, original)
 import qualified Data.Conduit.List as CL
 import           Control.Monad.Trans.Resource  (MonadResource, InternalState, runResourceT, withInternalState, getInternalState, liftResourceT, resourceForkIO)
 import qualified System.PosixCompat.Files as PC
-import           Data.Conduit (ConduitT, connect, transPipe, Flush (Flush), yield, Void)
+import           Conduit ((.|), runConduit)
+import           Data.Conduit (ConduitT, transPipe, Flush (Flush), yield, Void)
 import qualified Yesod.Core.TypeCache as Cache
 import qualified Data.Word8 as W8
 import qualified Data.Foldable as Fold
@@ -1369,7 +1370,7 @@ fileSource = transPipe liftResourceT . fileSourceRaw
 --
 -- @since 1.6.4
 fileSourceByteString :: MonadResource m => FileInfo -> m S.ByteString
-fileSourceByteString fileInfo = fileSource fileInfo `connect` CL.foldMap id
+fileSourceByteString fileInfo = runConduit $ fileSource fileInfo .| CL.foldMap id
 
 -- | Provide a pure value for the response body.
 --

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -1362,8 +1362,9 @@ rawRequestBody = do
 fileSource :: MonadResource m => FileInfo -> ConduitT () S.ByteString m ()
 fileSource = transPipe liftResourceT . fileSourceRaw
 
--- | Strict `ByteString` body from `FileInfo`.
--- This function blocking while read file.
+-- | Extract a strict `ByteString` body from a `FileInfo`.
+--
+-- This function will block while reading the file.
 --
 -- > do
 -- >     fileByteString <- fileSourceByteString fileInfo

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -254,7 +254,7 @@ import           Data.CaseInsensitive (CI, original)
 import qualified Data.Conduit.List as CL
 import           Control.Monad.Trans.Resource  (MonadResource, InternalState, runResourceT, withInternalState, getInternalState, liftResourceT, resourceForkIO)
 import qualified System.PosixCompat.Files as PC
-import           Conduit ((.|), runConduit, foldC)
+import           Conduit ((.|), runConduit, sinkLazy)
 import           Data.Conduit (ConduitT, transPipe, Flush (Flush), yield, Void)
 import qualified Yesod.Core.TypeCache as Cache
 import qualified Data.Word8 as W8
@@ -1392,7 +1392,7 @@ fileSource = transPipe liftResourceT . fileSourceRaw
 --
 -- @since 1.6.5
 fileSourceByteString :: MonadResource m => FileInfo -> m S.ByteString
-fileSourceByteString fileInfo = runConduit $ fileSource fileInfo .| foldC
+fileSourceByteString fileInfo = runConduit (L.toStrict <$> (fileSource fileInfo .| sinkLazy))
 
 -- | Provide a pure value for the response body.
 --

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -253,7 +253,7 @@ import           Data.CaseInsensitive (CI, original)
 import qualified Data.Conduit.List as CL
 import           Control.Monad.Trans.Resource  (MonadResource, InternalState, runResourceT, withInternalState, getInternalState, liftResourceT, resourceForkIO)
 import qualified System.PosixCompat.Files as PC
-import           Conduit ((.|), runConduit)
+import           Conduit ((.|), runConduit, sinkLazy)
 import           Data.Conduit (ConduitT, transPipe, Flush (Flush), yield, Void)
 import qualified Yesod.Core.TypeCache as Cache
 import qualified Data.Word8 as W8
@@ -1371,7 +1371,7 @@ fileSource = transPipe liftResourceT . fileSourceRaw
 --
 -- @since 1.6.4
 fileSourceByteString :: MonadResource m => FileInfo -> m S.ByteString
-fileSourceByteString fileInfo = runConduit $ fileSource fileInfo .| CL.foldMap id
+fileSourceByteString fileInfo = L.toStrict <$> runConduit (fileSource fileInfo .| sinkLazy)
 
 -- | Provide a pure value for the response body.
 --

--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -254,7 +254,7 @@ import           Data.CaseInsensitive (CI, original)
 import qualified Data.Conduit.List as CL
 import           Control.Monad.Trans.Resource  (MonadResource, InternalState, runResourceT, withInternalState, getInternalState, liftResourceT, resourceForkIO)
 import qualified System.PosixCompat.Files as PC
-import           Conduit ((.|), runConduit, sinkLazy)
+import           Conduit ((.|), runConduit, foldC)
 import           Data.Conduit (ConduitT, transPipe, Flush (Flush), yield, Void)
 import qualified Yesod.Core.TypeCache as Cache
 import qualified Data.Word8 as W8
@@ -1392,7 +1392,7 @@ fileSource = transPipe liftResourceT . fileSourceRaw
 --
 -- @since 1.6.5
 fileSourceByteString :: MonadResource m => FileInfo -> m S.ByteString
-fileSourceByteString fileInfo = L.toStrict <$> runConduit (fileSource fileInfo .| sinkLazy)
+fileSourceByteString fileInfo = runConduit $ fileSource fileInfo .| foldC
 
 -- | Provide a pure value for the response body.
 --

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.3
+version:         1.6.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This function is to get `FileInfo` raw body.

Conduit type is hard for begginer user.
* [haskell - Persisting an uploaded file in the database (Couldn't match type ‘ConduitM () ByteString (ResourceT IO) ()’ with ‘HandlerT App IO ByteString’) - Stack Overflow](https://stackoverflow.com/questions/34969335/persisting-an-uploaded-file-in-the-database-couldnt-match-type-conduitm-by)
* [Processing an uploaded file with and embedding it in a template - Google グループ](https://groups.google.com/forum/?hl=ja#!searchin/yesodweb/fileSource|sort:date/yesodweb/zeC_ZzDeg6E/EkXVISTdhAIJ)

Actually I was not sure when I was a Haskell beginner.

ByteString raw body of `FileInfo` is need to upload file to S3.
This function running our product.
I send it to upstream.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
