### PR TITLE
Document runDB

### DIFF
--- a/yesod-persistent/Yesod/Persist/Core.hs
+++ b/yesod-persistent/Yesod/Persist/Core.hs
@@ -41,6 +41,15 @@ type YesodDB site = ReaderT (YesodPersistBackend site) (HandlerFor site)
 
 class Monad (YesodDB site) => YesodPersist site where
     type YesodPersistBackend site
+    -- | Allows you to execute database actions within Yesod Handlers. For databases that support it, code inside the action will run as an atomic transaction.
+    --
+    --
+    -- ==== __Example Usage__
+    --
+    -- > userId <- runDB $ do
+    -- >   userId <- insert $ User "username" "email@example.com"
+    -- >   insert_ $ UserPreferences userId True
+    -- >   pure userId
     runDB :: YesodDB site a -> HandlerFor site a
 
 -- | Helper for creating 'runDB'.


### PR DESCRIPTION
My coworker who is new to Haskell was pointing out that for such an important function to Yesod, this one is lacking any documentation. It's slightly hard to document because people could provide various implementations for it, but I think this description captures the essence pretty well, and notes the important implicit behavior of opening a transaction.

![image](https://user-images.githubusercontent.com/1274145/53908250-c8d51c80-4003-11e9-83b9-c7eec4cc79a5.png)


(Ignoring the following since this is a documentation only PR)

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
