### PR TITLE
Fix quote ' not matching in htmlContain* functions

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -2,8 +2,8 @@
 
 ## 1.6.14
 
-* Fix quotes not matching in htmlContain* functions.
-* Add logging of the matches found of these functions.
+* Fix quotes not matching in htmlContain* functions [#1768](https://github.com/yesodweb/yesod/pull/1768).
+* Add logging of the matches found of these functions [#1768](https://github.com/yesodweb/yesod/pull/1768).
 
 ## 1.6.13
 

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for yesod-test
 
+## 1.6.14
+
+* Fix quotes not matching in htmlContain* functions.
+* Add logging of the matches found of these functions.
+
 ## 1.6.13
 
 * Add `Yesod.Test.Internal.SIO` module to expose the `SIO` type.

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.13
+version:            1.6.14
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -41,6 +41,7 @@ library
                    , xml-conduit               >= 1.0
                    , xml-types                 >= 0.3
                    , yesod-core                >= 1.6.17
+                   , blaze-markup
 
     exposed-modules: Yesod.Test
                      Yesod.Test.CssQuery


### PR DESCRIPTION
This sometimes occurred in our code base when generating
names with the fakedata package, someone named o'conner
randomly fails a particular test.

Also add tests for the other matching function and fixed them.
Furthermore, I added logging of the matches as well.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] (not relevant) Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] (not relevant)  Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
