### PR TITLE
sendClose and sendPing act in m ()

### DIFF
--- a/yesod-websockets/ChangeLog.md
+++ b/yesod-websockets/ChangeLog.md
@@ -1,3 +1,12 @@
+## 0.3.0.2
+
+* `sendClose` and `sendPing` correctly find the `Connection` from `WebSocketsT`
+
+  Previously, these types were incorrectly typed to look for the `Connection` on
+  the `m` of `WebSocketsT m ()`, and not via `WebSocketsT` itself. Because this
+  made them practically impossible to use, this change is unlikely to break any
+  existing code.
+
 ## 0.3.0.1
 
 * Minor cabal file improvements

--- a/yesod-websockets/Yesod/WebSockets.hs
+++ b/yesod-websockets/Yesod/WebSockets.hs
@@ -213,7 +213,7 @@ sendBinaryDataE = wrapWSE WS.sendBinaryData
 sendPing
   :: (MonadIO m, WS.WebSocketsData a, MonadReader WS.Connection m)
   => a
-  -> WebSocketsT m ()
+  -> m ()
 sendPing = wrapWS WS.sendPing
 
 -- | Send a ping message to the client.
@@ -242,7 +242,7 @@ sendDataMessageE x = do
 sendClose
   :: (MonadIO m, WS.WebSocketsData a, MonadReader WS.Connection m)
   => a
-  -> WebSocketsT m ()
+  -> m ()
 sendClose = wrapWS WS.sendClose
 
 -- | Send a close request to the client.

--- a/yesod-websockets/yesod-websockets.cabal
+++ b/yesod-websockets/yesod-websockets.cabal
@@ -1,5 +1,5 @@
 name:                yesod-websockets
-version:             0.3.0.1
+version:             0.3.0.2
 synopsis:            WebSockets support for Yesod
 homepage:            https://github.com/yesodweb/yesod
 license:             MIT


### PR DESCRIPTION
The previous type signature was attempting to read the Connection off of
the m in WebSocketsT m, rather than the WebSocketsT itself. This was
likely a typo that happened to type-check. The types for these now align
with the rest of the API, read the Connection off of WebSocketsT, and
make no demands of the m other than MonadIO.

Fixes #1599.


Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

*No new APIs.*

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)