### PR TITLE
Bumped cabal version to >= 1.10

### DIFF
--- a/yesod-form-multi/yesod-form-multi.cabal
+++ b/yesod-form-multi/yesod-form-multi.cabal
@@ -7,7 +7,7 @@ maintainer:      James Burton <jamesejburton@gmail.com>
 synopsis:        Multi-input form handling for Yesod Web Framework
 category:        Web, Yesod
 stability:       Stable
-cabal-version:   >= 1.8
+cabal-version:   >= 1.10
 build-type:      Simple
 homepage:        http://www.yesodweb.com/
 description:     API docs and the README are available at <http://www.stackage.org/package/yesod-form-multi>.
@@ -19,6 +19,7 @@ flag network-uri
   default: True
 
 library
+    default-language: Haskell2010
     build-depends:   base                  >= 4.10     && < 5
                    , containers            >= 0.2
                    , shakespeare           >= 2.0


### PR DESCRIPTION
After submitting your PR:

- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

Completely forgot to release version 1.7.0 of the yesod-form-multi package on hackage. Went to do it and I needed to make a couple of tweaks to the cabal file for it to be accepted. Namely bumping the `cabal-version` and adding a `default-language`.