### PR TITLE
urlParamRenderOverride includes prerequest session info and resovled approot

### DIFF
--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -103,7 +103,7 @@ class RenderRoute site => Yesod site where
     --
     -- Since 1.4.23
     urlParamRenderOverride :: site
-                           -> SessionMap -- ^ Session information
+                           -> SessionMap -- ^ Session information available before handler or middleware is processed
                            -> ResolvedApproot -- ^ Approot resolved to Text
                            -> Route site
                            -> [(T.Text, T.Text)] -- ^ query string

--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -103,10 +103,11 @@ class RenderRoute site => Yesod site where
     --
     -- Since 1.4.23
     urlParamRenderOverride :: site
+                           -> SessionMap -- ^ Session information
                            -> Route site
                            -> [(T.Text, T.Text)] -- ^ query string
                            -> Maybe Builder
-    urlParamRenderOverride _ _ _ = Nothing
+    urlParamRenderOverride _ _ _ _ = Nothing
 
     -- | Determine if a request is authorized or not.
     --

--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -104,10 +104,11 @@ class RenderRoute site => Yesod site where
     -- Since 1.4.23
     urlParamRenderOverride :: site
                            -> SessionMap -- ^ Session information
+                           -> ResolvedApproot -- ^ Approot resolved to Text
                            -> Route site
                            -> [(T.Text, T.Text)] -- ^ query string
                            -> Maybe Builder
-    urlParamRenderOverride _ _ _ _ = Nothing
+    urlParamRenderOverride _ _ _ _ _ = Nothing
 
     -- | Determine if a request is authorized or not.
     --

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -358,7 +358,7 @@ yesodRender y sm ar url params =
     fromMaybe
         (joinPath y ar ps
           $ params ++ params')
-        (urlParamRenderOverride y sm url params)
+        (urlParamRenderOverride y sm ar url params)
   where
     (ps, params') = renderRoute url
 


### PR DESCRIPTION
Submitting the PR for RFC not for merge really.

Basically I have a somewhat odd need in that when a URL is rendered if the session contains a specific value then I need put something in the query string so that the value persists even if the link is followed from an email to another computer etc. Since I only want to change the query string I need the resolved app root and since I need access to the session the only way i found to do that is by passing it in, but that means the middleware and handler can't affect the way the url is rendered so a full request must happen to set the session THEN the urls would have the needed session information passed on.

I tried to allow some kind of affects in urlParamRenderOverride but that just caused a huge rabbit hole of changing types everywhere which seemed like a bad option.

Is there a better way to do this? I'm not really a fan of this particular change but its the closest I've come to making what I need done. The only alternative I can think of is to change our architecture a bit and use sub domains to represent the data so that the resolved app root will "contain" it.

Thanks for the help! 

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
