### PR TITLE
Add methods to YesodAuthEmail that allow custom flow after registration/password reset

### DIFF
--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for yesod-auth
 
+## 1.6.9
+
+* Added `registerHelper` and `passwordResetHelper` methods to the `YesodAuthEmail` class, allowing for customizing behavior for user registration and forgot password requests
+* Exposed `defaultRegisterHelper` as default implementation for the above methods
+
 ## 1.6.8.1
 
 * Email: Fix typo in `defaultEmailLoginHandler` template [#1605](https://github.com/yesodweb/yesod/pull/1605)

--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.6.9
 
-* Added `registerHelper` and `passwordResetHelper` methods to the `YesodAuthEmail` class, allowing for customizing behavior for user registration and forgot password requests
+* Added `registerHelper` and `passwordResetHelper` methods to the `YesodAuthEmail` class, allowing for customizing behavior for user registration and forgot password requests [#1660](https://github.com/yesodweb/yesod/pull/1660)
 * Exposed `defaultRegisterHelper` as default implementation for the above methods
 
 ## 1.6.8.1

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -385,6 +385,10 @@ class ( YesodAuth site
       -> AuthHandler site TypedContent
     setPasswordHandler = defaultSetPasswordHandler
 
+
+    registerHelper :: Bool -> Bool -> Route Auth -> AuthHandler site TypedContent
+    registerHelper = defaultRegisterHelper
+
 authEmail :: (YesodAuthEmail m) => AuthPlugin m
 authEmail =
     AuthPlugin "email" dispatch emailLoginHandler
@@ -516,12 +520,12 @@ parseRegister = withObject "email" (\obj -> do
                                       pass <- obj .:? "password"
                                       return (email, pass))
 
-registerHelper :: YesodAuthEmail master
-               => Bool -- ^ allow usernames?
-               -> Bool -- ^ forgot password?
-               -> Route Auth
-               -> AuthHandler master TypedContent
-registerHelper allowUsername forgotPassword dest = do
+defaultRegisterHelper :: YesodAuthEmail master
+                      => Bool -- ^ allow usernames?
+                      -> Bool -- ^ forgot password?
+                      -> Route Auth
+                      -> AuthHandler master TypedContent
+defaultRegisterHelper allowUsername forgotPassword dest = do
     y <- getYesod
     checkCsrfHeaderOrParam defaultCsrfHeaderName defaultCsrfParamName
     result <- runInputPostResult $ (,)

--- a/yesod-auth/Yesod/Auth/Email.hs
+++ b/yesod-auth/Yesod/Auth/Email.hs
@@ -113,6 +113,8 @@ module Yesod.Auth.Email
     , defaultRegisterHandler
     , defaultForgotPasswordHandler
     , defaultSetPasswordHandler
+     -- * Default helpers
+    , defaultRegisterHelper
     ) where
 
 import           Yesod.Auth
@@ -386,8 +388,33 @@ class ( YesodAuth site
     setPasswordHandler = defaultSetPasswordHandler
 
 
-    registerHelper :: Bool -> Bool -> Route Auth -> AuthHandler site TypedContent
-    registerHelper = defaultRegisterHelper
+    -- | Helper that controls what happens after a user registration
+    -- request is submitted. This method can be overridden to completely
+    -- customize what happens during the user registration process,
+    -- such as for handling additional fields in the registration form.
+    --
+    -- The default implementation is in terms of 'defaultRegisterHelper'.
+    --
+    -- @since: 1.6.9
+    registerHelper :: Route Auth
+                      -- ^ Where to sent the user in the event
+                      -- that registration fails
+                   -> AuthHandler site TypedContent
+    registerHelper = defaultRegisterHelper False False
+
+    -- | Helper that controls what happens after a forgot password
+    -- request is submitted. As with `registerHelper`, this method can
+    -- be overridden to customize the behavior when a user attempts
+    -- to recover their password.
+    --
+    -- The default implementation is in terms of 'defaultRegisterHelper'.
+    --
+    -- @since: 1.6.9
+    passwordResetHelper :: Route Auth
+                           -- ^ Where to sent the user in the event
+                           -- that the password reset fails
+                        -> AuthHandler site TypedContent
+    passwordResetHelper = defaultRegisterHelper True True
 
 authEmail :: (YesodAuthEmail m) => AuthPlugin m
 authEmail =
@@ -521,8 +548,8 @@ parseRegister = withObject "email" (\obj -> do
                                       return (email, pass))
 
 defaultRegisterHelper :: YesodAuthEmail master
-                      => Bool -- ^ allow usernames?
-                      -> Bool -- ^ forgot password?
+                      => Bool -- ^ Allow lookup via username in addition to email
+                      -> Bool -- ^ Set to `True` for forgot password flow, `False` for new account registration
                       -> Route Auth
                       -> AuthHandler master TypedContent
 defaultRegisterHelper allowUsername forgotPassword dest = do
@@ -553,7 +580,7 @@ defaultRegisterHelper allowUsername forgotPassword dest = do
                     _ -> Nothing
 
     case eidentifier of
-      Left route -> loginErrorMessageI dest route
+      Left failMsg -> loginErrorMessageI dest failMsg
       Right identifier -> do
             mecreds <- getEmailCreds identifier
             registerCreds <-
@@ -590,7 +617,7 @@ defaultRegisterHelper allowUsername forgotPassword dest = do
 
 
 postRegisterR :: YesodAuthEmail master => AuthHandler master TypedContent
-postRegisterR = registerHelper False False registerR
+postRegisterR = registerHelper registerR
 
 getForgotPasswordR :: YesodAuthEmail master => AuthHandler master Html
 getForgotPasswordR = forgotPasswordHandler
@@ -634,7 +661,7 @@ defaultForgotPasswordHandler = do
         }
 
 postForgotPasswordR :: YesodAuthEmail master => AuthHandler master TypedContent
-postForgotPasswordR = registerHelper True True forgotPasswordR
+postForgotPasswordR = passwordResetHelper forgotPasswordR
 
 getVerifyR :: YesodAuthEmail site
            => AuthEmailId site

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,5 +1,5 @@
 name:            yesod-auth
-version:         1.6.8.1
+version:         1.6.9
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin


### PR DESCRIPTION
### Summary

This change moves `registerHelper` (previously a private function in `Yesod.Auth.Email`) into the `YesodAuthEmail` typeclass to allow for customization by end users of the library. It also adds a `passwordResetHelper`, allowing for different flow between registration and password reset behavior.

### Details

The issue was first mentioned in #948 almost five years ago, wherein using `Yesod.Auth.Email` currently has very limited customization capabilities in terms of what happens upon submission of a registration or password reset request.

Moreover, overriding `registerHelper` is necessary if the developer wants to handle additional fields that are sent from the registration form. For example, implementing a honeypot field that attempts to thwart bots requires examining the contents of the additional field upon submission, which was previously impossible, since the developer had no control over what happened after the form was POSTed to the registration action.

This change preserves the default behavior (by adding a `defaultRegisterHelper`) and so it should be fully backwards compatible with previous versions of `yesod-auth`.

I'm not sure what the typical versioning scheme used in the `yesod-*` plugins is, but since this isn't a breaking change, I've currently bumped the version of `yesod-auth` from `1.6.8.1` to `1.6.9`.

### Feedback

I'm happy to receive any feedback about this change. I know `Yesod.Auth.Email` is not the most active module in terms of development, but since it ships with `yesod-auth`, I figure exposing some of its internals and letting developers override some more of its defaults should improve its utility.

-----------

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)