### PR TITLE
[RFC] Allow arbitrary logger types

### DIFF
--- a/yesod-core/src/Yesod/Core.hs
+++ b/yesod-core/src/Yesod/Core.hs
@@ -151,7 +151,7 @@ import Network.Wai (Application)
 
 runFakeHandler :: (Yesod site, MonadIO m) =>
                   SessionMap
-               -> (site -> Logger)
+               -> (site -> SiteLogger site)
                -> site
                -> HandlerT site IO a
                -> m (Either ErrorResponse a)

--- a/yesod-core/src/Yesod/Core/Unsafe.hs
+++ b/yesod-core/src/Yesod/Core/Unsafe.hs
@@ -15,7 +15,7 @@ import Control.Monad.IO.Class (MonadIO)
 --
 -- > unsafeHandler = Unsafe.fakeHandlerGetLogger appLogger
 fakeHandlerGetLogger :: (Yesod site, MonadIO m)
-                     => (site -> Logger)
+                     => (site -> SiteLogger site)
                      -> site
                      -> HandlerFor site a
                      -> m a


### PR DESCRIPTION
Intended to fix #1735.

This is a possible solution to allowing Yesod to support basically any kind of logging library, using an associated type family for the logger representation.

I don't know whether or not the existence of `makeLogger` and the passing of the logger to `messageLoggerSource` still make sense - a better design might simply be to rip them out entirely - but these changes should at least be backwards-compatible from an API standpoint.

### Issues

This introduces a wedge between a Yesod site and the WAI server it runs on. The default logging middlewares that Yesod sets up will only accept `Logger`s, and since it's no longer possible to provide a `Logger` from the site type, a new one has to be created just to log from the middleware. That's a change in semantics that might surprise users. Additionally, *some* parts of middleware logging (like the exception logging in `warp`) *still* go through the Yesod site logger instead.