### PR TITLE
Remove use of deprecated forkPingThread

### DIFF
--- a/yesod-websockets/ChangeLog.md
+++ b/yesod-websockets/ChangeLog.md
@@ -1,3 +1,6 @@
+## 0.3.0.3
+* Removed the use of the deprecated forkPingThread and replaced it with the recommended withPingThread. [#1700](https://github.com/yesodweb/yesod/pull/1700)
+
 ## 0.3.0.2
 
 * `sendClose` and `sendPing` correctly find the `Connection` from `WebSocketsT`

--- a/yesod-websockets/Yesod/WebSockets.hs
+++ b/yesod-websockets/Yesod/WebSockets.hs
@@ -117,8 +117,8 @@ webSocketsOptionsWith wsConnOpts buildAr inner = do
                     rhead
                     (\pconn -> do
                         conn <- WS.acceptRequestWith pconn ar
-                        WS.forkPingThread conn 30
-                        runInIO $ runReaderT inner conn)
+                        WS.withPingThread conn 30 (pure ()) $
+                            runInIO $ runReaderT inner conn)
                     src
                     sink
 

--- a/yesod-websockets/Yesod/WebSockets.hs
+++ b/yesod-websockets/Yesod/WebSockets.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 module Yesod.WebSockets
@@ -117,8 +118,14 @@ webSocketsOptionsWith wsConnOpts buildAr inner = do
                     rhead
                     (\pconn -> do
                         conn <- WS.acceptRequestWith pconn ar
-                        WS.withPingThread conn 30 (pure ()) $
-                            runInIO $ runReaderT inner conn)
+                        let app = runInIO $ runReaderT inner conn
+#if MIN_VERSION_websockets(0,12,6)
+                        WS.withPingThread conn 30 (pure ()) $ app
+#else
+                        WS.forkPingThread conn 30
+                        app
+#endif
+                    )
                     src
                     sink
 

--- a/yesod-websockets/yesod-websockets.cabal
+++ b/yesod-websockets/yesod-websockets.cabal
@@ -1,5 +1,5 @@
 name:                yesod-websockets
-version:             0.3.0.2
+version:             0.3.0.3
 synopsis:            WebSockets support for Yesod
 homepage:            https://github.com/yesodweb/yesod
 license:             MIT


### PR DESCRIPTION
Removed the use of the deprecated [forkPingThread](https://hackage.haskell.org/package/websockets-0.12.7.1/docs/Network-WebSockets.html#v:forkPingThread) and replaced it with the recommended [withPingThread](https://hackage.haskell.org/package/websockets-0.12.7.1/docs/Network-WebSockets.html#v:withPingThread).

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
