### PR TITLE
Fix typo in how description meta tags are laid out

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.23.1
+
+* Fix typo in creation of the description `<meta>` tag in `defaultLayout`. [#1766](https://github.com/yesodweb/yesod/pull/1766)
+
 ## 1.6.23
 
 * Add idempotent versions of `setDescription`, `setDescriptionI`. These functions

--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -88,7 +88,7 @@ class RenderRoute site => Yesod site where
                 <head>
                     <title>#{pageTitle p}
                     $maybe description <- pageDescription p
-                      <meta type="description" content="#{description}">
+                      <meta name="description" content="#{description}">
                     ^{pageHead p}
                 <body>
                     $forall (status, msg) <- msgs

--- a/yesod-core/test/YesodCoreTest/Meta.hs
+++ b/yesod-core/test/YesodCoreTest/Meta.hs
@@ -48,7 +48,7 @@ metaTest = describe "Setting page metadata" $ do
             res <- request defaultRequest
                         { pathInfo = ["desc"]
                         }
-            assertBody "<!DOCTYPE html>\n<html><head><title></title><meta type=\"description\" content=\"Second description\"></head><body></body></html>" res
+            assertBody "<!DOCTYPE html>\n<html><head><title></title><meta name=\"description\" content=\"Second description\"></head><body></body></html>" res
 
 runner :: Session () -> IO ()
 runner f = toWaiAppPlain App >>= runSession f

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.23
+version:         1.6.23.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This is a silly typo I made.

---

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
