### PR TITLE
Trivial: rewrite stripColonLast function to be clearer

### DIFF
--- a/yesod-core/src/Yesod/Routes/Parse.hs
+++ b/yesod-core/src/Yesod/Routes/Parse.hs
@@ -75,6 +75,8 @@ resourcesFromString =
         parseAttr ('!':x) = Just x
         parseAttr _ = Nothing
 
+        -- If the last string in the list ends with a colon, remove it. Otherwise, return Nothing.
+        -- stripColonLast ["foo", "bar", "baz:"] -> ["foo", "bar", "baz"]
         stripColonLast [] = Nothing
         stripColonLast strings
             | null end = Nothing

--- a/yesod-core/src/Yesod/Routes/Parse.hs
+++ b/yesod-core/src/Yesod/Routes/Parse.hs
@@ -75,15 +75,13 @@ resourcesFromString =
         parseAttr ('!':x) = Just x
         parseAttr _ = Nothing
 
-        stripColonLast =
-            go id
+        stripColonLast [] = Nothing
+        stripColonLast strings
+            | null end = Nothing
+            | last end == ':' = Just $ start <> [end]
+            | otherwise = Nothing
           where
-            go _ [] = Nothing
-            go front [x]
-                | null x = Nothing
-                | last x == ':' = Just $ front [init x]
-                | otherwise = Nothing
-            go front (x:xs) = go (front . (x:)) xs
+            (start, end) = (init strings, last strings)
 
         spaces = takeWhile (== ' ') thisLine
         (others, remainder) = parse indent otherLines'


### PR DESCRIPTION
I think the new function is easier to read, but it might clash with the project's code style.

The new function should behave basically the same as the old function, so I haven't bumped the version number. Hope that's not wrong.

The comment is probably unnecessary.

Benchmark comparing the new and old `stripColonLast` functions, for lists that end with a colon and lists that do not:
```
benchmarking No colon/Old
time                 1.957 s    (1.754 s .. 2.398 s)
                     0.994 R²   (0.989 R² .. 1.000 R²)
mean                 1.944 s    (1.815 s .. 2.036 s)
std dev              129.6 ms   (51.55 ms .. 179.3 ms)
variance introduced by outliers: 20% (moderately inflated)

benchmarking No colon/New
time                 49.90 ms   (49.67 ms .. 50.17 ms)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 50.00 ms   (49.89 ms .. 50.15 ms)
std dev              251.4 μs   (174.9 μs .. 351.2 μs)

benchmarking Colon/Old
time                 6.403 s    (6.109 s .. 6.791 s)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 6.182 s    (5.940 s .. 6.303 s)
std dev              234.6 ms   (22.52 ms .. 281.0 ms)
variance introduced by outliers: 19% (moderately inflated)

benchmarking Colon/New
time                 656.5 ms   (655.7 ms .. 657.1 ms)
                     1.000 R²   (NaN R² .. 1.000 R²)
mean                 654.6 ms   (652.7 ms .. 655.3 ms)
std dev              1.307 ms   (151.6 μs .. 1.699 ms)
variance introduced by outliers: 19% (moderately inflated)
```