### PR TITLE
Documentation fix

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.6.1
+
+* Documentation fixes
+
 ## 1.6.6
 
 * Add utility functions to modify cookies [$1570](https://github.com/yesodweb/yesod/pull/1570)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -212,7 +212,7 @@ type Cookies = M.Map ByteString Cookie.SetCookie
 -- Since 1.2.0
 type YesodSpec site = Writer [YesodSpecTree site] ()
 
--- | Internal data structure, corresponding to hspec\'s 'YesodSpecTree'.
+-- | Internal data structure, corresponding to hspec\'s "SpecTree".
 --
 -- Since 1.2.0
 data YesodSpecTree site

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.6
+version:            1.6.6.1
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
The haddock documentation for YesodSpecTree was pointing at itself instead of the hspec type.