### PR TITLE
deleted: unneed cabal build-depends by weeder

### DIFF
--- a/yesod-auth-oauth/yesod-auth-oauth.cabal
+++ b/yesod-auth-oauth/yesod-auth-oauth.cabal
@@ -23,12 +23,11 @@ library
         build-depends:   base                >= 4         && < 4.3
     build-depends:   authenticate-oauth      >= 1.5       && < 1.7
                    , bytestring              >= 0.9.1.4
-                   , yesod-core              >= 1.6       && < 1.7
-                   , yesod-auth              >= 1.6       && < 1.7
                    , text                    >= 0.7
-                   , yesod-form              >= 1.6       && < 1.7
-                   , transformers            >= 0.2.2     && < 0.6
                    , unliftio
+                   , yesod-auth              >= 1.6       && < 1.7
+                   , yesod-core              >= 1.6       && < 1.7
+                   , yesod-form              >= 1.6       && < 1.7
     exposed-modules: Yesod.Auth.OAuth
     ghc-options:     -Wall
 

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -21,54 +21,46 @@ flag network-uri
 
 library
     build-depends:   base                    >= 4         && < 5
+                   , aeson                   >= 0.7
                    , authenticate            >= 1.3.4
-                   , bytestring              >= 0.9.1.4
-                   , yesod-core              >= 1.6       && < 1.7
-                   , wai                     >= 1.4
-                   , template-haskell
                    , base16-bytestring
-                   , cryptonite
-                   , memory
-                   , random                  >= 1.0.0.2
-                   , text                    >= 0.7
-                   , mime-mail               >= 0.3
-                   , yesod-persistent        >= 1.6
-                   , shakespeare
+                   , base64-bytestring
+                   , binary
+                   , blaze-builder
+                   , blaze-html              >= 0.5
+                   , blaze-markup            >= 0.5.1
+                   , bytestring              >= 0.9.1.4
+                   , conduit                 >= 1.3
+                   , conduit-extra
                    , containers
-                   , unordered-containers
-                   , yesod-form              >= 1.6       && < 1.7
-                   , transformers            >= 0.2.2
-                   , persistent              >= 2.8       && < 2.9
-                   , persistent-template     >= 2.1       && < 2.8
+                   , cryptonite
+                   , data-default
+                   , email-validate          >= 1.0
+                   , file-embed
                    , http-client             >= 0.5
                    , http-client-tls
                    , http-conduit            >= 2.1
-                   , aeson                   >= 0.7
-                   , unliftio
-                   , blaze-html              >= 0.5
-                   , blaze-markup            >= 0.5.1
                    , http-types
-                   , file-embed
-                   , email-validate          >= 1.0
-                   , data-default
-                   , resourcet
-                   , safe
-                   , time
-                   , base64-bytestring
-                   , byteable
-                   , binary
-                   , http-client
-                   , blaze-builder
-                   , conduit                 >= 1.3
-                   , conduit-extra
+                   , memory
                    , nonce                   >= 1.0.2     && < 1.1
-                   , unliftio-core
+                   , persistent              >= 2.8       && < 2.9
+                   , random                  >= 1.0.0.2
+                   , safe
+                   , shakespeare
+                   , template-haskell
+                   , text                    >= 0.7
+                   , time
+                   , transformers            >= 0.2.2
                    , unliftio
+                   , unliftio-core
+                   , unordered-containers
+                   , wai                     >= 1.4
+                   , yesod-core              >= 1.6       && < 1.7
+                   , yesod-form              >= 1.6       && < 1.7
+                   , yesod-persistent        >= 1.6
 
     if flag(network-uri)
       build-depends: network-uri >= 2.6
-    else
-      build-depends: network < 2.6
 
     exposed-modules: Yesod.Auth
                      Yesod.Auth.BrowserId

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -25,50 +25,41 @@ executable             yesod
         ld-options:      -Wl,-zwxneeded
 
     build-depends:     base               >= 4.3          && < 5
-                     , parsec             >= 2.1          && < 4
-                     , text               >= 0.11
-                     , shakespeare        >= 2.0
-                     , bytestring         >= 0.9.1.4
-                     , time               >= 1.1.4
-                     , template-haskell
-                     , directory          >= 1.2.1
                      , Cabal              >= 1.18
