### PR TITLE
Use DeriveLift to generate yesod-core's Lift instances

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -4,6 +4,11 @@
 
 * Add functions for setting description and OG meta [#1663](https://github.com/yesodweb/yesod/pull/1663)
 
+* Use `DeriveLift` to implement the `Lift` instances for `ResourceTree`,
+  `Resource`, `Piece`, and `Dispatch`. Among other benefits, this provides
+  implementations of `liftTyped` on `template-haskell-2.16` (GHC 8.10) or
+  later. [#1664](https://github.com/yesodweb/yesod/pull/1664)
+
 ## 1.6.17.3
 
 * Support for `unliftio-core` 0.2


### PR DESCRIPTION
GHC 8.0 and later come with the `DeriveLift` extension for deriving instances of `Language.Haskell.TH.Syntax.Lift`. `yesod-core` supports GHC 8.2 and up, so it is able to make use of this. Not only does `DeriveLift` make for much shorter code, but it also fixes warnings that you get when compiling `yesod-core` with GHC 8.10 or later:

```
[20 of 31] Compiling Yesod.Routes.TH.Types ( src/Yesod/Routes/TH/Types.hs, interpreted )

src/Yesod/Routes/TH/Types.hs:34:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift (ResourceTree t)’
   |
34 | instance Lift t => Lift (ResourceTree t) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Yesod/Routes/TH/Types.hs:49:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift (Resource t)’
   |
49 | instance Lift t => Lift (Resource t) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^

src/Yesod/Routes/TH/Types.hs:59:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift (Piece t)’
   |
59 | instance Lift t => Lift (Piece t) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^

src/Yesod/Routes/TH/Types.hs:78:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift (Dispatch t)’
   |
78 | instance Lift t => Lift (Dispatch t) where
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This is because `DeriveLift` fills in implementations of `liftTyped`, a method that was introduced to `Lift` in `template-haskell-2.16.0.0` (bundled with GHC 8.10).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
