### PR TITLE
Fix catch async exception on request threads

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add missing list to documentation for ``Yesod.Core.Dispatch.warp``. [#1745](https://github.com/yesodweb/yesod/pull/1745)
+* Handle async exceptions within yesod rather then warp. [#1753](https://github.com/yesodweb/yesod/pull/1753)
 
 ## 1.6.21.0
 

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -5,8 +5,21 @@
 {-# LANGUAGE TemplateHaskell   #-}
 {-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE FlexibleContexts  #-}
-module Yesod.Core.Internal.Run where
-
+module Yesod.Core.Internal.Run
+  ( toErrorHandler
+  , errFromShow
+  , basicRunHandler
+  , handleError
+  , handleContents
+  , evalFallback
+  , runHandler
+  , safeEh
+  , runFakeHandler
+  , yesodRunner
+  , yesodRender
+  , resolveApproot
+  )
+  where
 
 import Yesod.Core.Internal.Response
 import           Data.ByteString.Builder      (toLazyByteString)

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -96,7 +96,7 @@ basicRunHandler :: ToTypedContent c
                 -> YesodRequest
                 -> InternalState
                 -> IO (GHState, HandlerContents)
-basicRunHandler rhe handler yreq resState = mask $ \unmask -> do
+basicRunHandler rhe handler yreq resState = do
     -- Create a mutable ref to hold the state. We use mutable refs so
     -- that the updates will survive runtime exceptions.
     istate <- I.newIORef defState
@@ -104,7 +104,7 @@ basicRunHandler rhe handler yreq resState = mask $ \unmask -> do
     -- Run the handler itself, capturing any runtime exceptions and
     -- converting them into a @HandlerContents@
     contents' <- unsafeAsyncCatch
-        (unmask $ do
+        (do
             res <- unHandlerFor handler (hd istate)
             tc <- evaluate (toTypedContent res)
             -- Success! Wrap it up in an @HCContent@
@@ -218,9 +218,9 @@ runHandler :: ToTypedContent c
            => RunHandlerEnv site site
            -> HandlerFor site c
            -> YesodApp
-runHandler rhe@RunHandlerEnv {..} handler yreq = withInternalState $ \resState -> mask $ \unmask -> do
+runHandler rhe@RunHandlerEnv {..} handler yreq = withInternalState $ \resState -> do
     -- Get the raw state and original contents
-    (state, contents0) <- unmask $ basicRunHandler rhe handler yreq resState
+    (state, contents0) <- basicRunHandler rhe handler yreq resState
 
     -- Evaluate the unfortunately-lazy session and headers,
     -- propagating exceptions into the contents

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.21.0
+version:         1.6.22.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Solves this issue: https://github.com/yesodweb/yesod/issues/1751

Async exceptions for request threads are currently handled by warp, 
it's better if yesod handles these so that we get a nice rendered error page.

Not sure if we should mask the error runners as well, but it seems rather unlikely they get an async exception.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