-                     , unix-compat        >= 0.2
-                     , containers         >= 0.2
-                     , attoparsec         >= 0.10
-                     , http-types         >= 0.7
-                     , blaze-builder      >= 0.2.1.4      && < 0.5
-                     , filepath           >= 1.1
-                     , process
-                     , zlib               >= 0.5
-                     , tar                >= 0.4          && < 0.6
-                     , unordered-containers
-                     , yaml               >= 0.8          && < 0.9
-                     , optparse-applicative >= 0.11
-                     , fsnotify           >= 0.0          && < 0.4
-                     , split              >= 0.2          && < 0.3
-                     , file-embed
+                     , bytestring         >= 0.9.1.4
                      , conduit            >= 1.3
                      , conduit-extra      >= 1.3
-                     , resourcet          >= 1.2
-                     , base64-bytestring
-                     , http-reverse-proxy >= 0.4
-                     , network            >= 2.5
-                     , http-client-tls
+                     , containers         >= 0.2
+                     , data-default-class
+                     , directory          >= 1.2.1
+                     , file-embed
+                     , filepath           >= 1.1
+                     , fsnotify           >= 0.0          && < 0.4
                      , http-client        >= 0.4.7
+                     , http-client-tls
+                     , http-reverse-proxy >= 0.4
+                     , http-types         >= 0.7
+                     , network            >= 2.5
+                     , optparse-applicative >= 0.11
+                     , process
                      , project-template   >= 0.1.1
-                     , unliftio
                      , say
+                     , split              >= 0.2          && < 0.3
                      , stm
+                     , streaming-commons
+                     , tar                >= 0.4          && < 0.6
+                     , text               >= 0.11
+                     , time               >= 1.1.4
                      , transformers
                      , transformers-compat
-                     , warp               >= 1.3.7.5
+                     , unliftio
+                     , unordered-containers
                      , wai                >= 2.0
                      , wai-extra
-                     , data-default-class
-                     , streaming-commons
+                     , warp               >= 1.3.7.5
                      , warp-tls           >= 3.0.1
-                     , unliftio
+                     , yaml               >= 0.8          && < 0.9
+                     , zlib               >= 0.5
 
     ghc-options:       -Wall -threaded -rtsopts
     main-is:           main.hs

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -22,48 +22,45 @@ extra-source-files:
 
 library
     build-depends:   base                  >= 4.9      && < 5
-                   , time                  >= 1.5
-                   , wai                   >= 3.0
-                   , wai-extra             >= 3.0.7
-                   , bytestring            >= 0.10.2
-                   , text                  >= 0.7
-                   , template-haskell
-                   , path-pieces           >= 0.1.2    && < 0.3
-                   , shakespeare           >= 2.0
-                   , transformers          >= 0.4
-                   , mtl
-                   , clientsession         >= 0.9.1    && < 0.10
-                   , random                >= 1.0.0.2  && < 1.2
-                   , cereal                >= 0.3
-                   , old-locale            >= 1.0.0.2  && < 1.1
-                   , containers            >= 0.2
-                   , unordered-containers  >= 0.2
-                   , cookie                >= 0.4.3    && < 0.5
-                   , http-types            >= 0.7
-                   , case-insensitive      >= 0.2
-                   , parsec                >= 2        && < 3.2
-                   , directory             >= 1
-                   , vector                >= 0.9      && < 0.13
                    , aeson                 >= 1.0
-                   , fast-logger           >= 2.2
-                   , wai-logger            >= 0.2
-                   , monad-logger          >= 0.3.10   && < 0.4
-                   , conduit               >= 1.3
-                   , resourcet             >= 1.2
+                   , auto-update
                    , blaze-html            >= 0.5
                    , blaze-markup          >= 0.7.1
-                   , safe
-                   , warp                  >= 3.0.2
-                   , unix-compat
+                   , byteable
+                   , bytestring            >= 0.10.2
+                   , case-insensitive      >= 0.2
+                   , cereal                >= 0.3
+                   , clientsession         >= 0.9.1    && < 0.10
+                   , conduit               >= 1.3
                    , conduit-extra
+                   , containers            >= 0.2
+                   , cookie                >= 0.4.3    && < 0.5
                    , deepseq               >= 1.3
                    , deepseq-generics
