### PR TITLE
URL-encode POST parameters in yesod-test

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog for yesod-test
 
+## 1.6.6.2
+
+addPostParam will now URL-encode keys and values to prevent corruption
+when special characters such as `&` are used
+[#1617](https://github.com/yesodweb/yesod/pull/1617)
+
 ## 1.6.6.1
 
 * Documentation fixes

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -1242,9 +1242,8 @@ request reqBuilder = do
       BS8.concat $ separator : [BS8.concat [multipartPart p, separator] | p <- parts]
     multipartPart (ReqKvPart k v) = BS8.concat
       [ "Content-Disposition: form-data; "
-      , "name=\"", enc k, "\"\r\n\r\n"
-      , enc v, "\r\n"]
-      where enc = H.urlEncode False . TE.encodeUtf8
+      , "name=\"", TE.encodeUtf8 k, "\"\r\n\r\n"
+      , TE.encodeUtf8 v, "\r\n"]
     multipartPart (ReqFilePart k v bytes mime) = BS8.concat
       [ "Content-Disposition: form-data; "
       , "name=\"", TE.encodeUtf8 k, "\"; "

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -146,10 +146,10 @@ main = hspec $ do
                     setMethod "POST"
                     setUrl $ LiteAppRoute ["post"]
                     -- If value uses special characters,
-                    addPostParam "foo" "foo+bar%41&baz"
+                    addPostParam "foo" "foo+bar%41<&baz"
                 statusIs 200
                 -- They pass through the server correctly.
-                bodyEquals "foo+bar%41&baz"
+                bodyEquals "foo+bar%41<&baz"
             yit "labels" $ do
                 get ("/form" :: Text)
                 statusIs 200
@@ -157,13 +157,13 @@ main = hspec $ do
                 request $ do
                     setMethod "POST"
                     setUrl ("/form" :: Text)
-                    byLabel "Some Label" "foo+bar%41&baz"
+                    byLabel "Some Label" "foo+bar%41<&baz"
                     fileByLabel "Some File" "test/main.hs" "text/plain"
                     addToken
                 statusIs 200
-                -- The '%', '&' get further encoded because "/form"
-                -- (unlike "/post") uses toHtml.
-                bodyEquals "foo+bar%2541&amp;baz"
+                -- The '<' and '&' get encoded to HTML entities because
+                -- "/form" (unlike "/post") uses toHtml.
+                bodyEquals "foo+bar%41&lt;&amp;baz"
             yit "labels WForm" $ do
                 get ("/wform" :: Text)
                 statusIs 200

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -145,9 +145,11 @@ main = hspec $ do
                 request $ do
                     setMethod "POST"
                     setUrl $ LiteAppRoute ["post"]
-                    addPostParam "foo" "foobarbaz"
+                    -- If value uses special characters,
+                    addPostParam "foo" "foo+bar%41&baz"
                 statusIs 200
-                bodyEquals "foobarbaz"
+                -- They pass through the server correctly.
+                bodyEquals "foo+bar%41&baz"
             yit "labels" $ do
                 get ("/form" :: Text)
                 statusIs 200
@@ -155,11 +157,13 @@ main = hspec $ do
                 request $ do
                     setMethod "POST"
                     setUrl ("/form" :: Text)
-                    byLabel "Some Label" "12345"
+                    byLabel "Some Label" "foo+bar%41&baz"
                     fileByLabel "Some File" "test/main.hs" "text/plain"
                     addToken
                 statusIs 200
-                bodyEquals "12345"
+                -- The '%', '&' get further encoded because "/form"
+                -- (unlike "/post") uses toHtml.
+                bodyEquals "foo+bar%2541&amp;baz"
             yit "labels WForm" $ do
                 get ("/wform" :: Text)
                 statusIs 200

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.6.1
+version:            1.6.6.2
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
Addresses #1616. Includes tests that fail without the corresponding change to the code. Potentially this change could cause somebody's tests to fail, if they were already working around the issue (because URL-encoding is not idempotent). 

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
