### PR TITLE
Fix SubSub compilation for GHC >= 9.0.1

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.24.4
+
+* Fix test-suite compilation error for GHC >= 9.0.1 [#1812](https://github.com/yesodweb/yesod/pull/1812)
+
 ## 1.6.24.3
 
 * Fix subsite-to-subsite dispatch [#1805](https://github.com/yesodweb/yesod/pull/1805)

--- a/yesod-core/test/YesodCoreTest/SubSub.hs
+++ b/yesod-core/test/YesodCoreTest/SubSub.hs
@@ -18,6 +18,10 @@ import YesodCoreTest.SubSubData
 
 data App = App { getOuter :: OuterSubSite }
 
+mkYesod "App" [parseRoutes|
+/ OuterSubSiteR OuterSubSite getOuter
+|]
+
 instance Yesod App
 
 getSubR :: SubHandlerFor InnerSubSite master T.Text
@@ -28,10 +32,6 @@ instance YesodSubDispatch OuterSubSite master where
 
 instance YesodSubDispatch InnerSubSite master where
   yesodSubDispatch = $(mkYesodSubDispatch resourcesInnerSubSite)
-
-mkYesod "App" [parseRoutes|
-/ OuterSubSiteR OuterSubSite getOuter
-|]
 
 app :: App
 app = App { getOuter = OuterSubSite { getInner = InnerSubSite }}

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.24.3
+version:         1.6.24.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Resolves #1811.

Related:

- https://stackoverflow.com/questions/73719275/evaluation-of-template-haskell-in-yesod?noredirect=1&lq=1

- https://github.com/yesodweb/yesodweb.com-content/pull/269

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] ~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~ N/A
- [ ] ~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs~ N/A

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