-                   , primitive
-                   , word8
-                   , auto-update
+                   , fast-logger           >= 2.2
+                   , http-types            >= 0.7
+                   , monad-logger          >= 0.3.10   && < 0.4
+                   , mtl
+                   , parsec                >= 2        && < 3.2
+                   , path-pieces           >= 0.1.2    && < 0.3
+                   , random                >= 1.0.0.2  && < 1.2
+                   , resourcet             >= 1.2
+                   , safe
                    , semigroups
-                   , byteable
+                   , shakespeare           >= 2.0
+                   , template-haskell
+                   , text                  >= 0.7
+                   , time                  >= 1.5
+                   , transformers          >= 0.4
+                   , unix-compat
                    , unliftio
+                   , unordered-containers  >= 0.2
+                   , vector                >= 0.9      && < 0.13
+                   , wai                   >= 3.0
+                   , wai-extra             >= 3.0.7
+                   , wai-logger            >= 0.2
+                   , warp                  >= 3.0.2
+                   , word8
 
     exposed-modules: Yesod.Core
                      Yesod.Core.Content
@@ -173,30 +170,28 @@ test-suite tests
                    YesodCoreTest.YesodTest
 
     cpp-options:   -DTEST
-    build-depends: base
-                  ,hspec >= 1.3
-                  ,hspec-expectations
-                  ,clientsession
-                  ,wai >= 3.0
-                  ,yesod-core
-                  ,bytestring
-                  ,text
-                  ,http-types
-                  , random
-                  ,HUnit
-                  ,QuickCheck >= 2 && < 3
-                  ,transformers
-                  , conduit
-                  , containers
-                  , resourcet
-                  , network
+    build-depends:  base
                   , async
+                  , bytestring
+                  , clientsession
+                  , conduit
                   , conduit-extra
+                  , containers
+                  , cookie >= 0.4.1    && < 0.5
+                  , hspec >= 1.3
+                  , hspec-expectations
+                  , http-types
+                  , network
+                  , random
+                  , resourcet
                   , shakespeare
                   , streaming-commons
-                  , wai-extra
-                  , cookie >= 0.4.1    && < 0.5
+                  , text
+                  , transformers
                   , unliftio
+                  , wai >= 3.0
+                  , wai-extra
+                  , yesod-core
     ghc-options:     -Wall
     extensions: TemplateHaskell
 
@@ -204,13 +199,11 @@ benchmark widgets
     type: exitcode-stdio-1.0
     hs-source-dirs: bench
     build-depends:  base
-                  , gauge
-                  , bytestring
-                  , text
-                  , transformers
-                  , yesod-core
                   , blaze-html
+                  , bytestring
+                  , gauge
                   , shakespeare
+                  , text
     main-is:        widget.hs
     ghc-options:    -Wall -O2
 

--- a/yesod-eventsource/yesod-eventsource.cabal
+++ b/yesod-eventsource/yesod-eventsource.cabal
@@ -15,13 +15,12 @@ extra-source-files: README.md ChangeLog.md
 
 library
     build-depends:   base                  >= 4        && < 5
-                   , yesod-core            == 1.6.*
-                   , conduit               >= 1.3
-                   , wai                   >= 1.3
-                   , wai-eventsource       >= 1.3
-                   , wai-extra
                    , blaze-builder
+                   , conduit               >= 1.3
                    , transformers
+                   , wai                   >= 1.3
+                   , wai-extra
+                   , yesod-core            == 1.6.*
     exposed-modules: Yesod.EventSource
     ghc-options:     -Wall
 

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -20,33 +20,30 @@ flag network-uri
 
 library
     build-depends:   base                  >= 4        && < 5
-                   , yesod-core            >= 1.6      && < 1.7
-                   , yesod-persistent      >= 1.6      && < 1.7
-                   , time                  >= 1.1.4
-                   , shakespeare           >= 2.0
-                   , persistent
-                   , template-haskell
-                   , transformers          >= 0.2.2
-                   , data-default
-                   , xss-sanitize          >= 0.3.0.1
+                   , aeson
+                   , attoparsec            >= 0.10
                    , blaze-builder         >= 0.2.1.4
-                   , email-validate        >= 1.0
-                   , bytestring            >= 0.9.1.4
-                   , text                  >= 0.9
-                   , wai                   >= 1.3
-                   , containers            >= 0.2
                    , blaze-html            >= 0.5
                    , blaze-markup          >= 0.5.1
