### PR TITLE
Use at most one valid session cookie per request

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.12
+
+* Use at most one valid session cookie per request [#1581](https://github.com/yesodweb/yesod/pull/1581)
+
 ## 1.6.11
 
 * Deprecate insecure JSON parsing functions [#1576](https://github.com/yesodweb/yesod/pull/1576)

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.11
+version:         1.6.12
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Makes `loadClientSession` ignore all sessions in a request if more than a single session cookie decodes successfully. The prior behavior was to merge all valid session cookies' values.

Bumps version to 1.6.11.1.

Not sure if this counts as a bugfix or breaking change that would require 1.7.

Closes #994, I figured after 3 years it's probably fair game :slightly_smiling_face:. Feel free to close if you don't think this change is warranted anymore.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)