### PR TITLE
updated: stack: resolver: lts-8.12 -> lts-11.5

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.12
+resolver: lts-11.5
 packages:
   - ./yesod-core
   - ./yesod-static
@@ -13,33 +13,3 @@ packages:
   - ./yesod
   - ./yesod-eventsource
   - ./yesod-websockets
-extra-deps:
-- unliftio-core-0.1.1.0
-- unliftio-0.2.4.0
-- authenticate-1.3.4
-- typed-process-0.2.1.0
-- conduit-1.3.0
-- conduit-extra-1.3.0
-- persistent-2.8.0
-- resourcet-1.2.0
-- mono-traversable-1.0.8.1
-- yaml-0.8.28
-- project-template-0.2.0.1
-- xml-conduit-1.8.0
-- wai-extra-3.0.22.0
-- monad-logger-0.3.28.1
-- html-conduit-1.3.0
-- http-conduit-2.3.0
-- persistent-sqlite-2.8.0
-- cookie-0.4.3
-- gauge-0.2.1
-- basement-0.0.6
-- foundation-0.0.19
-- memory-0.14.14
-- simple-sendfile-0.2.27
-- aeson-1.2.4.0
-- http-client-0.5.10
-- http-client-tls-0.3.5.2
-- websockets-0.12.3.1
-- th-abstraction-0.2.6.0
-- persistent-template-2.5.3.1


### PR DESCRIPTION
[th-lift-instances](https://github.com/bennofs/th-lift-instances) cause build error on appveyor on Windows.
This bug fixed [230839c](https://github.com/bennofs/th-lift-instances/commit/230839cb3460f30e61812f125e1ef9c3f26f9fc4).
This commit goal is to fix to appveyor build.