### PR TITLE
Support `JSONPath` in error messages

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.24.2
+version:         1.6.25
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -26,7 +26,7 @@ library
     hs-source-dirs: src
 
     build-depends:   base                  >= 4.10     && < 5
-                   , aeson                 >= 1.0
+                   , aeson                 >= 2.1.0.0
                    , auto-update
                    , blaze-html            >= 0.5
                    , blaze-markup          >= 0.7.1


### PR DESCRIPTION
JSON error messages can optionally include the JSON path so that you get a nicer error like `Error in $.foo.bar: rest of the message`. The trick is to parse into an `IResult` instead of a `Result` since `IResult` includes a `JSONPath`.

This also updates the `requre*JsonBody` utilites to use these new `IResult`-based utilities, so anything that depends on them will automatically pick up improved error messages.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
