### PR TITLE
Absolute templates path

### DIFF
--- a/yesod/ChangeLog.md
+++ b/yesod/ChangeLog.md
@@ -1,3 +1,7 @@
+## 1.6.1.0
+
+* `widgetFileReload` and `widgetFileNoReload` now use absolute paths via the new `globFilePackage` Q Exp which can provide absolute templates paths within the project [#1691](https://github.com/yesodweb/yesod/pull/1691)
+
 ## 1.6.0.2
 
 * Replace deprecated decodeFile with decodeFileEither. This should have no semantic impact, but silences a deprecation warning. [#1658](https://github.com/yesodweb/yesod/pull/1658)

--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -5,6 +5,7 @@
 module Yesod.Default.Util
     ( addStaticContentExternal
     , globFile
+    , globFilePackage
     , widgetFileNoReload
     , widgetFileReload
     , TemplateLanguage (..)
@@ -15,6 +16,7 @@ module Yesod.Default.Util
     ) where
 
 import qualified Data.ByteString.Lazy as L
+import Data.FileEmbed (makeRelativeToProject)
 import Data.Text (Text, pack, unpack)
 import Yesod.Core -- purposely using complete import so that Haddock will see addStaticContent
 import Control.Monad (when, unless)
@@ -63,6 +65,10 @@ addStaticContentExternal minify hash staticDir toRoute ext' _ content = do
 -- | expects a file extension for each type, e.g: hamlet lucius julius
 globFile :: String -> String -> FilePath
 globFile kind x = "templates/" ++ x ++ "." ++ kind
+
+-- | `globFile` but returned path is absolute and within the package the Q Exp is evaluated
+globFilePackage :: String -> String -> Q FilePath
+globFilePackage = (makeRelativeToProject <$>) . globFile
 
 data TemplateLanguage = TemplateLanguage
     { tlRequiresToWidget :: Bool

--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -130,7 +130,7 @@ warnUnlessExists :: Bool
                  -> Bool -- ^ requires toWidget wrap
                  -> String -> (FilePath -> Q Exp) -> Q (Maybe Exp)
 warnUnlessExists shouldWarn x wrap glob f = do
-    let fn = globFile glob x
+    fn <- globFilePackage glob x
     e <- qRunIO $ doesFileExist fn
     when (shouldWarn && not e) $ qRunIO $ putStrLn $ "widget file not found: " ++ fn
     if e

--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -67,6 +67,7 @@ globFile :: String -> String -> FilePath
 globFile kind x = "templates/" ++ x ++ "." ++ kind
 
 -- | `globFile` but returned path is absolute and within the package the Q Exp is evaluated
+-- @since 1.6.1.0
 globFilePackage :: String -> String -> Q FilePath
 globFilePackage = (makeRelativeToProject <$>) . globFile
 

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -25,6 +25,7 @@ library
                    , data-default-class
                    , directory
                    , fast-logger
+                   , file-embed
                    , monad-logger
                    , shakespeare
                    , streaming-commons

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -1,5 +1,5 @@
 name:            yesod
-version:         1.6.0.2
+version:         1.6.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

fixes #1690

i'm 99% certain this can't break any usages of `widgetFileReload` or `widgetFileNoReload` because those those `Q Exp` must have already been evaluated in the correct project. unless someone was jumping through a lot of hoops to run ghc manually