### PR TITLE
In the route syntax, allow trailing backslashes to indicate line continuation.

### DIFF
--- a/yesod-core/Yesod/Routes/Parse.hs
+++ b/yesod-core/Yesod/Routes/Parse.hs
@@ -285,7 +285,9 @@ dropBracket str@('{':x) = case break (== '}') x of
     _ -> error $ "Unclosed bracket ('{'): " ++ str
 dropBracket x = x
 
--- If this line ends with a backslash, concatenate it together with the next line.
+-- | If this line ends with a backslash, concatenate it together with the next line.
+--
+-- @since 1.6.8
 lineContinuations :: String -> [String] -> [String]
 lineContinuations this [] = [this]
 lineContinuations this below@(next:rest) = case unsnoc this of

--- a/yesod-core/Yesod/Routes/Parse.hs
+++ b/yesod-core/Yesod/Routes/Parse.hs
@@ -65,7 +65,7 @@ parseRoutesNoCheck = QuasiQuoter
 -- invalid input.
 resourcesFromString :: String -> [ResourceTree String]
 resourcesFromString =
-    fst . parse 0 . filter (not . all (== ' ')) . lines . filter (/= '\r')
+    fst . parse 0 . filter (not . all (== ' ')) . foldr lineContinuations [] . lines . filter (/= '\r')
   where
     parse _ [] = ([], [])
     parse indent (thisLine:otherLines)
@@ -285,3 +285,10 @@ dropBracket str@('{':x) = case break (== '}') x of
     _ -> error $ "Unclosed bracket ('{'): " ++ str
 dropBracket x = x
 
+-- If this line ends with a backslash, concatenate it together with the next line.
+lineContinuations :: String -> [String] -> [String]
+lineContinuations this [] = [this]
+lineContinuations this below@(next:rest) = case unsnoc this of
+    Just (this', '\\') -> (this'++next):rest
+    _ -> this:below
+  where unsnoc s = if null s then Nothing else Just (init s, last s)

--- a/yesod-core/test/RouteSpec.hs
+++ b/yesod-core/test/RouteSpec.hs
@@ -17,7 +17,7 @@ import Test.HUnit ((@?=))
 import Data.Text (Text, pack, unpack, singleton)
 import Yesod.Routes.Class hiding (Route)
 import qualified Yesod.Routes.Class as YRC
-import Yesod.Routes.Parse (parseRoutesNoCheck, parseTypeTree, TypeTree (..))
+import Yesod.Routes.Parse (parseRoutesFile, parseRoutesNoCheck, parseTypeTree, TypeTree (..))
 import Yesod.Routes.Overlap (findOverlapNames)
 import Yesod.Routes.TH hiding (Dispatch)
 import Language.Haskell.TH.Syntax
@@ -219,10 +219,16 @@ main = hspec $ do
         it "routes to subparam" $ disp "PUT" ["subparam", "6", "q"]
             @?= (pack "subparam 6 q", Just $ SubparamR 6 $ ParamRoute 'q')
 
-    describe "parsing" $ do
+    describe "route parsing" $ do
         it "subsites work" $ do
             parseRoute ([pack "subsite", pack "foo"], [(pack "bar", pack "baz")]) @?=
                 Just (SubsiteR $ MySubRoute ([pack "foo"], [(pack "bar", pack "baz")]))
+
+    describe "routing table parsing" $ do
+        it "recognizes trailing backslashes as line continuation directives" $ do
+            let routes :: [ResourceTree String]
+                routes = $(parseRoutesFile "test/fixtures/routes_with_line_continuations")
+            length routes @?= 3
 
     describe "overlap checking" $ do
         it "catches overlapping statics" $ do

--- a/yesod-core/test/fixtures/routes_with_line_continuations
+++ b/yesod-core/test/fixtures/routes_with_line_continuations
@@ -1,0 +1,11 @@
+-- This fixture to test line continuations is in a separate file
+-- because when I put it in an in-line quasi-quotation, the compiler
+-- performed the line continuations processing itself.
+
+/foo1 \
+    Foo1
+/foo2 Foo2
+/foo3 \
+    Foo3 \
+    GET POST \
+    !foo

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.7
+version:         1.6.8
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Just as a convenience to those of us who have type identifiers in our routes that are very long and bound to the database schema. 

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
