### PR TITLE
Color field

### DIFF
--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-form
 
+## 1.7.1
+
+* Added `colorField` for creating a html color field (`<input type="color">`) ciukstar:color-field [#1748](https://github.com/yesodweb/yesod/pull/1748)
+
 ## 1.7.0
 
 * Extended `OptionList` by `OptionListGrouped` and implemented grouped select fields (`<select>` with `<optgroup>`) [#1722](https://github.com/yesodweb/yesod/pull/1722)

--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.7.1
 
-* Added `colorField` for creating a html color field (`<input type="color">`) ciukstar:color-field [#1748](https://github.com/yesodweb/yesod/pull/1748)
+* Added `colorField` for creating a html color field (`<input type="color">`) [#1748](https://github.com/yesodweb/yesod/pull/1748)
 
 ## 1.7.0
 

--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -954,6 +954,8 @@ prependZero t0 = if T.null t1
 
 -- | Creates an input with @type="color"@.
 --   The input value must be provided in hexadecimal format #rrggbb.
+--
+-- @since 1.7.1 
 colorField :: Monad m => RenderMessage (HandlerSite m) FormMessage => Field m Text
 colorField = Field
     { fieldParse = parseHelper $ \s ->

--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -62,6 +62,7 @@ module Yesod.Form.Fields
     , optionsPairs
     , optionsPairsGrouped
     , optionsEnum
+    , colorField
     ) where
 
 import Yesod.Form.Types
@@ -116,6 +117,8 @@ import Data.String (IsString)
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
+
+import Data.Char (isHexDigit)
 
 defaultFormMessage :: FormMessage -> Text
 defaultFormMessage = englishFormMessage
@@ -948,3 +951,21 @@ prependZero t0 = if T.null t1
 -- The basic datastructure used is an 'Option', which combines a user-facing display value, the internal Haskell value being selected, and an external 'Text' stored as the @value@ in the form (used to map back to the internal value). A list of these, together with a function mapping from an external value back to a Haskell value, form an 'OptionList', which several of these functions take as an argument.
 -- 
 -- Typically, you won't need to create an 'OptionList' directly and can instead make one with functions like 'optionsPairs' or 'optionsEnum'. Alternatively, you can use functions like 'selectFieldList', which use their @[(msg, a)]@ parameter to create an 'OptionList' themselves.
+
+-- | Creates an input with @type="color"@.
+--   The input value must be provided in hexadecimal format #rrggbb.
+colorField :: Monad m => RenderMessage (HandlerSite m) FormMessage => Field m Text
+colorField = Field
+    { fieldParse = parseHelper $ \s ->
+        if isHexColor $ unpack s then Right s
+        else Left $ MsgInvalidHexColorFormat s
+    , fieldView = \theId name attrs val _ -> [whamlet|
+$newline never
+<input ##{theId} name=#{name} *{attrs} type=color value=#{either id id val}>
+|]
+    , fieldEnctype = UrlEncoded
+    }
+  where
+      isHexColor :: String -> Bool
+      isHexColor ['#',a,b,c,d,e,f] = all isHexDigit [a,b,c,d,e,f]
+      isHexColor _ = False

--- a/yesod-form/Yesod/Form/I18n/Chinese.hs
+++ b/yesod-form/Yesod/Form/I18n/Chinese.hs
@@ -24,3 +24,4 @@ chineseFormMessage (MsgInvalidBool t) = "无效的逻辑值: " `mappend` t
 chineseFormMessage MsgBoolYes = "是"
 chineseFormMessage MsgBoolNo = "否"
 chineseFormMessage MsgDelete = "删除?"
+chineseFormMessage (MsgInvalidHexColorFormat t) = "颜色无效，必须为 #rrggbb 十六进制格式: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Croatian.hs
+++ b/yesod-form/Yesod/Form/I18n/Croatian.hs
@@ -24,3 +24,4 @@ croatianFormMessage (MsgInvalidBool t)    = "Logička vrijednost nije valjana: "
 croatianFormMessage MsgBoolYes            = "Da"
 croatianFormMessage MsgBoolNo             = "Ne"
 croatianFormMessage MsgDelete             = "Izbrisati?"
+croatianFormMessage (MsgInvalidHexColorFormat t) = "Nevažeća boja, mora biti u #rrggbb heksadecimalnom formatu: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Czech.hs
+++ b/yesod-form/Yesod/Form/I18n/Czech.hs
@@ -24,3 +24,4 @@ czechFormMessage (MsgInvalidBool t) = "Neplatná pravdivostní hodnota: " `mappe
 czechFormMessage MsgBoolYes = "Ano"
 czechFormMessage MsgBoolNo = "Ne"
 czechFormMessage MsgDelete = "Smazat?"
+czechFormMessage (MsgInvalidHexColorFormat t) = "Neplatná barva, musí být v #rrggbb hexadecimálním formátu: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Dutch.hs
+++ b/yesod-form/Yesod/Form/I18n/Dutch.hs
@@ -24,3 +24,4 @@ dutchFormMessage (MsgInvalidBool t)    = "Ongeldige waarheidswaarde: " `mappend`
 dutchFormMessage MsgBoolYes            = "Ja"
 dutchFormMessage MsgBoolNo             = "Nee"
 dutchFormMessage MsgDelete             = "Verwijderen?"
+dutchFormMessage (MsgInvalidHexColorFormat t) = "Ongeldige kleur, moet de hexadecimale indeling #rrggbb hebben: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/English.hs
+++ b/yesod-form/Yesod/Form/I18n/English.hs
@@ -24,3 +24,4 @@ englishFormMessage (MsgInvalidBool t) = "Invalid boolean: " `mappend` t
 englishFormMessage MsgBoolYes = "Yes"
 englishFormMessage MsgBoolNo = "No"
 englishFormMessage MsgDelete = "Delete?"
+englishFormMessage (MsgInvalidHexColorFormat t) = "Invalid color, must be in #rrggbb hexadecimal format: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/French.hs
+++ b/yesod-form/Yesod/Form/I18n/French.hs
@@ -24,3 +24,4 @@ frenchFormMessage (MsgInvalidBool t) = "Booléen invalide : " `mappend` t
 frenchFormMessage MsgBoolYes = "Oui"
 frenchFormMessage MsgBoolNo = "Non"
 frenchFormMessage MsgDelete = "Détruire ?"
+frenchFormMessage (MsgInvalidHexColorFormat t) = "Couleur non valide, doit être au format hexadécimal #rrggbb: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/German.hs
+++ b/yesod-form/Yesod/Form/I18n/German.hs
@@ -24,3 +24,4 @@ germanFormMessage (MsgInvalidBool t) = "Ungültiger Wahrheitswert: " `mappend` t
 germanFormMessage MsgBoolYes = "Ja"
 germanFormMessage MsgBoolNo = "Nein"
 germanFormMessage MsgDelete = "Löschen?"
+germanFormMessage (MsgInvalidHexColorFormat t) = "Ungültige Farbe, muss im Hexadezimalformat #rrggbb vorliegen: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Japanese.hs
+++ b/yesod-form/Yesod/Form/I18n/Japanese.hs
@@ -24,3 +24,4 @@ japaneseFormMessage (MsgInvalidBool t) = "無効なbool値です: " `mappend` t
 japaneseFormMessage MsgBoolYes = "はい"
 japaneseFormMessage MsgBoolNo = "いいえ"
 japaneseFormMessage MsgDelete = "削除しますか?"
+japaneseFormMessage (MsgInvalidHexColorFormat t) = "無効な色。＃rrggbb16進形式である必要があります: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Korean.hs
+++ b/yesod-form/Yesod/Form/I18n/Korean.hs
@@ -24,3 +24,4 @@ koreanFormMessage (MsgInvalidBool t) = "잘못된 불(boolean)입니다: " `mapp
 koreanFormMessage MsgBoolYes = "예"
 koreanFormMessage MsgBoolNo = "아니오"
 koreanFormMessage MsgDelete = "삭제하시겠습니까?"
+koreanFormMessage (MsgInvalidHexColorFormat t) = "색상이 잘못되었습니다. #rrggbb 16진수 형식이어야 합니다.: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Norwegian.hs
+++ b/yesod-form/Yesod/Form/I18n/Norwegian.hs
@@ -24,3 +24,4 @@ norwegianBokmålFormMessage MsgBoolYes = "Ja"
 norwegianBokmålFormMessage MsgBoolNo = "Nei"
 norwegianBokmålFormMessage MsgDelete = "Slette?"
 norwegianBokmålFormMessage MsgCsrfWarning = "Som beskyttelse mot «cross-site request forgery»-angrep, vennligst bekreft innsendt skjema."
+norwegianBokmålFormMessage (MsgInvalidHexColorFormat t) = "Ugyldig farge, må være i #rrggbb heksadesimalt format: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Portuguese.hs
+++ b/yesod-form/Yesod/Form/I18n/Portuguese.hs
@@ -24,3 +24,4 @@ portugueseFormMessage (MsgInvalidBool t) = "Booleano inválido: " `mappend` t
 portugueseFormMessage MsgBoolYes = "Sim"
 portugueseFormMessage MsgBoolNo = "Não"
 portugueseFormMessage MsgDelete = "Remover?"
+portugueseFormMessage (MsgInvalidHexColorFormat t) = "Cor inválida, deve estar no formato #rrggbb hexadecimal: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Russian.hs
+++ b/yesod-form/Yesod/Form/I18n/Russian.hs
@@ -24,3 +24,4 @@ russianFormMessage (MsgInvalidBool t) = "Неверное логическое �
 russianFormMessage MsgBoolYes = "Да"
 russianFormMessage MsgBoolNo = "Нет"
 russianFormMessage MsgDelete = "Удалить?"
+russianFormMessage (MsgInvalidHexColorFormat t) = "Недопустимое значение цвета, должен быть в шестнадцатеричном формате #rrggbb: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Spanish.hs
+++ b/yesod-form/Yesod/Form/I18n/Spanish.hs
@@ -25,3 +25,4 @@ spanishFormMessage (MsgInvalidBool t) = "Booleano inválido: " `mappend` t
 spanishFormMessage MsgBoolYes = "Sí"
 spanishFormMessage MsgBoolNo = "No"
 spanishFormMessage MsgDelete = "¿Eliminar?"
+spanishFormMessage (MsgInvalidHexColorFormat t) = "Color no válido, debe estar en formato hexadecimal #rrggbb: " `mappend` t

--- a/yesod-form/Yesod/Form/I18n/Swedish.hs
+++ b/yesod-form/Yesod/Form/I18n/Swedish.hs
@@ -24,3 +24,4 @@ swedishFormMessage MsgBoolYes = "Ja"
 swedishFormMessage MsgBoolNo = "Nej"
 swedishFormMessage MsgDelete = "Radera?"
 swedishFormMessage MsgCsrfWarning = "Som skydd mot \"cross-site request forgery\" attacker, vänligen bekräfta skickandet av formuläret."
+swedishFormMessage (MsgInvalidHexColorFormat t) = "Ogiltig färg, måste vara i #rrggbb hexadecimalt format: " `mappend` t

--- a/yesod-form/Yesod/Form/Types.hs
+++ b/yesod-form/Yesod/Form/Types.hs
@@ -229,4 +229,5 @@ data FormMessage = MsgInvalidInteger Text
                  | MsgBoolYes
                  | MsgBoolNo
                  | MsgDelete
+                 | MsgInvalidHexColorFormat Text
     deriving (Show, Eq, Read)

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            yesod-form
-version:         1.7.0
+version:         1.7.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Reference issue #1747

This PR adds a new `colorField` function to create an html color field (`<input type="color">`) as described at [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/color](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/color)
<hr>
Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
