### PR TITLE
Fix compatibility with template-haskell 2.17 for yesod

### DIFF
--- a/yesod/ChangeLog.md
+++ b/yesod/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod
 
+## 1.6.1.2
+
+* Fix compatibility with template-haskell 2.17 [#1730](https://github.com/yesodweb/yesod/pull/1730)
+
 ## 1.6.1.1
 
 * Allow yesod-form 1.7

--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -113,7 +113,11 @@ combine func file isReload tls = do
             , show file
             , ", but no templates were found."
             ]
+#if MIN_VERSION_template_haskell(2,17,0)
+        exps -> return $ DoE Nothing $ map NoBindS exps
+#else
         exps -> return $ DoE $ map NoBindS exps
+#endif
   where
     qmexps :: Q [Maybe Exp]
     qmexps = mapM go tls

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -1,5 +1,5 @@
 name:            yesod
-version:         1.6.1.1
+version:         1.6.1.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Fixes the following build failure with template-haskell 2.17:

```
[6 of 6] Compiling Yesod.Default.Util ( Yesod/Default/Util.hs, dist/build/Yesod/Default/Util.dyn_o )

Yesod/Default/Util.hs:116:17: error:
    • Couldn't match type ‘[Stmt] -> Exp’ with ‘Exp’
      Expected: Q Exp
        Actual: Q ([Stmt] -> Exp)
    • In the expression: return $ DoE $ map NoBindS exps
      In a case alternative: exps -> return $ DoE $ map NoBindS exps
      In a stmt of a 'do' block:
        case catMaybes mexps of
          [] -> error $ concat ["Called ", func, ....]
          exps -> return $ DoE $ map NoBindS exps
    |
116 |         exps -> return $ DoE $ map NoBindS exps
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Yesod/Default/Util.hs:116:32: error:
    • Couldn't match expected type: Maybe ModName
                  with actual type: [Stmt]
    • In the second argument of ‘($)’, namely ‘map NoBindS exps’
      In the second argument of ‘($)’, namely ‘DoE $ map NoBindS exps’
      In the expression: return $ DoE $ map NoBindS exps
    |
116 |         exps -> return $ DoE $ map NoBindS exps
    |                                ^^^^^^^^^^^^^^^^
```

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
