### PR TITLE
Devel SSL

### DIFF
--- a/yesod-bin/ChangeLog.md
+++ b/yesod-bin/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-bin
 
+## 1.6.1
+
+Added command line options `cert` and `key` to allow TLS certificate and key files to be passed to `yesod devel` [#1717](https://github.com/yesodweb/yesod/pull/1717)
+
 ## 1.6.0.6
 
 Fix the `add-handler` subcommand to support both the old default routes filename (`routes`) and the new one (`routes.yesodroutes`) [#1688](https://github.com/yesodweb/yesod/pull/1688)

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -9,7 +9,6 @@ module Devel
     ) where
 
 import           Control.Applicative                   ((<|>))
-import           Control.Arrow                         ((&&&))
 import           UnliftIO                              (race_)
 import           Control.Concurrent                    (threadDelay)
 import           Control.Concurrent.STM
@@ -19,7 +18,6 @@ import           Control.Monad                         (forever, unless, void,
 import Data.ByteString (ByteString, isInfixOf)
 import qualified Data.ByteString.Lazy                  as LB
 import           Conduit
-import           Data.Bitraversable                    (bisequence)
 import           Data.FileEmbed                        (embedFile)
 import qualified Data.Map                              as Map
 import           Data.Maybe                            (isJust)

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -174,28 +174,28 @@ reverseProxy opts appPortVar = do
                 manager
         defaultSettings' = maybe id (setHost . fromString) (develHost opts) defaultSettings
         runProxyTls port app = do
-          let certDef = $(embedFile "certificate.pem")
-              keyDef = $(embedFile "key.pem")
-              certOpts = bisequence $ (certPath &&& keyPath) opts
-              theSettings = maybe (tlsSettingsMemory certDef keyDef) (uncurry tlsSettings) certOpts
-          runTLS theSettings (setPort port defaultSettings') $ \req send -> do
-            let req' = req
-                    { requestHeaders
-                        = ("X-Forwarded-Proto", "https")
-                        -- Workaround for
-                        -- https://github.com/yesodweb/wai/issues/478, where
-                        -- the Host headers aren't set. Without this, generated
-                        -- URLs from guestApproot are incorrect, see:
-                        -- https://github.com/yesodweb/yesod-scaffold/issues/114
-                        : (case lookup "host" (requestHeaders req) of
-                            Nothing ->
-                                case requestHeaderHost req of
-                                    Just host -> (("Host", host):)
-                                    Nothing -> id
-                            Just _ -> id)
-                          (requestHeaders req)
-                    }
-            app req' send
+            let certDef = $(embedFile "certificate.pem")
+                keyDef = $(embedFile "key.pem")
+                certOpts = bisequence $ (certPath &&& keyPath) opts
+                theSettings = maybe (tlsSettingsMemory certDef keyDef) (uncurry tlsSettings) certOpts
+            runTLS theSettings (setPort port defaultSettings') $ \req send -> do
+                let req' = req
+                        { requestHeaders
+                            = ("X-Forwarded-Proto", "https")
+                            -- Workaround for
+                            -- https://github.com/yesodweb/wai/issues/478, where
+                            -- the Host headers aren't set. Without this, generated
+                            -- URLs from guestApproot are incorrect, see:
+                            -- https://github.com/yesodweb/yesod-scaffold/issues/114
+                            : (case lookup "host" (requestHeaders req) of
+                                Nothing ->
+                                    case requestHeaderHost req of
+                                        Just host -> (("Host", host):)
+                                        Nothing -> id
+                                Just _ -> id)
+                            (requestHeaders req)
+                        }
+                app req' send
         httpProxy = runSettings (setPort (develPort opts) defaultSettings') proxyApp
         httpsProxy = runProxyTls (develTlsPort opts) proxyApp
     say "Application can be accessed at:\n"

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -174,28 +174,28 @@ reverseProxy opts appPortVar = do
                 manager
         defaultSettings' = maybe id (setHost . fromString) (develHost opts) defaultSettings
         runProxyTls port app = do
-            let certDef = $(embedFile "certificate.pem")
-                keyDef = $(embedFile "key.pem")
-                certOpts = bisequence $ (certPath &&& keyPath) opts
-                theSettings = maybe (tlsSettingsMemory certDef keyDef) (uncurry tlsSettings) certOpts
-            runTLS theSettings (setPort port defaultSettings') $ \req send -> do
-                let req' = req
-                        { requestHeaders
-                            = ("X-Forwarded-Proto", "https")
-                            -- Workaround for
-                            -- https://github.com/yesodweb/wai/issues/478, where
-                            -- the Host headers aren't set. Without this, generated
-                            -- URLs from guestApproot are incorrect, see:
-                            -- https://github.com/yesodweb/yesod-scaffold/issues/114
-                            : (case lookup "host" (requestHeaders req) of
-                                Nothing ->
-                                    case requestHeaderHost req of
-                                        Just host -> (("Host", host):)
-                                        Nothing -> id
-                                Just _ -> id)
-                            (requestHeaders req)
-                        }
-                app req' send
+          let certDef = $(embedFile "certificate.pem")
+              keyDef = $(embedFile "key.pem")
+              certOpts = bisequence $ (certPath &&& keyPath) opts
+              theSettings = maybe (tlsSettingsMemory certDef keyDef) (uncurry tlsSettings) certOpts
+          runTLS theSettings (setPort port defaultSettings') $ \req send -> do
+            let req' = req
+                    { requestHeaders
+                        = ("X-Forwarded-Proto", "https")
+                        -- Workaround for
+                        -- https://github.com/yesodweb/wai/issues/478, where
+                        -- the Host headers aren't set. Without this, generated
+                        -- URLs from guestApproot are incorrect, see:
+                        -- https://github.com/yesodweb/yesod-scaffold/issues/114
+                        : (case lookup "host" (requestHeaders req) of
+                            Nothing ->
+                                case requestHeaderHost req of
+                                    Just host -> (("Host", host):)
+                                    Nothing -> id
+                            Just _ -> id)
+                          (requestHeaders req)
+                    }
+            app req' send
         httpProxy = runSettings (setPort (develPort opts) defaultSettings') proxyApp
         httpsProxy = runProxyTls (develTlsPort opts) proxyApp
     say "Application can be accessed at:\n"

--- a/yesod-bin/main.hs
+++ b/yesod-bin/main.hs
@@ -30,12 +30,14 @@ data Command = Init [String]
              | Build { buildExtraArgs   :: [String] }
              | Touch
              | Devel { develSuccessHook :: Maybe String
-                     , develExtraArgs    :: [String]
+                     , develExtraArgs   :: [String]
                      , develPort        :: Int
                      , develTlsPort     :: Int
                      , proxyTimeout     :: Int
                      , noReverseProxy   :: Bool
                      , develHost        :: Maybe String
+                     , certPath         :: Maybe FilePath
+                     , keyPath          :: Maybe FilePath
                      }
              | DevelSignal
              | Test
@@ -90,6 +92,8 @@ main = do
                              , proxyTimeout = proxyTimeout
                              , useReverseProxy = not noReverseProxy
                              , develHost    = develHost
+                             , certPath     = certPath
+                             , keyPath      = keyPath
                              } develExtraArgs
     DevelSignal     -> develSignal
   where
@@ -167,6 +171,10 @@ develOptions = Devel <$> optStr ( long "success-hook" <> short 's' <> metavar "C
                             <> help "Disable reverse proxy" )
                      <*> optStr (long "host" <> metavar "HOST"
                             <> help "Host interface to bind to; IP address, '*' for all interfaces, '*4' for IP4, '*6' for IP6")
+                     <*> optStr (long "cert" <> metavar "CERT"
+                            <> help "Path to TLS certificate file, does nothing if --key is not also defined")
+                     <*> optStr (long "key" <> metavar "KEY"
+                            <> help "Path to TLS key file, does nothing if --cert is not also defined")
 
 extraStackArgs :: Parser [String]
 extraStackArgs = many (strOption ( long "extra-stack-arg" <> short 'e' <> metavar "ARG"

--- a/yesod-bin/main.hs
+++ b/yesod-bin/main.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE RecordWildCards             #-}
 module Main (main) where
 
-import           Data.Bitraversable     (bisequence)
 import           Data.Monoid
 import           Data.Version           (showVersion)
 import           Options.Applicative

--- a/yesod-bin/main.hs
+++ b/yesod-bin/main.hs
@@ -169,15 +169,11 @@ develOptions = Devel <$> optStr ( long "success-hook" <> short 's' <> metavar "C
                             <> help "Disable reverse proxy" )
                      <*> optStr (long "host" <> metavar "HOST"
                             <> help "Host interface to bind to; IP address, '*' for all interfaces, '*4' for IP4, '*6' for IP6")
-                     <*> optionPair
-                            (strOption (long "cert" <> metavar "CERT"
-                                   <> help "Path to TLS certificate file, requires that --key is also defined"))
-                            (strOption (long "key" <> metavar "KEY"
-                                   <> help "Path to TLS key file, requires that --cert is also defined"))
-
-optionPair :: Parser a -> Parser b -> Parser (Maybe (a,b))
-optionPair pa pb = Just <$> liftA2 (,) pa pb
-                   <|> pure Nothing
+                     <*> optional ( (,)
+                            <$> strOption (long "cert" <> metavar "CERT"
+                                   <> help "Path to TLS certificate file, requires that --key is also defined")
+                            <*> strOption (long "key" <> metavar "KEY"
+                                   <> help "Path to TLS key file, requires that --cert is also defined") )
 
 extraStackArgs :: Parser [String]
 extraStackArgs = many (strOption ( long "extra-stack-arg" <> short 'e' <> metavar "ARG"

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -1,5 +1,5 @@
 name:            yesod-bin
-version:         1.6.0.6
+version:         1.6.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [X] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

This change was made in response to the discussion found [here](https://groups.google.com/g/yesodweb/c/ztCwgWeuErs).

I've tested this on a site I currently have in development and it seems to work in allowing a certificate to be provided for localhost.

Assuming everything else is fine, there are a couple of minor issues / oddities that may need fixing before this is merged. If you access the development site via https then a minute or so later the line `data: end of file` appears in stdout. Also if you issue a CTRL+C command (Ubuntu) there is a pause of a couple of seconds before the above text is printed and then the process exits.

I'm not sure where the `data: end of file` is coming from but my guess is that the delay in the process exiting is to do with a file handle that's not yet been closed due to lazy IO. I tried to work around this by using `hGetContents` and `tlsSettingsMemory` to read the files into strict `ByteString`s rather than passing `FilePath`s to `tlsSettings` (which ultimately uses a lazy `ByteString`). Unfortunately this didn't seem to make any difference so I'm out of ideas. Below is a snippet of what the aforementioned attempt looked like for anyone interested:

```
readStrict fp = withBinaryFile fp ReadMode hGetContents
runProxyTls port app = do
    certOpts <- traverse (bitraverse readStrict readStrict)
                $ bisequence $ (certPath &&& keyPath) opts
    let certDef = $(embedFile "certificate.pem")
        keyDef = $(embedFile "key.pem")
        tlsSettings = uncurry tlsSettingsMemory $ fromMaybe (certDef, keyDef) certOpts
    runTLS tlsSettings (setPort port defaultSettings') $ \req send -> do
```

Another peculiarity is that once you access the site on, for example, `https://localhost:3443`, Chrome then refuses to connect with  `http://localhost:3000` until the cache is cleared. Not sure why this is is the case but it doesn't happen on Firefox so I don't think it's anything on the `yesod devel` end of things.

Any input on the above "issues" would be appreciated.