### PR TITLE
Add Basic Auth support to yesod-test

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-test
 
+## 1.6.7
+
+TODO
+
 ## 1.6.6.2
 
 addPostParam will now URL-encode keys and values to prevent corruption

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.6.7
 
-TODO
+Add `addBasicAuthHeader` function [#1632](https://github.com/yesodweb/yesod/pull/1632)
 
 ## 1.6.6.2
 

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -1153,6 +1153,8 @@ addRequestHeader header = modifySIO $ \rbd -> rbd
 --
 -- > request $ do
 -- >   addBasicAuthHeader "Aladdin" "OpenSesame"
+--
+-- @since 1.6.7
 addBasicAuthHeader :: CI ByteString -- ^ Username
                    -> CI ByteString -- ^ Password
                    -> RequestBuilder site ()

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.6.2
+version:            1.6.7
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>
@@ -28,6 +28,7 @@ library
                    , html-conduit              >= 0.1
                    , http-types                >= 0.7
                    , network                   >= 2.2
+                   , memory
                    , pretty-show               >= 1.6
                    , semigroups
                    , text


### PR DESCRIPTION
This allows setting username/password for HTTP basic auth, similar to the --user flag of curl.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
