### PR TITLE
Add extensions for yesod-persistent tests to be compatible with lates…

### DIFF
--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -4,7 +4,7 @@
 
 * Fix test suite to be compatible with latest `persistent-template`
 * See https://github.com/yesodweb/persistent/pull/1002
-* [#]()
+* [#1649](https://github.com/yesodweb/yesod/pull/1649/files)
 
 ## 1.6.0.3
 

--- a/yesod-persistent/ChangeLog.md
+++ b/yesod-persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog for yesod-persistent
 
+## 1.6.0.4
+
+* Fix test suite to be compatible with latest `persistent-template`
+* See https://github.com/yesodweb/persistent/pull/1002
+* [#]()
+
 ## 1.6.0.3
 
 * Replace call to `connPrepare` with `getStmtConn`. [#1635](https://github.com/yesodweb/yesod/issues/1635)

--- a/yesod-persistent/test/Yesod/PersistSpec.hs
+++ b/yesod-persistent/test/Yesod/PersistSpec.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Yesod.PersistSpec where
 
 import Test.Hspec

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -17,7 +17,7 @@ library
     build-depends:   base                      >= 4        && < 5
                    , yesod-core                >= 1.6      && < 1.7
                    , persistent                >= 2.8      && < 2.11
-                   , persistent-template       >= 2.1      && < 2.8
+                   , persistent-template       >= 2.1      && < 2.9
                    , transformers              >= 0.2.2
                    , blaze-builder
                    , conduit

--- a/yesod-persistent/yesod-persistent.cabal
+++ b/yesod-persistent/yesod-persistent.cabal
@@ -1,5 +1,5 @@
 name:            yesod-persistent
-version:         1.6.0.3
+version:         1.6.0.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
…t persistent-template

The upcoming version of persistent-template will require these yesodweb/persistent#1002

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html) - no new APIS
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs - no new APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
