### PR TITLE
Update yesod-auth and yesod-persistent to persistent-2.9

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.4
+
+* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
+
 ## 1.6.3
 
 * Generalize GoogleEmail2.getPerson [#1501](https://github.com/yesodweb/yesod/pull/1501)

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.6.3
+version:         1.6.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -43,7 +43,7 @@ library
                    , http-types
                    , memory
                    , nonce                   >= 1.0.2     && < 1.1
-                   , persistent              >= 2.8       && < 2.9
+                   , persistent              >= 2.8       && < 2.10
                    , random                  >= 1.0.0.2
                    , safe
                    , shakespeare

--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
+
 ## 1.6.0
 
 * Upgrade to yesod-core 1.6.0

--- a/yesod-persistent/Yesod/Persist/Core.hs
+++ b/yesod-persistent/Yesod/Persist/Core.hs
@@ -98,7 +98,11 @@ defaultGetDBRunner getPool = do
     (relKey, (conn, local)) <- allocate
         (do
             (conn, local) <- takeResource pool
+#if MIN_VERSION_persistent(2,9,0)
+            withPrep conn (\c f -> SQL.connBegin c f Nothing)
+#else
             withPrep conn SQL.connBegin
+#endif
             return (conn, local)
             )
         (\(conn, local) -> do

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -1,5 +1,5 @@
 name:            yesod-persistent
-version:         1.6.0
+version:         1.6.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -16,7 +16,7 @@ extra-source-files: README.md ChangeLog.md
 library
     build-depends:   base                      >= 4        && < 5
                    , yesod-core                >= 1.6      && < 1.7
-                   , persistent                >= 2.8      && < 2.9
+                   , persistent                >= 2.8      && < 2.10
                    , persistent-template       >= 2.1      && < 2.8
                    , transformers              >= 0.2.2
                    , blaze-builder


### PR DESCRIPTION
This is an accompanying PR to fix changes from https://github.com/yesodweb/persistent/pull/812

Could use advice on the following, not sure whether to bump the patch version or the minor version.
- [x] Bumped the version number