### PR TITLE
Fix typo in deprecation message

### DIFF
--- a/yesod-auth-oauth/Yesod/Auth/OAuth.hs
+++ b/yesod-auth-oauth/Yesod/Auth/OAuth.hs
@@ -130,7 +130,7 @@ authTwitter :: YesodAuth m
             -> ByteString -- ^ Consumer Secret
             -> AuthPlugin m
 authTwitter key secret = authTwitter' key secret "screen_name"
-{-# DEPRECATED authTwitter "Use authTwitterUsingUserID instead" #-}
+{-# DEPRECATED authTwitter "Use authTwitterUsingUserId instead" #-}
 
 -- | Twitter plugin which uses Twitter's /user_id/ as ID.
 --


### PR DESCRIPTION
The message recommended using `authTwitterUsingUserID` (note that the `ID` at the end of the method name is all capitalized).

However, the actual method name is `authTwitterUsingUserId` (note the `Id` at the end).

-------------

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
