### PR TITLE
Trivial: add stack.yaml.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.hi
 dist/
 dist-stack/
+stack.yaml.lock
 .stack-work
 *.swp
 client_session_key.aes


### PR DESCRIPTION
Should I be putting these trivial commits into a single PR? I've put them in separate ones because I thought it would be easy to cherry-pick them.