### PR TITLE
Relax constraint, allow persistent-2.9.*

### DIFF
--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -16,7 +16,7 @@ extra-source-files: README.md ChangeLog.md
 library
     build-depends:   base                      >= 4        && < 5
                    , yesod-core                >= 1.6      && < 1.7
-                   , persistent                >= 2.8      && < 2.9
+                   , persistent                >= 2.8      && < 2.10
                    , persistent-template       >= 2.1      && < 2.8
                    , transformers              >= 0.2.2
                    , blaze-builder


### PR DESCRIPTION
In anticipation of a new release of `persistent`. See: https://github.com/yesodweb/persistent/blob/04d1c5169e6174fcfd8836c64739168c9e975d68/persistent/persistent.cabal#L2

```
Before submitting your PR, check that you've:
- [ ] Bumped the version number
```

I have not bumped the version number, as this change can be published as a revision, and the actual "code change" can be uploaded later.