### PR TITLE
Stop moving session language ahead of reqLangs

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,6 +1,6 @@
 # ChangeLog for yesod-core
 
-## 1.6.18.9
+## 1.6.19.0
 
 * Change order of priority in `languages`[#1721](https://github.com/yesodweb/yesod/pull/1721)
 

--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.18.9
+
+* Change order of priority in `languages`[#1721](https://github.com/yesodweb/yesod/pull/1721)
+
 ## 1.6.18.8
 
 * Fix test suite for wai-extra change around vary header

--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -1239,7 +1239,7 @@ cacheBySet key value = do
 --
 -- This is handled by parseWaiRequest (not exposed).
 --
--- __NOTE__: Before version @1.6.18.9@, this function prioritized the session
+-- __NOTE__: Before version @1.6.19.0@, this function prioritized the session
 -- variable above all other sources.
 --
 languages :: MonadHandler m => m [Text]

--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -1238,6 +1238,10 @@ cacheBySet key value = do
 -- If a matching language is not found the default language will be used.
 --
 -- This is handled by parseWaiRequest (not exposed).
+--
+-- __NOTE__: Before version @1.6.18.9@, this function prioritized the session
+-- variable above all other sources.
+--
 languages :: MonadHandler m => m [Text]
 languages = reqLangs <$> getRequest
 

--- a/yesod-core/src/Yesod/Core/Handler.hs
+++ b/yesod-core/src/Yesod/Core/Handler.hs
@@ -1226,9 +1226,9 @@ cacheBySet key value = do
 -- Languages are determined based on the following (in descending order
 -- of preference):
 --
--- * The _LANG user session variable.
---
 -- * The _LANG get parameter.
+--
+-- * The _LANG user session variable.
 --
 -- * The _LANG cookie.
 --
@@ -1239,10 +1239,7 @@ cacheBySet key value = do
 --
 -- This is handled by parseWaiRequest (not exposed).
 languages :: MonadHandler m => m [Text]
-languages = do
-    mlang <- lookupSession langKey
-    langs <- reqLangs <$> getRequest
-    return $ maybe id (:) mlang langs
+languages = reqLangs <$> getRequest
 
 lookup' :: Eq a => a -> [(a, b)] -> [b]
 lookup' a = map snd . filter (\x -> a == fst x)

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.18.9
+version:         1.6.19.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.18.8
+version:         1.6.18.9
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
`Yesod.Core.Handler.languages` checks first for a language set in the user's
session, prepending that value to `YesodRequest{reqLangs}`, so it is respected
above all else if present.

For context, `reqLangs` itself also includes the session, but just later in
line:

```hs
langs' = catMaybes [ lookup langKey gets -- Query _LANG
                   , lookup langKey cookies     -- Cookie _LANG
                   , lookupText langKey session -- Session _LANG
                   ] ++ langs                    -- Accept-Language(s)
```

In #1720, it was raised that allowing the session (something implicitly present
for any request) to override a query parameter (something explicitly given on
that request) is surprising.

We decided (without knowing what order `reqLangs` was doing) that query, cookie,
session, accept was best and `languages` should be changed to do that.
Conveniently, this just makes `languages` equivalent to `reqLangs`, so that is
what this patch does.

---

I'll do this in a fast-follow:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
- [x] Send a message to the mailing list about the order change