### PR TITLE
Add Getting Started to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,40 @@ An advanced web framework using the Haskell programming language. Featuring:
   * asynchronous IO
     * this is built in to the Haskell programming language (like Erlang)
 
+## Getting Started
+
 Learn more about Yesod on [its main website](http://www.yesodweb.com/). If you
 want to get started using Yesod, we strongly recommend the [quick start
 guide](http://www.yesodweb.com/page/quickstart), based on [the Haskell build
 tool stack](https://github.com/commercialhaskell/stack#readme).
+
+Here's a minimal example!
+
+```haskell
+{-# LANGUAGE OverloadedStrings, QuasiQuotes, TemplateHaskell, TypeFamilies #-}
+
+import Yesod
+
+data App = App -- Put your config, database connection pool, etc. in here.
+
+-- Derive routes and instances for App.
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+|]
+
+instance Yesod App -- Methods in here can be overridden as needed.
+
+-- The handler for the GET request at /, corresponds to HomeR.
+getHomeR :: Handler Html
+getHomeR = defaultLayout [whamlet|Hello World!|]
+
+main :: IO ()
+main = warp 3000 App
+```
+
+To read about each of the concepts in use above (routing, handlers,
+linking, JSON), in detail, visit
+[Basics in the Yesod book](https://www.yesodweb.com/book/basics#basics_routing).
 
 ## Hacking on Yesod
 

--- a/yesod/README.md
+++ b/yesod/README.md
@@ -8,3 +8,38 @@ the core code lives in
 For the yesod executable, see [yesod-bin](http://www.stackage.org/package/yesod-bin/).
 
 Yesod is [fully documented on its website](http://www.yesodweb.com/).
+
+## Getting Started
+
+Learn more about Yesod on [its main website](http://www.yesodweb.com/). If you
+want to get started using Yesod, we strongly recommend the [quick start
+guide](http://www.yesodweb.com/page/quickstart), based on [the Haskell build
+tool stack](https://github.com/commercialhaskell/stack#readme).
+
+Here's a minimal example!
+
+```haskell
+{-# LANGUAGE OverloadedStrings, QuasiQuotes, TemplateHaskell, TypeFamilies #-}
+
+import Yesod
+
+data App = App -- Put your config, database connection pool, etc. in here.
+
+-- Derive routes and instances for App.
+mkYesod "App" [parseRoutes|
+/ HomeR GET
+|]
+
+instance Yesod App -- Methods in here can be overridden as needed.
+
+-- The handler for the GET request at /, corresponds to HomeR.
+getHomeR :: Handler Html
+getHomeR = defaultLayout [whamlet|Hello World!|]
+
+main :: IO ()
+main = warp 3000 App
+```
+
+To read about each of the concepts in use above (routing, handlers,
+linking, JSON), in detail, visit
+[Basics in the Yesod book](https://www.yesodweb.com/book/basics#basics_routing).


### PR DESCRIPTION
This adds a code sample and direct link to the "Basics" chapter of the Yesod book.

* Adds to the README seen on Github.
* Adds to the README that will be seen on Stackage/Hackage.

The idea is to show how Yesod can be small and quick to setup, like Scotty/Spock. Newbies perusing the crop of Haskell web service libraries may be passing up Yesod because it seems "too complicated" (requiring a few clicks away from the main package before seeing an actual code sample), when actually it can be as small or big as you want. Hence: put a code sample on the first screen many devs are likely to see.