### PR TITLE
cleaned: appveyor conf

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,19 +1,15 @@
+# cache:
+#   - '%AppData%\stack'
+
+install:
+  - curl -sS -ostack.zip -L https://get.haskellstack.org/stable/windows-i386.zip
+  - 7z x stack.zip stack.exe
+  - stack setup > nul
+
 build: off
 
-before_test:
-# http://help.appveyor.com/discussions/problems/6312-curl-command-not-found
-- set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
-
-- curl -sS -ostack.zip -L --insecure http://www.stackage.org/stack/windows-i386
-- 7z x stack.zip stack.exe
-
-clone_folder: "c:\\stack"
-environment:
-  global:
-    STACK_ROOT: "c:\\sr"
+build_script:
+  - stack --no-terminal test --no-run-tests
 
 test_script:
-- stack setup > nul
-# The ugly echo "" hack is to avoid complaints about 0 being an invalid file
-# descriptor
-- echo "" | stack --no-terminal test
+  - stack --jobs 1 --no-terminal test

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,5 +13,3 @@ packages:
 - ./yesod
 - ./yesod-eventsource
 - ./yesod-websockets
-extra-deps:
-- network-2.6.3.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,3 +13,5 @@ packages:
 - ./yesod
 - ./yesod-eventsource
 - ./yesod-websockets
+extra-deps:
+- network-2.6.3.3


### PR DESCRIPTION
* use network-2.6.3.3, network-2.6.3.4 include only fix to OpenBSD and **bug** and document
* appveyor.yml conf file to simple from offcial reference
* AppVeyor split build and test, So we can easy detect build or test error
* AppVeyor test job to single thread, So we can easy find bug of test

↓ I fix only CI, I think to do not need bump version.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
