### PR TITLE
Add a warning about DB actions getting rolled back

### DIFF
--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -91,7 +91,8 @@ module Yesod.Core.Handler
     , permissionDeniedI
     , invalidArgs
     , invalidArgsI
-      -- ** Short-circuit responses.
+      -- ** Short-circuit responses
+      -- $rollbackWarning
     , sendFile
     , sendFilePart
     , sendResponse
@@ -606,6 +607,20 @@ setMessageI = addMessageI ""
 -- discards the rest and the status
 getMessage :: MonadHandler m => m (Maybe Html)
 getMessage = fmap (fmap snd . listToMaybe) getMessages
+
+-- $rollbackWarning
+--
+-- Note that since short-circuiting is implemented by using exceptions,
+-- using e.g. 'sendStatusJSON' inside a runDB block
+-- will result in the database actions getting rolled back:
+--
+-- @
+-- runDB $ do
+--   userId <- insert $ User "username" "email@example.com"
+--   postId <- insert $ BlogPost "title" "hi there!"
+--     /The previous two inserts will be rolled back./
+--   sendStatusJSON Status.status200 ()
+-- @
 
 -- | Bypass remaining handler code and output the given file.
 --


### PR DESCRIPTION
As mentioned in https://github.com/yesodweb/yesod/issues/1639 I've added a comment to remind the user about using things like `sendStatusJSON` inside `runDB` blocks.

Here's a screenshot to show what the docs look like with my change:
![Screenshot from 2019-11-13 20-55-38](https://user-images.githubusercontent.com/5606260/68828020-f4aba600-0658-11ea-9951-5979c127a426.png)