-                   , attoparsec            >= 0.10
                    , byteable
-                   , aeson
+                   , bytestring            >= 0.9.1.4
+                   , containers            >= 0.2
+                   , data-default
+                   , email-validate        >= 1.0
+                   , persistent
                    , resourcet
                    , semigroups
+                   , shakespeare           >= 2.0
+                   , text                  >= 0.9
+                   , time                  >= 1.1.4
+                   , transformers          >= 0.2.2
+                   , wai                   >= 1.3
+                   , xss-sanitize          >= 0.3.0.1
+                   , yesod-core            >= 1.6      && < 1.7
+                   , yesod-persistent      >= 1.6      && < 1.7
 
     if flag(network-uri)
       build-depends: network-uri >= 2.6
-    else
-      build-depends: network < 2.6
 
     exposed-modules: Yesod.Form
                      Yesod.Form.Types

--- a/yesod-sitemap/yesod-sitemap.cabal
+++ b/yesod-sitemap/yesod-sitemap.cabal
@@ -15,14 +15,13 @@ extra-source-files: README.md ChangeLog.md
 
 library
     build-depends:   base                      >= 4        && < 5
-                   , yesod-core                >= 1.6      && < 1.7
+                   , conduit
+                   , data-default
+                   , text
                    , time                      >= 1.1.4
                    , xml-conduit               >= 1.0
-                   , text
-                   , containers
-                   , data-default
-                   , conduit
                    , xml-types
+                   , yesod-core                >= 1.6      && < 1.7
     exposed-modules: Yesod.Sitemap
     ghc-options:     -Wall
 

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -27,39 +27,34 @@ extra-source-files:
 
 library
     build-depends:   base                  >= 4        && < 5
-                   , containers            >= 0.2
-                   , old-time              >= 1.0
-                   , yesod-core            >= 1.6      && < 1.7
-                   , base64-bytestring     >= 0.1.0.1
-                   , byteable              >= 0.1
-                   , bytestring            >= 0.9.1.4
-                   , template-haskell
-                   , directory             >= 1.0
-                   , transformers          >= 0.2.2
-                   , wai-app-static        >= 3.1
-                   , wai                   >= 1.3
-                   , text                  >= 0.9
-                   , file-embed            >= 0.0.4.1  && < 0.5
-                   , http-types            >= 0.7
-                   , unix-compat           >= 0.2
-                   , conduit               >= 1.3
-                   , cryptonite-conduit    >= 0.1
-                   , cryptonite            >= 0.11
-                   , memory
-                   , data-default
-                   , mime-types            >= 0.1
-                   , hjsmin
-                   , filepath              >= 1.3
-                   , resourcet             >= 0.4
-                   , unordered-containers  >= 0.2
-                   , process
                    , async
-
                    , attoparsec            >= 0.10
+                   , base64-bytestring     >= 0.1.0.1
                    , blaze-builder         >= 0.3
+                   , bytestring            >= 0.9.1.4
+                   , conduit               >= 1.3
+                   , containers            >= 0.2
+                   , cryptonite            >= 0.11
+                   , cryptonite-conduit    >= 0.1
                    , css-text              >= 0.1.2
+                   , data-default
+                   , directory             >= 1.0
+                   , file-embed            >= 0.0.4.1  && < 0.5
+                   , filepath              >= 1.3
                    , hashable              >= 1.1
-                   , exceptions
+                   , hjsmin
+                   , http-types            >= 0.7
+                   , memory
+                   , mime-types            >= 0.1
+                   , process
+                   , template-haskell
+                   , text                  >= 0.9
+                   , transformers          >= 0.2.2
+                   , unix-compat           >= 0.2
+                   , unordered-containers  >= 0.2
+                   , wai                   >= 1.3
+                   , wai-app-static        >= 3.1
+                   , yesod-core            >= 1.6      && < 1.7
 
     exposed-modules: Yesod.Static
                      Yesod.EmbeddedStatic
@@ -96,34 +91,30 @@ test-suite tests
                    , HUnit
 
                    -- copy from above
-                   , containers
-                   , old-time
-                   , yesod-core
+                   , async
                    , base64-bytestring
                    , bytestring
-                   , byteable
-                   , template-haskell
-                   , directory
-                   , transformers
-                   , wai-app-static
-                   , wai
-                   , text
-                   , file-embed
-                   , http-types
-                   , unix-compat
                    , conduit
