### PR TITLE
added: addContentDispositionFileName

### DIFF
--- a/yesod-core/Yesod/Core/Handler.hs
+++ b/yesod-core/Yesod/Core/Handler.hs
@@ -118,6 +118,7 @@ module Yesod.Core.Handler
     , setHeader
     , replaceOrAddHeader
     , setLanguage
+    , addContentDispositionFileName
       -- ** Content caching and expiration
     , cacheSeconds
     , neverExpires
@@ -779,6 +780,14 @@ deleteCookie a = addHeaderInternal . DeleteCookie (encodeUtf8 a) . encodeUtf8
 -- next request.
 setLanguage :: MonadHandler m => Text -> m ()
 setLanguage = setSession langKey
+
+-- | Set attachment file name.
+--
+-- allow UTF-8 character.
+addContentDispositionFileName :: MonadHandler m => T.Text -> m ()
+addContentDispositionFileName name
+    = addHeader "Content-Disposition" $
+      "attachment; filename*=UTF-8''" `mappend` decodeUtf8 (H.urlEncode True (encodeUtf8 name))
 
 -- | Set an arbitrary response header.
 --


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

I pushed other pull request, I checkbox after complete other pull request.

This function is setting attchment file name.
Setting is hard that allow UTF-8 multibyte character.
This function running our product.
I want to push upstream.