### PR TITLE
Use original type var names when generating type synonyms

### DIFF
--- a/yesod-core/src/Yesod/Core/Internal/TH.hs
+++ b/yesod-core/src/Yesod/Core/Internal/TH.hs
@@ -160,7 +160,7 @@ mkYesodGeneral appCxt' namestr mtys isSub f resS = do
             , renderRouteDec
             , [routeAttrsDec]
             , resourcesDec
-            , if isSub then [] else masterTypeSyns vns site
+            , if isSub then [] else masterTypeSyns (map mkName mtys) site
             ]
     return (dataDec, dispatchDec)
 


### PR DESCRIPTION
(Potentially) fixes #1629 

This makes the synonyms valid when the using type params, e.g.
```haskell
mkYesod "App a" ...
```

However I am not sure if this is the "right" fix, i.e. if I've accidentally fixed it by doing something wrong that breaks other stuff. I've added my thoughts as a comment on the review.

I would love to add a test for this, if someone could give me a hint on how to do so.

Additionally I am not sure **which** version to bump, and **how much**, so I've left a bit of the template below as a `TODO`.

Before submitting your PR, check that you've:

- [ ] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

