### PR TITLE
Expose SIO type

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-test
 
+## TODO
+
+* Add `Yesod.Test.Internal.SIO` module to expose the `SIO` type.
+
 ## 1.6.12
 
 * Fix import in cookie example [#1713](https://github.com/yesodweb/yesod/pull/1713)

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,6 +1,6 @@
 # ChangeLog for yesod-test
 
-## TODO
+## 1.6.13
 
 * Add `Yesod.Test.Internal.SIO` module to expose the `SIO` type.
 

--- a/yesod-test/Yesod/Test/Internal/SIO.hs
+++ b/yesod-test/Yesod/Test/Internal/SIO.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | The 'SIO' type is used by "Yesod.Test" to provide exception-safe
+-- environment between requests and assertions.
+--
+-- This module is internal. Breaking changes to this module will not be
+-- reflected in the major version of this package.
+--
+-- @since TODO
+module Yesod.Test.Internal.SIO where
+
+import Control.Monad.Trans.Reader (ReaderT (..))
+import Conduit (MonadThrow)
+import qualified Control.Monad.State.Class as MS
+import Yesod.Core
+import Data.IORef
+
+-- | State + IO
+--
+-- @since 1.6.0
+newtype SIO s a = SIO (ReaderT (IORef s) IO a)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadUnliftIO)
+
+instance MS.MonadState s (SIO s)
+  where
+  get = getSIO
+  put = putSIO
+
+getSIO :: SIO s s
+getSIO = SIO $ ReaderT readIORef
+
+putSIO :: s -> SIO s ()
+putSIO s = SIO $ ReaderT $ \ref -> writeIORef ref $! s
+
+modifySIO :: (s -> s) -> SIO s ()
+modifySIO f = SIO $ ReaderT $ \ref -> modifyIORef' ref f
+
+evalSIO :: SIO s a -> s -> IO a
+evalSIO (SIO (ReaderT f)) s = newIORef s >>= f
+
+execSIO :: SIO s () -> s -> IO s
+execSIO (SIO (ReaderT f)) s = do
+  ref <- newIORef s
+  f ref
+  readIORef ref

--- a/yesod-test/Yesod/Test/Internal/SIO.hs
+++ b/yesod-test/Yesod/Test/Internal/SIO.hs
@@ -15,7 +15,7 @@
 -- This module is internal. Breaking changes to this module will not be
 -- reflected in the major version of this package.
 --
--- @since TODO
+-- @since 1.6.13
 module Yesod.Test.Internal.SIO where
 
 import Control.Monad.Trans.Reader (ReaderT (..))
@@ -35,20 +35,54 @@ instance MS.MonadState s (SIO s)
   get = getSIO
   put = putSIO
 
+-- | Retrieve the current state in the 'SIO' type.
+--
+-- Equivalent to 'MS.get'
+--
+-- @since 1.6.13
 getSIO :: SIO s s
 getSIO = SIO $ ReaderT readIORef
 
+-- | Put the given @s@ into the 'SIO' state for later retrieval.
+--
+-- Equivalent to 'MS.put', but the value is evaluated to weak head normal
+-- form.
+--
+-- @since 1.6.13
 putSIO :: s -> SIO s ()
 putSIO s = SIO $ ReaderT $ \ref -> writeIORef ref $! s
 
+-- | Modify the underlying @s@ state.
+--
+-- This is strict in the function used, and is equivalent to 'MS.modify''.
+--
+-- @since 1.6.13
 modifySIO :: (s -> s) -> SIO s ()
 modifySIO f = SIO $ ReaderT $ \ref -> modifyIORef' ref f
 
+-- | Run an 'SIO' action with the intial state @s@ provided, returning the
+-- result, and discard the final state.
+--
+-- @since 1.6.13
 evalSIO :: SIO s a -> s -> IO a
-evalSIO (SIO (ReaderT f)) s = newIORef s >>= f
+evalSIO action =
+    fmap snd . runSIO action
 
+-- | Run an 'SIO' action with the initial state @s@ provided, returning the
+-- final state, and discarding the result.
+--
+-- @since 1.6.13
 execSIO :: SIO s () -> s -> IO s
-execSIO (SIO (ReaderT f)) s = do
-  ref <- newIORef s
-  f ref
-  readIORef ref
+execSIO action =
+    fmap fst . runSIO action
+
+-- | Run an 'SIO' action with the initial state provided, returning both
+-- the result of the computation as well as the final state.
+--
+-- @since 1.6.13
+runSIO :: SIO s a -> s -> IO (s, a)
+runSIO (SIO (ReaderT f)) s = do
+    ref <- newIORef s
+    a <- f ref
+    s' <- readIORef ref
+    pure (s', a)

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.12
+version:            1.6.13
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -46,6 +46,7 @@ library
                      Yesod.Test.CssQuery
                      Yesod.Test.TransversingCSS
                      Yesod.Test.Internal
+                     Yesod.Test.Internal.SIO
     ghc-options:  -Wall
 
 test-suite test


### PR DESCRIPTION
I'm implementing a function at work `runYesodExample :: TestApp site -> YesodExample site a -> IO a` so I can implement an instance of `Example (PropertyT IO (YesodExample App (PropertyT IO ())))` in the style of my [Effectful Property Testing](https://www.parsonsmatt.org/2020/03/11/effectful_property_testing.html) blog post.

In order to do this, I need the `SIO` type to be exposed.

I can work-around this by `unsafeCoerce`ing the `SIO` into the `ReaderT (IORef s) IO` that it truly is, but this is pretty awful.

Additionally, if I go ahead with `yesod-hspec`, it'd be nice to have the same `SIO` type underlying them, to avoid any potential issues.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
