### PR TITLE
[yesod-test] Adds requireJSONResponse function

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.17
+
+Adds `contentTypeIsJson` [#1646](https://github.com/yesodweb/yesod/pull/1646)
+
 ## 1.6.16.1
 
 * Compiles with GHC 8.8.1

--- a/yesod-core/src/Yesod/Core/Json.hs
+++ b/yesod-core/src/Yesod/Core/Json.hs
@@ -218,3 +218,4 @@ acceptsJson =  (maybe False ((== "application/json") . B8.takeWhile (/= ';'))
             .  listToMaybe
             .  reqAccept)
            `liftM` getRequest
+

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.16.1
+version:         1.6.17
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-test
 
+## 1.6.9
+
+Add `requireJSONResponse` function [#164](https://github.com/yesodweb/yesod/pull/164)
+
 ## 1.6.8
 
 Add `testModifySite` function [#1642](https://github.com/yesodweb/yesod/pull/1642)

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.6.9
 
-Add `requireJSONResponse` function [#164](https://github.com/yesodweb/yesod/pull/164)
+Add `requireJSONResponse` function [#1646](https://github.com/yesodweb/yesod/pull/1646)
 
 ## 1.6.8
 

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -171,6 +171,7 @@ import System.IO
 import Yesod.Core.Unsafe (runFakeHandler)
 import Yesod.Test.TransversingCSS
 import Yesod.Core
+import Yesod.Core.Json (contentTypeHeaderIsJson)
 import qualified Data.Text.Lazy as TL
 import Data.Text.Lazy.Encoding (encodeUtf8, decodeUtf8, decodeUtf8With)
 import Text.XML.Cursor hiding (element)
@@ -604,7 +605,7 @@ htmlCount query count = do
 
 -- | Parses the response body from JSON into a Haskell value, throwing an error if parsing fails.
 --
--- This function also checks that the @Content-Type@ of the response is @application/json@.
+-- This function also checks that the @Content-Type@ of the response is @application\/json@.
 --
 -- ==== __Examples__
 --
@@ -619,7 +620,7 @@ requireJSONResponse :: (HasCallStack, FromJSON a) => YesodExample site a
 requireJSONResponse = do
   withResponse $ \(SResponse _status headers body) -> do
     let mContentType = lookup hContentType headers
-        isJSONContentType = maybe False (\contentType -> BS8.takeWhile (/= ';') contentType == "application/json") mContentType
+        isJSONContentType = maybe False contentTypeHeaderIsJson mContentType
     unless
         isJSONContentType
         (failure $ T.pack $ "Expected `Content-Type: application/json` in the headers, got: " ++ show headers)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -605,7 +605,7 @@ htmlCount query count = do
 
 -- | Parses the response body from JSON into a Haskell value, throwing an error if parsing fails.
 --
--- This function also checks that the @Content-Type@ of the response is @application\/json@.
+-- This function also checks that the @Content-Type@ of the response is @application/json@.
 --
 -- ==== __Examples__
 --

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -611,6 +611,9 @@ htmlCount query count = do
 -- > get CommentR
 -- > (comment :: Comment) <- requireJSONResponse
 --
+-- > post UserR
+-- > (json :: Value) <- requireJSONResponse
+--
 -- @since 1.6.9
 requireJSONResponse :: (HasCallStack, FromJSON a) => YesodExample site a
 requireJSONResponse = do

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -610,6 +610,8 @@ htmlCount query count = do
 --
 -- > get CommentR
 -- > (comment :: Comment) <- requireJSONResponse
+--
+-- @since 1.6.9
 requireJSONResponse :: (HasCallStack, FromJSON a) => YesodExample site a
 requireJSONResponse = do
   withResponse $ \(SResponse _status headers body) -> do

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -45,7 +45,6 @@ import Control.Monad.IO.Unlift (toIO)
 import qualified Web.Cookie as Cookie
 import Data.Maybe (isNothing)
 import qualified Data.Text as T
--- import qualified Data.Aeson as A
 
 parseQuery_ :: Text -> [[SelectorGroup]]
 parseQuery_ = either error id . parseQuery
@@ -587,7 +586,6 @@ app = liteApp $ do
         (sendStatusJSON status200 ([1] :: [Integer])) :: LiteHandler Value
     onStatic "get-json-wrong-content-type" $ dispatchTo $ do
         return ("[1]" :: Text)
-        -- (sendResponse "[1]") :: LiteHandler Text
 
 cookieApp :: LiteApp
 cookieApp = liteApp $ do

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.8
+version:            1.6.9
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>
@@ -15,6 +15,7 @@ extra-source-files: README.md, LICENSE, test/main.hs, ChangeLog.md
 
 library
     build-depends:   HUnit                     >= 1.2
+                   , aeson
                    , attoparsec                >= 0.10
                    , base                      >= 4.3      && < 5
                    , blaze-builder
@@ -65,6 +66,7 @@ test-suite test
                           , http-types
                           , unliftio
                           , cookie
+                          , unliftio-core
 
 source-repository head
   type: git


### PR DESCRIPTION
This function checks that a response body is JSON, and parses it into a Haskell value. Having something like this function is pretty essential to using Yesod as a JSON API server, so I think it's a good addition. You can use it to parse a Haskell record directly (usually by adding FromJSON classes to your response types), or parse a Value and pull out individual fields, maybe using something like `aeson-lens` (though probably a testing-specific library would be better).

I debated over these things:

1. The name. I was thinking of something like [assert/require/decode/parse]JSON[Response/Body]. I ultimately went with requireJSONResponse:
	- decode/parse sound like the aeson functions that return Either or Maybe, and I wanted this function to throw an error if it failed
	- I'm open to using `assertJSONResponse`—it matches the other functions (`assertEq`) better—but I think it reads less like English.
	- I chose Response over Body because (a) It also checks the content-type header, which is not in the body (b) "Body" felt slightly in-the-weeds of HTTP; I think "response" is more approachable.
	- Edit: Oh, just realized the function on the serve is called `requireJsonBody`. That kind of rules out that name to avoid duplicate identifier issues.      
2. Should it require the JSON content type? You can definitely have a server that returns JSON without JSON content types, but I think that's a such a bad idea, it's more likely requiring it helps people if they accidentally don't add the header.
3. Should it take a String parameter to add to the error message? This would match `assertEq`, but other functions like `statusIs` don't take a message. Ultimately I went without it, because the messages felt like I was repeating myself: `(comment :: Comment) <- requireJSONResponse "the response has a comment"`

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
