### PR TITLE
Fix import in cookie example

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-test
 
+## Unreleased
+
+* Fix import in cookie example [#1713](https://github.com/yesodweb/yesod/pull/1713)
+
 ## 1.6.11
 
 * Add missing `HasCallStack`s [#1710](https://github.com/yesodweb/yesod/pull/1710)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -462,7 +462,7 @@ testModifySite newSiteFn = do
 --
 -- ==== __Examples__
 --
--- > import qualified Data.Cookie as Cookie
+-- > import qualified Web.Cookie as Cookie
 -- > :set -XOverloadedStrings
 -- > testSetCookie Cookie.defaultSetCookie { Cookie.setCookieName = "name" }
 --


### PR DESCRIPTION
Fixes #1712 

- [ ] ~Bumped the version number~
- [ ] ~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~
- [ ] ~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs~

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
