### PR TITLE
Update persistent, make buildable with ghc 8.6

### DIFF
--- a/yesod-auth-oauth/ChangeLog.md
+++ b/yesod-auth-oauth/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.0.1
+
+* Compile with GHC 8.6
+
 ## 1.6.0
 
 * Upgrade to yesod-core 1.6.0

--- a/yesod-auth-oauth/ChangeLog.md
+++ b/yesod-auth-oauth/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 1.6.0.1
 
-* Compile with GHC 8.6
+* Compile with GHC 8.6 [#1561](https://github.com/yesodweb/yesod/pull/1561)
 
 ## 1.6.0
 

--- a/yesod-auth-oauth/Yesod/Auth/OAuth.hs
+++ b/yesod-auth-oauth/Yesod/Auth/OAuth.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable, OverloadedStrings, QuasiQuotes #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -69,7 +70,9 @@ authOAuth oauth mkCreds = AuthPlugin name dispatch login
         setSession oauthSessionName $ lookupTokenSecret tok
         redirect $ authorizeUrl oauth' tok
     dispatch "GET" [] = do
-      Just tokSec <- lookupSession oauthSessionName
+      tokSec <- lookupSession oauthSessionName >>= \case
+        Just t -> return t
+        Nothing -> liftIO $ fail "lookupSession could not find session"
       deleteSession oauthSessionName
       reqTok <-
         if oauthVersion oauth == OAuth10

--- a/yesod-auth-oauth/yesod-auth-oauth.cabal
+++ b/yesod-auth-oauth/yesod-auth-oauth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth-oauth
-version:         1.6.0
+version:         1.6.0.1
 license:         BSD3
 license-file:    LICENSE
 author:          Hiromi Ishii

--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.6.4.2
 
-* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
+* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516), [#1561](https://github.com/yesodweb/yesod/pull/1561)
 
 ## 1.6.4.1
 

--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,6 +1,11 @@
 # ChangeLog for yesod-auth
 
+## 1.6.4.2
+
+* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
+
 ## 1.6.4.1
+
 * Email: Fix forgot-password endpoint [#1537](https://github.com/yesodweb/yesod/pull/1537)
 
 ## 1.6.4

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.6.4.1
+version:         1.6.4.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin
@@ -43,7 +43,7 @@ library
                    , http-types
                    , memory
                    , nonce                   >= 1.0.2     && < 1.1
-                   , persistent              >= 2.8       && < 2.9
+                   , persistent              >= 2.8       && < 2.10
                    , random                  >= 1.0.0.2
                    , safe
                    , shakespeare

--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,4 +1,4 @@
-## 1.6.1
+## 1.6.0.1
 
 * Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
 

--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 1.6.0.1
 
-* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
+* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516), [#1561](https://github.com/yesodweb/yesod/pull/1561)
 
 ## 1.6.0
 

--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.1
+
+* Add support for persistent 2.9 [#1516](https://github.com/yesodweb/yesod/pull/1516)
+
 ## 1.6.0
 
 * Upgrade to yesod-core 1.6.0

--- a/yesod-persistent/Yesod/Persist/Core.hs
+++ b/yesod-persistent/Yesod/Persist/Core.hs
@@ -98,7 +98,11 @@ defaultGetDBRunner getPool = do
     (relKey, (conn, local)) <- allocate
         (do
             (conn, local) <- takeResource pool
+#if MIN_VERSION_persistent(2,9,0)
+            withPrep conn (\c f -> SQL.connBegin c f Nothing)
+#else
             withPrep conn SQL.connBegin
+#endif
             return (conn, local)
             )
         (\(conn, local) -> do

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -1,5 +1,5 @@
 name:            yesod-persistent
-version:         1.6.0
+version:         1.6.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -16,7 +16,7 @@ extra-source-files: README.md ChangeLog.md
 library
     build-depends:   base                      >= 4        && < 5
                    , yesod-core                >= 1.6      && < 1.7
-                   , persistent                >= 2.8      && < 2.9
+                   , persistent                >= 2.8      && < 2.10
                    , persistent-template       >= 2.1      && < 2.8
                    , transformers              >= 0.2.2
                    , blaze-builder

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -1,5 +1,5 @@
 name:            yesod-persistent
-version:         1.6.1
+version:         1.6.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod-static/ChangeLog.md
+++ b/yesod-static/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.0.1
+
+* Make test suite build with GHC 8.6 [#1561](https://github.com/yesodweb/yesod/pull/1561)
+
 ## 1.6.0
 
 * Upgrade to yesod-core 1.6.0

--- a/yesod-static/test/EmbedProductionTest.hs
+++ b/yesod-static/test/EmbedProductionTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE TemplateHaskell, QuasiQuotes, TypeFamilies, OverloadedStrings #-}
+{-# LANGUAGE LambdaCase #-}
 module EmbedProductionTest where
 
 -- Tests the production mode of the embedded static subsite by
@@ -108,7 +109,9 @@ embedProductionSpecs = yesodSpec (MyApp eProduction) $ do
         yit "Embedded Javascript" $ do
             get HomeR
             statusIs 200
-            [script] <- htmlQuery "script"
+            script <- htmlQuery "script" >>= \case
+                [s] -> return s
+                _ -> liftIO $ fail "Expected singleton list of script"
             let src = BL.takeWhile (/= 34) $ BL.drop 1 $ BL.dropWhile (/= 34) script -- 34 is "
 
             get $ TL.toStrict $ TL.decodeUtf8 src

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -1,5 +1,5 @@
 name:            yesod-static
-version:         1.6.0
+version:         1.6.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.5.1
+
+* Make test suite build with GHC 8.6 [#1561](https://github.com/yesodweb/yesod/pull/1561)
+
 ## 1.6.5
 bodyEquals prints out actual body in addition to expected body in failure msg
 [#1525](https://github.com/yesodweb/yesod/pull/1525)

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -482,8 +483,10 @@ postHomeR = defaultLayout
 
 postResourcesR :: Handler ()
 postResourcesR = do
-  ([("foo", t)], _) <- runRequestBody
-  sendResponseCreated $ ResourceR t
+    t <- runRequestBody >>= \case
+        ([("foo", t)], _) -> return t
+        _ -> liftIO $ fail "postResourcesR pattern match failure"
+    sendResponseCreated $ ResourceR t
 
 getResourceR :: Text -> Handler Html
 getResourceR i = defaultLayout

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.5
+version:            1.6.5.1
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
## Changes

* Addressed merge conflicts with https://github.com/yesodweb/yesod/pull/1516.
  * This PR adds CPP to make the code compatible with persistent-2.9 (still unreleased).
* Make all packages in the repo buildable with ghc 8.6.
  * This involved addressing a few issues with MonadFail. (See [the GHC 8.6 migration guide]( https://ghc.haskell.org/trac/ghc/wiki/Migration/8.6#MonadFailDesugaringbydefault).)
    This was accomplished by making pattern match failures explicitly call `liftIO $ fail "$msg"`, instead of the formerly implicit call to `fail` on irrefutable pattern matches. Further improvements may be desired, but I believe this change at least preserves (and makes more explicit) the pre-existing behavior.

## Tests

I have successfully built & run tests on these changes using the current `stack.yaml` as follows:

```bash
$ stack build --test --bench --no-run-benchmarks --fast
```

I have additionally built & run tests using the following `stack.yaml` which uses ghc 8.6 as well as persistent-2.9.2 (& others in that repo) from source, (as well as a small tweak on the constraints on `email-validate`) like so:

```bash
$ stack build --test --bench --no-run-benchmarks --fast --stack-yaml stack-nightly.yaml
```

```yaml
# stack-nightly.yaml
resolver: nightly-2018-10-11
packages:
- ./yesod-core
- ./yesod-static
- ./yesod-persistent
- ./yesod-newsfeed
- ./yesod-form
- ./yesod-auth
- ./yesod-auth-oauth
- ./yesod-sitemap
- ./yesod-test
- ./yesod-bin
- ./yesod
- ./yesod-eventsource
- ./yesod-websockets
extra-deps:
# on hackage
- byteable-0.1.1@sha256:12eeda93251d4b5d510ac95cf578f5c89d4a399b14ca73116deaf4921a516fdf
- clientsession-0.9.1.2@sha256:8a1a9099e9289103020af45079b5cfeb3c1b33c6d0fb7bd5a1d8abf985f69574
- authenticate-1.3.4@sha256:0a017e0bd0292366b1a6c15f0d8aa4929c031197c0289eae478ed22725b4e30a
- authenticate-oauth-1.6@sha256:ba9e93e7b949fa4799ae7b3cb302df38dc7fb0be0460803b6c48636317b2bcbb
- cipher-aes-0.2.11@sha256:3f887a53efb0df216d44e954108fd660a7548e6f109bba1f158cc2c792810f8b
- cprng-aes-0.6.1@sha256:5f16cee07ffc501078a81bf4e3061e74656c00fa4f7714a0495fc2539734a737
- crypto-random-0.0.9@sha256:3fc8e0bf4e07591ce08bf4bf40b69100b8bcce786f3253130f46af0b61c4161d
- cryptonite-conduit-0.2.2@sha256:bfbae677a44f3a5cf3bf7f36271682979a402825f3d1e8767cfd62f2ddb702c2
- http-client-tls-0.3.5.3@sha256:25d3b7c42198d0e1d193c0bb323b9a0071d56aacb41960ff448eb663055e15bf
- http-conduit-2.3.2@sha256:0f505ab01bdf659831568839ff1f644c498e9993fb20517aaeb9e031327ad93c
- http-reverse-proxy-0.6.0@sha256:df4ff669d7b33a0587c5e38299424d4c44812e0618df75e8b65f6eafc8dac6cb
- project-template-0.2.0.1@sha256:d47377695425b048f1670fcf9d64c165901cff68402993aec3b22c8ee4a64a38
- skein-1.0.9.4@sha256:863e3b7293f062e2f62c8e7c4c4e95200dbd3662f3bd641d7e250e91544ba2fc
- wai-app-static-3.1.6.2@sha256:4625dcfcde450b4b6c009387ab0468ea8404ae5b2bb88d318ccd4d39bc752be7
- wai-websockets-3.0.1.2@sha256:0e713ddb8c28d47be76cefeab3a73b6876477d648ddcd873ba6b15d08691aa7f
- warp-tls-3.2.4.3@sha256:f7dca8b38d9bdddb3713efbca4389eacb7bd98011d04aace2374a1fbe48c887a
- RSA-2.3.0@sha256:e2f8bc09c869bcd78a02974c40d1b1a5792f866b71e7ad18edde027e124acc4f
- connection-0.2.8@sha256:80671b805383147d41bc099a2b591442da5659d075b17f528c4729a39c99d6d8
- crypto-cipher-types-0.0.9@sha256:db4b94bd674d5d81caa41e1154396ae09c4de916a85163c8cd7892bc80c4c0cf
- crypto-pubkey-types-0.4.3@sha256:9bcf9ec7045f1043edac2b8331d9120bc055083578dbd953a3cccfc7452d9e8c
- html-conduit-1.3.1@sha256:fff57b4befad09ef398ecf9af47c9d1e534ea4c21f604b519f05dba1ee071e5f
- securemem-0.1.10@sha256:1e69f378f2837c502ebe02760c136e67e84dfe6052b7ecf694ccbe66c16a86d2
- tls-1.4.1@sha256:10087515f118d29938c3442b1255c10e0c866efa3639b3813dfb9755a8f89d86
- tls-session-manager-0.0.0.2@sha256:e3d3f8a026196df46746a19d3d7d31211b2fca3aefed9074e951b2dcc1b8833c
- asn1-encoding-0.9.5@sha256:7d4acf178ef17aad650f2073dd2ed94febb1e468fddb0d5ca65c1a54caffcfb8
- asn1-types-0.3.2@sha256:2fc0d64079e9ac9ec7f349aa65c1775acb060f19601deee129a9769fdcf8f07a
- x509-1.7.4@sha256:dfc5cc9617dc084c5560dff230644da009e1a63dd71bc954f5c8a210e4ff3f5d
- x509-store-1.6.6@sha256:5503bf2d77f5d7349e92b3961cbfab9cdbb48a310a4ac74b22069c3b6c18f4d8
- x509-system-1.6.6@sha256:3a1b9cc26715d7cb3cd1a3f8b6153f12c2d42187ac5df305c3973c78a061db05
- x509-validation-1.6.10@sha256:1c50be76040e7a02b1cf6ca8a2806aa159a47c29c1be212fc161c01736ba4ac7
- pem-0.2.4@sha256:cc8e62118b783e284dc0fa032f54fe386a3861a948ec88079370a433c103a705
- asn1-parse-0.9.4@sha256:748249e23024dde8fed1d99e85e7e952576ce51b3ce460b9d131b2e91ff9c5a4
# from source
- git: https://github.com/yesodweb/persistent
  commit: 04d1c5169e6174fcfd8836c64739168c9e975d68
  subdirs:
  - persistent
  - persistent-template
  - persistent-sqlite
- git: https://github.com/DanBurton/email-validate-hs
  commit: 1c2ffb4c8a7dc35403d7a3458ace3998c1bbda3c
```

## Checklists

Before submitting your PR, check that you've:

- [x] Bumped the version number
- ~~[ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~~
- ~~[ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs~~

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
