### PR TITLE
AuthEmail: Fix forgot-password endpoint

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,5 +1,8 @@
 # ChangeLog for yesod-auth
 
+## 1.6.4.1
+* Email: Fix forgot-password endpoint [#1537](https://github.com/yesodweb/yesod/pull/1537)
+
 ## 1.6.4
 
 * Make `registerHelper` configurable [#1524](https://github.com/yesodweb/yesod/issues/1524)

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -516,10 +516,10 @@ parseRegister = withObject "email" (\obj -> do
 
 registerHelper :: YesodAuthEmail master
                => Bool -- ^ allow usernames?
-               -> Bool -- ^ allow password?
+               -> Bool -- ^ forgot password?
                -> Route Auth
                -> AuthHandler master TypedContent
-registerHelper allowUsername allowPassword dest = do
+registerHelper allowUsername forgotPassword dest = do
     y <- getYesod
     checkCsrfHeaderOrParam defaultCsrfHeaderName defaultCsrfParamName
     result <- runInputPostResult $ (,)
@@ -542,8 +542,8 @@ registerHelper allowUsername allowPassword dest = do
                               | allowUsername -> Right $ TS.strip x
                               | otherwise -> Left Msg.InvalidEmailAddress
 
-    let mpass = case (allowPassword, creds) of
-                    (True, Just (_, mp)) -> mp
+    let mpass = case (forgotPassword, creds) of
+                    (False, Just (_, mp)) -> mp
                     _ -> Nothing
 
     case eidentifier of
@@ -571,9 +571,10 @@ registerHelper allowUsername allowPassword dest = do
                 Nothing -> loginErrorMessageI dest (Msg.IdentifierNotFound identifier)
                 Just creds@(_, False, _, _) -> sendConfirmationEmail creds
                 Just creds@(_, True, _, _) -> do
-                  case emailPreviouslyRegisteredResponse identifier of
-                    Just response -> response
-                    Nothing -> sendConfirmationEmail creds
+                  if forgotPassword then sendConfirmationEmail creds
+                    else case emailPreviouslyRegisteredResponse identifier of
+                      Just response -> response
+                      Nothing -> sendConfirmationEmail creds
               where sendConfirmationEmail (lid, _, verKey, email) = do
                       render <- getUrlRender
                       tp <- getRouteToParent
@@ -583,7 +584,7 @@ registerHelper allowUsername allowPassword dest = do
 
 
 postRegisterR :: YesodAuthEmail master => AuthHandler master TypedContent
-postRegisterR = registerHelper False True registerR
+postRegisterR = registerHelper False False registerR
 
 getForgotPasswordR :: YesodAuthEmail master => AuthHandler master Html
 getForgotPasswordR = forgotPasswordHandler
@@ -627,7 +628,7 @@ defaultForgotPasswordHandler = do
         }
 
 postForgotPasswordR :: YesodAuthEmail master => AuthHandler master TypedContent
-postForgotPasswordR = registerHelper True False forgotPasswordR
+postForgotPasswordR = registerHelper True True forgotPasswordR
 
 getVerifyR :: YesodAuthEmail site
            => AuthEmailId site

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.6.4
+version:         1.6.4.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
Currently, defining `emailPreviouslyRegisteredResponse` will prevent `sendConfirmationEmail` from happening, even when `registerHelper` is called from `postForgotPasswordR`; which effectively disable the forgot password function.
Since this is just a quick fix for https://github.com/yesodweb/yesod/pull/1524, I don't think we need to bump version?