### PR TITLE
Move 'addClass' to Yesod.Form.Functions and add 'removeClass'

### DIFF
--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,3 +1,8 @@
+## 1.6.2
+
+* Move `addClass` from private/undocumented in `Yesod.Form.Bootstrap3` to `Yesod.Form.Functions`
+* Add `Yesod.Form.Functions.removeClass`
+
 ## 1.6.1
 
 * Explicitly define `(<>)` in the `Semigroup` instance for `Enctype`

--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,7 +1,7 @@
 ## 1.6.2
 
-* Move `addClass` from private/undocumented in `Yesod.Form.Bootstrap3` to `Yesod.Form.Functions`
-* Add `Yesod.Form.Functions.removeClass`
+* Move `addClass` from private/undocumented in `Yesod.Form.Bootstrap3` to `Yesod.Form.Functions` [#1510](https://github.com/yesodweb/yesod/pull/1510)
+* Add `Yesod.Form.Functions.removeClass` [#1510](https://github.com/yesodweb/yesod/pull/1510)
 
 ## 1.6.1
 

--- a/yesod-form/Yesod/Form/Bootstrap3.hs
+++ b/yesod-form/Yesod/Form/Bootstrap3.hs
@@ -33,9 +33,6 @@ import Control.Monad (liftM)
 import Data.Text (Text)
 import Data.String (IsString(..))
 import Yesod.Core
-
-import qualified Data.Text as T
-
 import Yesod.Form.Types
 import Yesod.Form.Functions
 
@@ -80,12 +77,6 @@ withLargeInput fs = fs { fsAttrs = newAttrs }
 withSmallInput :: FieldSettings site -> FieldSettings site
 withSmallInput fs = fs { fsAttrs = newAttrs }
     where newAttrs = addClass "input-sm" (fsAttrs fs)
-
-
-addClass :: Text -> [(Text, Text)] -> [(Text, Text)]
-addClass klass []                    = [("class", klass)]
-addClass klass (("class", old):rest) = ("class", T.concat [old, " ", klass]) : rest
-addClass klass (other         :rest) = other : addClass klass rest
 
 
 -- | How many bootstrap grid columns should be taken (see

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -623,9 +623,8 @@ convertField to from (Field fParse fView fEnctype) = let
 --
 -- ==== __Examples__
 --
--- > removeFormControl :: FieldSettings site -> FieldSettings site
--- > removeFormControl fs = fs { fsAttrs = newAttrs }
--- >   where newAttrs = removeClass "form-control" (fsAttrs fs)
+-- >>> removeClass "form-control" [("class","form-control login-form"),("id","home-login")]
+-- [("class","  login-form"),("id","home-login")]
 --
 -- @since 1.6.2
 removeClass :: Text -- ^ The class to remove
@@ -639,9 +638,8 @@ removeClass klass (other         :rest) = other : removeClass klass rest
 --
 -- ==== __Examples__
 --
--- > withLargeInput :: FieldSettings site -> FieldSettings site
--- > withLargeInput fs = fs { fsAttrs = newAttrs }
--- >    where newAttrs = addClass "input-lg" (fsAttrs fs)
+-- >>> addClass "login-form" [("class", "form-control"), ("id", "home-login")]
+-- [("class","form-control login-form"),("id","home-login")]
 --
 -- @since 1.6.2
 addClass :: Text -- ^ The class to add

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -621,6 +621,12 @@ convertField to from (Field fParse fView fEnctype) = let
 
 -- | Removes a CSS class from the 'fsAttrs' in a 'FieldSettings'.
 --
+-- ==== __Examples__
+--
+-- > removeFormControl :: FieldSettings site -> FieldSettings site
+-- > removeFormControl fs = fs { fsAttrs = newAttrs }
+-- >   where newAttrs = removeClass "form-control" (fsAttrs fs)
+--
 -- @since 1.6.2
 removeClass :: Text -- ^ The class to remove
             -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
@@ -630,6 +636,12 @@ removeClass klass (("class", old):rest) = ("class"::Text, T.replace klass " " ol
 removeClass klass (other         :rest) = other : removeClass klass rest
 
 -- | Adds a CSS class to the 'fsAttrs' in a 'FieldSettings'.
+--
+-- ==== __Examples__
+--
+-- > withLargeInput :: FieldSettings site -> FieldSettings site
+-- > withLargeInput fs = fs { fsAttrs = newAttrs }
+-- >    where newAttrs = addClass "input-lg" (fsAttrs fs)
 --
 -- @since 1.6.2
 addClass :: Text -- ^ The class to add

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -620,6 +620,8 @@ convertField to from (Field fParse fView fEnctype) = let
   in Field fParse' fView' fEnctype
 
 -- | Removes a CSS class from the 'fsAttrs' in a 'FieldSettings'.
+--
+-- @since 1.6.2
 removeClass :: Text -- ^ The class to remove
             -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
             -> [(Text, Text)]
@@ -628,6 +630,8 @@ removeClass klass (("class", old):rest) = ("class"::Text, T.replace klass " " ol
 removeClass klass (other         :rest) = other : removeClass klass rest
 
 -- | Adds a CSS class to the 'fsAttrs' in a 'FieldSettings'.
+--
+-- @since 1.6.2
 addClass :: Text -- ^ The class to add
          -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
          -> [(Text, Text)]

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -631,7 +631,7 @@ removeClass :: Text -- ^ The class to remove
             -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
             -> [(Text, Text)]
 removeClass _     []                    = []
-removeClass klass (("class", old):rest) = ("class"::Text, T.replace klass " " old) : rest
+removeClass klass (("class", old):rest) = ("class", T.replace klass " " old) : rest
 removeClass klass (other         :rest) = other : removeClass klass rest
 
 -- | Adds a CSS class to the 'fsAttrs' in a 'FieldSettings'.
@@ -645,6 +645,6 @@ removeClass klass (other         :rest) = other : removeClass klass rest
 addClass :: Text -- ^ The class to add
          -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
          -> [(Text, Text)]
-addClass klass []                    = [("class"::Text, klass)]
+addClass klass []                    = [("class", klass)]
 addClass klass (("class", old):rest) = ("class", T.concat [old, " ", klass]) : rest
 addClass klass (other         :rest) = other : addClass klass rest

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -51,10 +51,13 @@ module Yesod.Form.Functions
     , parseHelper
     , parseHelperGen
     , convertField
+    , addClass
+    , removeClass
     ) where
 
 import Yesod.Form.Types
 import Data.Text (Text, pack)
+import qualified Data.Text as T
 import Control.Arrow (second)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.RWS (ask, get, put, runRWST, tell, evalRWST, local, mapRWST)
@@ -615,3 +618,19 @@ convertField to from (Field fParse fView fEnctype) = let
   fParse' ts = fmap (fmap (fmap to)) . fParse ts
   fView' ti tn at ei = fView ti tn at (fmap from ei)
   in Field fParse' fView' fEnctype
+
+-- | Removes a CSS class from the 'fsAttrs' in a 'FieldSettings'.
+removeClass :: Text -- ^ The class to remove
+            -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
+            -> [(Text, Text)]
+removeClass _     []                    = []
+removeClass klass (("class", old):rest) = ("class"::Text, T.replace klass " " old) : rest
+removeClass klass (other         :rest) = other : removeClass klass rest
+
+-- | Adds a CSS class to the 'fsAttrs' in a 'FieldSettings'.
+addClass :: Text -- ^ The class to add
+         -> [(Text, Text)] -- ^ List of existing 'fsAttrs'
+         -> [(Text, Text)]
+addClass klass []                    = [("class"::Text, klass)]
+addClass klass (("class", old):rest) = ("class", T.concat [old, " ", klass]) : rest
+addClass klass (other         :rest) = other : addClass klass rest

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,5 +1,5 @@
 name:            yesod-form
-version:         1.6.1
+version:         1.6.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
'addClass' is more general than just Bootstrap forms. In particular, it is
copied into the yesod-form-bootstrap4 project and I found myself using it in my
custom forms. It would be useful to have it exported for use elsewhere.

I added 'removeClass' because I needed it while creating a custom 'readonly'
input in a form and thought it might be generally useful.

---

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
