### PR TITLE
Drop dependency on semigroups

### DIFF
--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -32,7 +32,6 @@ library
                    , email-validate        >= 1.0
                    , persistent
                    , resourcet
-                   , semigroups
                    , shakespeare           >= 2.0
                    , text                  >= 0.9
                    , time                  >= 1.1.4

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -32,7 +32,6 @@ library
                    , network                   >= 2.2
                    , memory
                    , pretty-show               >= 1.6
-                   , semigroups
                    , text
                    , time
                    , transformers              >= 0.2.2

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -26,7 +26,6 @@ library
                    , directory
                    , fast-logger
                    , monad-logger
-                   , semigroups
                    , shakespeare
                    , streaming-commons
                    , template-haskell


### PR DESCRIPTION
They are not needed on GHC we support.
