### PR TITLE
WIP - Add testModifySite

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.6.8
 
-Add `testModifySite` function [#](https://github.com/yesodweb/yesod/pull/)
+Add `testModifySite` function [#1642](https://github.com/yesodweb/yesod/pull/1642)
 
 ## 1.6.7
 

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-test
 
+## 1.6.8
+
+Add `testModifySite` function [#](https://github.com/yesodweb/yesod/pull/)
+
 ## 1.6.7
 
 Add `addBasicAuthHeader` function [#1632](https://github.com/yesodweb/yesod/pull/1632)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -45,6 +45,9 @@ module Yesod.Test
     , ydescribe
     , yit
 
+    -- * Modify test site
+    , testModifySite
+
     -- * Modify test state
     , testSetCookie
     , testDeleteCookie
@@ -340,6 +343,18 @@ yesodSpecApp site getApp yspecs =
 -- | Describe a single test that keeps cookies, and a reference to the last response.
 yit :: String -> YesodExample site () -> YesodSpec site
 yit label example = tell [YesodSpecItem label example]
+
+-- | Modifies the site ('yedSite') of the test
+-- 
+-- TODO documentation here
+--
+-- TODO @since
+testModifySite :: YesodDispatch site => (site -> site) -> Middleware -> YesodExample site ()
+testModifySite newSiteFn middleware = do
+  currentSite <- getTestYesod 
+  let newSite = newSiteFn currentSite
+  app <- liftIO $ toWaiAppPlain newSite
+  modifySIO $ \yed -> yed { yedSite = newSite, yedApp = middleware app }
 
 -- | Sets a cookie
 --

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -344,15 +344,33 @@ yesodSpecApp site getApp yspecs =
 yit :: String -> YesodExample site () -> YesodSpec site
 yit label example = tell [YesodSpecItem label example]
 
--- | Modifies the site ('yedSite') of the test
+-- | Modifies the site ('yedSite') of the test, and creates a new WAI app ('yedApp') for it.
 -- 
--- TODO documentation here
+-- yesod-test allows sending requests to your application to test that it handles them correctly.
+-- In rare cases, you may wish to modify that application in the middle of a test.
+-- This may be useful if you wish to, for example, test your application under a certain configuration,
+-- then change that configuration to see if your app responds differently.
 --
--- TODO @since
-testModifySite :: YesodDispatch site => (site -> site) -> Middleware -> YesodExample site ()
-testModifySite newSiteFn middleware = do
+-- ==== __Examples__
+--
+-- > post SendEmailR
+-- > -- Assert email not created in database
+-- > testModifySite (\site -> pure (site { siteSettingsStoreEmail = True }, id))
+-- > post SendEmailR
+-- > -- Assert email created in database
+--
+-- > testModifySite (\site -> do
+-- >   middleware <- makeLogware site
+-- >   pure (site { appRedisConnection = Nothing }, middleware)
+-- > )
+--
+-- @since 1.6.8
+testModifySite :: YesodDispatch site
+               => (site -> IO (site, Middleware)) -- ^ A function from the existing site, to a new site and middleware for a WAI app.
+               -> YesodExample site ()
+testModifySite newSiteFn = do
   currentSite <- getTestYesod 
-  let newSite = newSiteFn currentSite
+  (newSite, middleware) <- liftIO $ newSiteFn currentSite
   app <- liftIO $ toWaiAppPlain newSite
   modifySIO $ \yed -> yed { yedSite = newSite, yedApp = middleware app }
 

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -42,6 +42,7 @@ import Network.HTTP.Types.Status (status301, status303, status403, status422, un
 import UnliftIO.Exception (tryAny, SomeException, try)
 import qualified Web.Cookie as Cookie
 import Data.Maybe (isNothing)
+import qualified Data.Text as T
 
 parseQuery_ :: Text -> [[SelectorGroup]]
 parseQuery_ = either error id . parseQuery
@@ -49,13 +50,23 @@ parseQuery_ = either error id . parseQuery
 findBySelector_ :: HtmlLBS -> Query -> [String]
 findBySelector_ x = either error id . findBySelector x
 
-data RoutedApp = RoutedApp
+data RoutedApp = RoutedApp { routedAppInteger :: Integer }
+
+defaultRoutedApp :: RoutedApp
+defaultRoutedApp = RoutedApp 0
 
 mkYesod "RoutedApp" [parseRoutes|
 /                HomeR      GET POST
 /resources       ResourcesR POST
 /resources/#Text ResourceR  GET
+/get-integer     IntegerR   GET
 |]
+
+-- data ParamaterizedApp = ParamaterizedApp { parameterizedAppInteger :: Integer }
+
+-- mkYesod "ParamaterizedApp" [parseRoutes|
+-- /get-integer ParameterizedGetInteger GET
+-- |]
 
 main :: IO ()
 main = hspec $ do
@@ -378,7 +389,7 @@ main = hspec $ do
             testModifyCookies (\_ -> Map.empty)
             get ("cookie/check-no-cookie" :: Text)
             statusIs 200
-    describe "CSRF with cookies/headers" $ yesodSpec RoutedApp $ do
+    describe "CSRF with cookies/headers" $ yesodSpec defaultRoutedApp $ do
         yit "Should receive a CSRF cookie and add its value to the headers" $ do
             get ("/" :: Text)
             statusIs 200
@@ -420,7 +431,7 @@ main = hspec $ do
             r <- followRedirect
             liftIO $ assertBool "expected a Left when not a redirect" $ isLeft r
 
-    describe "route parsing in tests" $ yesodSpec RoutedApp $ do
+    describe "route parsing in tests" $ yesodSpec defaultRoutedApp $ do
         yit "parses location header into a route" $ do
             -- get CSRF token
             get HomeR
@@ -443,6 +454,14 @@ main = hspec $ do
             statusIs 200
             loc <- getLocation
             liftIO $ assertBool "expected a Left when not a redirect" $ isLeft loc
+
+    describe "modifying site value" $ yesodSpec defaultRoutedApp $ do
+        yit "can change site value" $ do
+            get ("/get-integer" :: Text)
+            bodyContains "0"
+            testModifySite (\site -> site { routedAppInteger = 1 }) id
+            get ("/get-integer" :: Text)
+            bodyContains "1"
 
     describe "Basic Authentication" $ yesodSpec app $ do
         yit "rejects no header" $ do
@@ -571,6 +590,9 @@ cookieApp = liteApp $ do
 instance Yesod RoutedApp where
     yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
 
+-- instance Yesod ParameterizedApp where
+--     yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
+
 getHomeR :: Handler Html
 getHomeR = defaultLayout
     [whamlet|
@@ -598,3 +620,8 @@ getResourceR i = defaultLayout
         <p>
             Read item #{i}.
     |]
+
+getIntegerR :: Handler Text
+getIntegerR = do
+    app <- getYesod
+    pure $ T.pack $ show (routedAppInteger app)

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -453,7 +453,7 @@ main = hspec $ do
         yit "can change site value" $ do
             get ("/get-integer" :: Text)
             bodyContains "0"
-            testModifySite (\site -> site { routedAppInteger = 1 }) id
+            testModifySite (\site -> pure (site { routedAppInteger = 1 }, id))
             get ("/get-integer" :: Text)
             bodyContains "1"
 

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -62,12 +62,6 @@ mkYesod "RoutedApp" [parseRoutes|
 /get-integer     IntegerR   GET
 |]
 
--- data ParamaterizedApp = ParamaterizedApp { parameterizedAppInteger :: Integer }
-
--- mkYesod "ParamaterizedApp" [parseRoutes|
--- /get-integer ParameterizedGetInteger GET
--- |]
-
 main :: IO ()
 main = hspec $ do
     describe "CSS selector parsing" $ do
@@ -589,9 +583,6 @@ cookieApp = liteApp $ do
 
 instance Yesod RoutedApp where
     yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
-
--- instance Yesod ParameterizedApp where
---     yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
 
 getHomeR :: Handler Html
 getHomeR = defaultLayout

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.7
+version:            1.6.8
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
~*This PR is a draft to propose a new function `testModifySite`*~

In most Yesod apps, there is an `App` datatype at the core of the application, holding all configuration and state for the app (e.g. settings, connection pools, `IORef`s, etc.). In the tests, this is setup on a per-test basis. This PR adds a new function, `testModifySite`, to modify that site in the middle of a test. This is the signature:

```haskell
testModifySite :: YesodDispatch site => (site -> site) -> Middleware -> YesodExample site ()
```

Here are some use cases I'm imagining:

### Testing how modifying settings changes behavior

The yesod scaffold comes with an `AppSettings` type you use to configure your app. An app may want to have a test like so:

```
it "only fires missiles if config allows it" $ do
  -- Many
  -- common
  -- lines
  -- of
  -- database
  -- configuration
  post FireMissilesR
  -- Assert nothing happens
  testModifySite (\site -> site { appSettings = (appSettings site) { appSettingsFireMissiles = True } }) id
  post FireMissilesR
  -- Assert missiles are fired
```

### Changing out stubbed functions

The use case we have at work is we have a `Stubs` datatype in our app, and we use it to stub out functions. This looks roughly like so:

```
data App = App
  { appTestStubs :: Stubs
  ...
  }

data Stubs = Stubs 
  { stubMailerHandlerSendEmail :: forall m. (MonadIO m) => Maybe (m ())
  ...
  }

withStub :: (Monad m, HasApp m) => (Stubs -> Maybe (m a)) -> m a -> m a
withStub f realImpl = do
  stubs <- appTestStubs <$> getApp
  fromMaybe realImpl (f stubs)

handlerSendEmail message = withStub stubMailerHandlerSendEmail $ do
  -- Real implementation here
```

And in production, we set `stubMailerHandlerSendEmail` to `Nothing`, in which case our codebase uses the production implementation, but in tests we can use the stubbed function to customize behavior.

`testModifySite` would allow us to modify that stub in the middle of a test, so we could have tests like this:

```
it "records sent emails in the database if sending succeeds" $ do
  -- Lots
  -- of 
  -- test 
  -- setup
  post SendEmailR
  -- Assert that SentEmail record exists in database
  testModifySite (\site -> site { appTestStubs = (appTestStubs site) { stubMailerHandlerSendEmail = Just . liftIO $ throwIO EmailSendException } }) id
  post SendEmailR
  -- Assert that new email record was not created
```

<hr>

A gotcha about this function is that the `yedSite` and `yedApp` parameters are tied together. So, once the site is modified, a new `yedApp` must be created from it using `toWaiAppPlain` then calling a new middleware function. I think this is OK though?

One could maybe drop the `Middleware` parameter of `testModifySite`, but the `Middleware` initially provided would have to be stored in `YesodExampleData` for later, which would be a breaking change. Also, it adds complexity to `YesodExampleData` just for the convenience of this function.

<hr>

If this function sounds good, I'll add another function called `testSetSite` that outright replaces the site value.