### PR TITLE
Update monad-logger upper bound

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -43,7 +43,7 @@ library
                    , fast-logger           >= 2.2
                    , http-types            >= 0.7
                    , memory
-                   , monad-logger          >= 0.3.10   && < 0.4
+                   , monad-logger          >= 0.3.10   && < 0.3.38
                    , mtl
                    , parsec                >= 2        && < 3.2
                    , path-pieces           >= 0.1.2    && < 0.3


### PR DESCRIPTION
0.3.38 (which I think should have been 0.4?) removed instances that `yesod-core` depended on. Without this, we get:

```
src/Yesod/Core/Class/Handler.hs:79:10: error:
    • Could not deduce (MonadLogger (ListT m))
        arising from the superclasses of an instance declaration
      from the context: MonadHandler m
        bound by the instance declaration
        at src/Yesod/Core/Class/Handler.hs:79:10-49
    • In the instance declaration for ‘MonadHandler (ListT m)’
   |
79 | GO(ListT)
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
