### PR TITLE
Make Routes.Parse use rio

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -125,6 +125,7 @@ test-suite test-routes
     extensions:      TemplateHaskell
 
     build-depends: base
+                 , rio
                  , hspec
                  , containers
                  , bytestring


### PR DESCRIPTION
This replaces #1609 

One thing I noticed doing this is that `lineContinuations` will keep empty strings in its input, is that ok? i.e.

`lineContinuations [] rest = []:rest`, not `lineContinuations [] rest = rest`