### PR TITLE
Increase CI timeout

### DIFF
--- a/.azure/azure-linux-template.yml
+++ b/.azure/azure-linux-template.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: ${{ parameters.name }}
-  timeoutInMinutes: 120
+  timeoutInMinutes: 180
   pool:
     vmImage: ${{ parameters.vmImage }}
   strategy:


### PR DESCRIPTION
The build on Azure DevOps is [currently failing](https://dev.azure.com/yesodweb/yesod/_build/results?buildId=181) as the build-time is exceeding 120 minutes. Hopefully 180 minutes should be sufficient.

