### PR TITLE
Fix warnings in yesod-core

### DIFF
--- a/yesod-core/src/Yesod/Core/Class/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Class/Handler.hs
@@ -19,7 +19,6 @@ import Control.Monad.Trans.Class (lift)
 import Data.Conduit.Internal (Pipe, ConduitM)
 
 import Control.Monad.Trans.Identity ( IdentityT)
-import Control.Monad.Trans.List     ( ListT    )
 import Control.Monad.Trans.Maybe    ( MaybeT   )
 import Control.Monad.Trans.Except   ( ExceptT  )
 import Control.Monad.Trans.Reader   ( ReaderT  )
@@ -76,7 +75,6 @@ instance MonadHandler (WidgetFor site) where
 #define GO(T) instance MonadHandler m => MonadHandler (T m) where type HandlerSite (T m) = HandlerSite m; type SubHandlerSite (T m) = SubHandlerSite m; liftHandler = lift . liftHandler; liftSubHandler = lift . liftSubHandler
 #define GOX(X, T) instance (X, MonadHandler m) => MonadHandler (T m) where type HandlerSite (T m) = HandlerSite m; type SubHandlerSite (T m) = SubHandlerSite m; liftHandler = lift . liftHandler; liftSubHandler = lift . liftSubHandler
 GO(IdentityT)
-GO(ListT)
 GO(MaybeT)
 GO(ExceptT e)
 GO(ReaderT r)
@@ -104,7 +102,6 @@ liftWidgetT = liftWidget
 #define GO(T) instance MonadWidget m => MonadWidget (T m) where liftWidget = lift . liftWidget
 #define GOX(X, T) instance (X, MonadWidget m) => MonadWidget (T m) where liftWidget = lift . liftWidget
 GO(IdentityT)
-GO(ListT)
 GO(MaybeT)
 GO(ExceptT e)
 GO(ReaderT r)

--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -247,7 +247,6 @@ import           Data.Typeable                 (Typeable)
 import           Web.PathPieces                (PathPiece(..))
 import           Yesod.Core.Class.Handler
 import           Yesod.Core.Types
-import           Yesod.Routes.Class            (Route)
 import           Data.ByteString.Builder (Builder)
 import           Data.CaseInsensitive (CI, original)
 import qualified Data.Conduit.List as CL
@@ -1431,7 +1430,7 @@ rawRequestBody :: MonadHandler m => ConduitT i S.ByteString m ()
 rawRequestBody = do
     req <- lift waiRequest
     let loop = do
-            bs <- liftIO $ W.requestBody req
+            bs <- liftIO $ W.getRequestBodyChunk req
             unless (S.null bs) $ do
                 yield bs
                 loop

--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -1430,7 +1430,7 @@ rawRequestBody :: MonadHandler m => ConduitT i S.ByteString m ()
 rawRequestBody = do
     req <- lift waiRequest
     let loop = do
-            bs <- liftIO $ W.getRequestBodyChunk req
+            bs <- liftIO $ W.requestBody req
             unless (S.null bs) $ do
                 yield bs
                 loop

--- a/yesod-core/src/Yesod/Core/Internal/Request.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Request.hs
@@ -51,7 +51,7 @@ limitRequestBody maxLen req = do
     ref <- newIORef maxLen
     return req
         { W.requestBody = do
-            bs <- W.getRequestBodyChunk req
+            bs <- W.requestBody req
             remaining <- readIORef ref
             let len = fromIntegral $ S8.length bs
                 remaining' = remaining - len

--- a/yesod-core/src/Yesod/Core/Internal/Request.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Request.hs
@@ -51,7 +51,7 @@ limitRequestBody maxLen req = do
     ref <- newIORef maxLen
     return req
         { W.requestBody = do
-            bs <- W.requestBody req
+            bs <- W.getRequestBodyChunk req
             remaining <- readIORef ref
             let len = fromIntegral $ S8.length bs
                 remaining' = remaining - len
@@ -66,7 +66,7 @@ tooLargeResponse :: Word64 -> Word64 -> W.Response
 tooLargeResponse maxLen bodyLen = W.responseLBS
     (Status 413 "Too Large")
     [("Content-Type", "text/plain")]
-    (L.concat 
+    (L.concat
         [ "Request body too large to be processed. The maximum size is "
         , (LS8.pack (show maxLen))
         , " bytes; your request body was "

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -36,7 +36,7 @@ import           Yesod.Core.Types
 import           Yesod.Core.Internal.Request  (parseWaiRequest,
                                                tooLargeResponse)
 import           Yesod.Core.Internal.Util     (getCurrentMaxExpiresRFC1123)
-import           Yesod.Routes.Class           (Route, renderRoute)
+import           Yesod.Routes.Class           (renderRoute)
 import           Control.DeepSeq              (($!!), NFData)
 import           UnliftIO.Exception
 
@@ -343,7 +343,6 @@ yesodRunner handler' YesodRunnerEnv {..} route req sendResponse = do
           yar <- runInternalState (runHandler rhe handler yreq') is
           yarToResponse yar saveSession yreq' req is sendResponse
   where
-    mmaxLen = maximumContentLength yreSite route
     handler = yesodMiddleware handler'
 
 yesodRender :: Yesod y

--- a/yesod-core/src/Yesod/Core/Types.hs
+++ b/yesod-core/src/Yesod/Core/Types.hs
@@ -28,7 +28,6 @@ import           Data.IORef                         (IORef, modifyIORef')
 import           Data.Map                           (Map, unionWith)
 import qualified Data.Map                           as Map
 import           Data.Monoid                        (Endo (..), Last (..))
-import           Data.Semigroup                     (Semigroup(..))
 import           Data.Serialize                     (Serialize (..),
                                                      putByteString)
 import           Data.String                        (IsString (fromString))

--- a/yesod-core/src/Yesod/Core/Types.hs
+++ b/yesod-core/src/Yesod/Core/Types.hs
@@ -28,6 +28,7 @@ import           Data.IORef                         (IORef, modifyIORef')
 import           Data.Map                           (Map, unionWith)
 import qualified Data.Map                           as Map
 import           Data.Monoid                        (Endo (..), Last (..))
+import           Data.Semigroup                     (Semigroup(..))
 import           Data.Serialize                     (Serialize (..),
                                                      putByteString)
 import           Data.String                        (IsString (fromString))

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.18
+version:         1.6.19
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I originally set out to resolve this [issue](https://github.com/yesodweb/yesod/issues/1656) but it turned out to be a fairly trivial change, so I handled a couple other warnings that were coming up with `-Wall` enabled. 

I don't think that there were any changes to the logic, and the test suite seems to be passing.

This is my first PR against Yesod so let me know if I missed something!

Before submitting your PR, check that you've:

- [x] Bumped the version number
- ~~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~~
- ~~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs~~

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
