### PR TITLE
Content type check

### DIFF
--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -191,6 +191,7 @@ module Yesod.Core.Handler
     , defaultCsrfParamName
       -- ** Checking CSRF Headers or POST Parameters
     , checkCsrfHeaderOrParam
+    , lookupContentType
     ) where
 
 import           Data.Time                     (UTCTime, addUTCTime,
@@ -1686,3 +1687,8 @@ getRouteToParent = liftSubHandler $ SubHandlerFor $ return . rheRouteToMaster . 
 
 getSubCurrentRoute :: MonadHandler m => m (Maybe (Route (SubHandlerSite m)))
 getSubCurrentRoute = liftSubHandler $ SubHandlerFor $ return . rheRoute . handlerEnv
+
+lookupContentType :: MonadHandler m => m (Maybe S8.ByteString)
+lookupContentType = do
+    mct <- lookupHeader "content-type"
+    return $ fmap (S8.takeWhile (/= ';')) mct

--- a/yesod-core/src/Yesod/Core/Json.hs
+++ b/yesod-core/src/Yesod/Core/Json.hs
@@ -34,7 +34,7 @@ module Yesod.Core.Json
     , acceptsJson
     ) where
 
-import Yesod.Core.Handler (HandlerFor, getRequest, invalidArgs, redirect, selectRep, provideRep, rawRequestBody, ProvidedRep, lookupHeader)
+import Yesod.Core.Handler (HandlerFor, getRequest, invalidArgs, redirect, selectRep, provideRep, rawRequestBody, ProvidedRep, lookupHeader, lookupContentType)
 import Control.Monad.Trans.Writer (Writer)
 import Data.Monoid (Endo)
 import Yesod.Core.Content (TypedContent)
@@ -133,10 +133,12 @@ parseInsecureJsonBody = do
 -- @since 0.3.0
 parseCheckJsonBody :: (MonadHandler m, J.FromJSON a) => m (J.Result a)
 parseCheckJsonBody = do
-    mct <- lookupHeader "content-type"
-    case fmap (B8.takeWhile (/= ';')) mct of
-        Just "application/json" -> parseInsecureJsonBody
-        _ -> return $ J.Error $ "Non-JSON content type: " ++ show mct
+    mct <- lookupContentType
+    case mct of
+        Just "application/json"  ->
+            parseInsecureJsonBody
+        _ ->
+            return $ J.Error $ "Non-JSON content type: " ++ show mct
 
 -- | Same as 'parseInsecureJsonBody', but return an invalid args response on a parse
 -- error.


### PR DESCRIPTION
This is still a work-in-progress. We've discussed in a [previous PR](https://github.com/yesodweb/yesod/pull/1619#discussion_r316180937) having something in core to check if the content-type is JSON-ish.

I thought of creating a function like `hasJsonMime :: MonadHandler m => m (Bool)`. But saying if a mime is either JSON or anything else does not seem too useful (i.e. if it's not JSON it could be really anything else). 

Another way would be to have something like

```hs
data Mime
  = Html
  | Json
  | ...
```
And a function `lookupContentType :: MonadHandler m => m (Mime)`. But I'm not sure it's a good approach.

At the moment I've added a `lookupContentType :: MonadHandler m => m (Maybe S8.ByteString)`. But I'm not sure having the caller `case`ing on a `Maybe S8.ByteString` is a good idea.

Also, I see in the code both the terms "content type" and "mime", do you have a preference on any of the two? Would you use them both but in different contexts?

How would you approach all of this?

---

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