-                   , cryptonite-conduit
+                   , containers
                    , cryptonite
-                   , memory
+                   , cryptonite-conduit
                    , data-default
-                   , mime-types
-                   , hjsmin
+                   , directory
+                   , file-embed
                    , filepath
-                   , resourcet
-                   , unordered-containers
-                   , async
+                   , hjsmin
+                   , http-types
+                   , memory
+                   , mime-types
                    , process
-                   , exceptions
+                   , template-haskell
+                   , text
+                   , transformers
+                   , unix-compat
+                   , unordered-containers
+                   , wai
+                   , wai-app-static
+                   , yesod-core
 
     ghc-options:     -Wall -threaded
     extensions: TemplateHaskell

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -19,16 +19,15 @@ library
                    , base                      >= 4.3      && < 5
                    , blaze-builder
                    , blaze-html                >= 0.5
-                   , blaze-markup              >= 0.5.1
                    , bytestring                >= 0.9
                    , case-insensitive          >= 0.2
+                   , conduit
                    , containers
                    , cookie
                    , hspec-core                == 2.*
                    , html-conduit              >= 0.1
                    , http-types                >= 0.7
                    , network                   >= 2.2
-                   , persistent                >= 1.0
                    , pretty-show               >= 1.6
                    , semigroups
                    , text
@@ -39,7 +38,6 @@ library
                    , xml-conduit               >= 1.0
                    , xml-types                 >= 0.3
                    , yesod-core                >= 1.6
-                   , conduit
 
     exposed-modules: Yesod.Test
                      Yesod.Test.CssQuery

--- a/yesod-websockets/yesod-websockets.cabal
+++ b/yesod-websockets/yesod-websockets.cabal
@@ -15,17 +15,13 @@ extra-source-files:  README.md ChangeLog.md
 library
   exposed-modules:     Yesod.WebSockets
   build-depends:       base              >= 4.5 && < 5
-
-                     -- Just for CPP macro
-                     , wai
-
-                     , wai-websockets    >= 2.1
-                     , websockets        >= 0.10
-                     , transformers      >= 0.2
-                     , yesod-core        >= 1.6
-                     , unliftio
                      , conduit           >= 1.3
                      , mtl
+                     , transformers      >= 0.2
+                     , unliftio
+                     , wai-websockets    >= 2.1
+                     , websockets        >= 0.10
+                     , yesod-core        >= 1.6
 
 source-repository head
   type:     git

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -18,31 +18,27 @@ library
         cpp-options: -DWINDOWS
 
     build-depends:   base                      >= 4.6      && < 5
-                   , yesod-core                >= 1.6      && < 1.7
-                   , yesod-persistent          >= 1.6      && < 1.7
-                   , yesod-form                >= 1.6      && < 1.7
-                   , transformers              >= 0.2.2
-                   , wai                       >= 1.3
-                   , wai-extra                 >= 1.3
-                   , warp                      >= 1.3
-                   , blaze-html                >= 0.5
-                   , blaze-markup              >= 0.5.1
                    , aeson
-                   , data-default-class
-                   , unordered-containers
-                   , yaml                      >= 0.8.17
-                   , text
-                   , directory
-                   , template-haskell
                    , bytestring
-                   , monad-logger
-                   , fast-logger
                    , conduit                   >= 1.3
-                   , resourcet
+                   , data-default-class
+                   , directory
+                   , fast-logger
+                   , monad-logger
+                   , semigroups
                    , shakespeare
                    , streaming-commons
+                   , template-haskell
+                   , text
+                   , unordered-containers
+                   , wai                       >= 1.3
+                   , wai-extra                 >= 1.3
                    , wai-logger
-                   , semigroups
+                   , warp                      >= 1.3
+                   , yaml                      >= 0.8.17
+                   , yesod-core                >= 1.6      && < 1.7
+                   , yesod-form                >= 1.6      && < 1.7
+                   , yesod-persistent          >= 1.6      && < 1.7
 
     exposed-modules: Yesod
                    , Yesod.Default.Config


### PR DESCRIPTION
[weeder: Detect dead code](https://hackage.haskell.org/package/weeder)

deleted depends is

* mime-mail
* wai-eventsource

I sort build-depends, because duplicate depend some exist, to sort is detect to easy.

Do I need bump version number?

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
