### PR TITLE
Upstream helper functions to Yesod.Form.Option.

### DIFF
--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -3,8 +3,8 @@
 
 ## 1.7.7
 
-* Added `optionsFromList'` to create an OptionList from a List, using the PathPiece instance for the external value and a custom
-function for the user-facing value. Also added `optionsEnum'` to create an OptionList from an enumeration
+* Added `optionsFromList'` to create an OptionList from a List, using the PathPiece instance for the external value and
+a custom function for the user-facing value. Also added `optionsEnum'` to create an OptionList from an enumeration
 [#1828](https://github.com/yesodweb/yesod/pull/1828)
 
 ## 1.7.6

--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-form
 
+## 1.7.2
+
+* Added `optionsFromList'` to create an OptionList from a List, using the PathPiece instance for the external value and a custom function for the user-facing value. Also added `optionsEnum'` to create an OptionList from an enumeration [#1827](https://github.com/yesodweb/yesod/pull/1827)
+
 ## 1.7.1
 
 * Added `colorField` for creating a html color field (`<input type="color">`) [#1748](https://github.com/yesodweb/yesod/pull/1748)

--- a/yesod-form/Yesod/Form/Option.hs
+++ b/yesod-form/Yesod/Form/Option.hs
@@ -17,13 +17,6 @@ import Yesod.Form.Fields
 --
 -- === __Example usage__
 --
--- @messages/en.msg
--- > MsgSalesTeam: Sales Team
--- > MsgSalesHead: Head of Sales Team
--- > MsgTechTeam: Tech Team
--- > MsgTechHead: Head of Tech Team
---
--- @example.hs
 -- > data UserRole = URSalesTeam | URSalesHead | URTechTeam | URTechHead
 -- >
 -- > instance PathPiece UserDepartment where
@@ -44,11 +37,12 @@ import Yesod.Form.Fields
 -- > userRoleOptions = optionsFromList' userRoles toMsg
 -- >   where
 -- >   userRoles = [URSalesTeam, URSalesHead, URTechTeam, URTechHead]
+-- >   toMsg :: UserRole -> Text
 -- >   toMsg = \case
--- >     URSalesTeam -> MsgSalesTeam
--- >     URSalesHead -> MsgSalesHead
--- >     URTechTeam -> MsgTechTeam
--- >     URTechHead -> MsgTechHead
+-- >     URSalesTeam -> "Sales Team"
+-- >     URSalesHead -> "Head of Sales Team"
+-- >     URTechTeam -> "Tech Team"
+-- >     URTechHead -> "Head of Tech Team"
 --
 -- userRoleOptions, will produce an OptionList with the following attributes:
 --
@@ -63,6 +57,9 @@ import Yesod.Form.Fields
 -- > +----------------+----------------+--------------------+
 -- > | URTechHead     | tech-head      | Head of Tech Team  |
 -- > +----------------+----------------+--------------------+
+--
+-- Note that the type constraint allows localizable messages in place of toMsg (see
+-- https://en.wikipedia.org/wiki/Yesod_(web_framework)#Localizable_messages).
 
 optionsFromList' ::
      MonadHandler m

--- a/yesod-form/Yesod/Form/Option.hs
+++ b/yesod-form/Yesod/Form/Option.hs
@@ -5,11 +5,65 @@ module Yesod.Form.Option where
 import Yesod.Core
 import Yesod.Form.Fields
 
--- | Creates an 'OptionList' from a 'List', using the 'PathPiece' instance for
+-- | Creates an `OptionList` from a `List`, using the `PathPiece` instance for
 -- the external value and a custom function for the user-facing value.
--- NB: We choose PathPiece as the most suitable class for generating External
--- Values. The motivation is to avoid Show/Read instances which could leak
--- an internal representation to forms, query params, javascript etc.
+--
+-- @since 1.7.7
+--
+-- PathPiece instances should provide suitable external values, since path
+-- pieces serve to be exposed through URLs or HTML anyway. Show/Read instances
+-- are avoided here since they could leak internal representations to forms,
+-- query params, javascript etc.
+--
+-- === __Example usage__
+--
+-- @messages/en.msg
+-- > MsgSalesTeam: Sales Team
+-- > MsgSalesHead: Head of Sales Team
+-- > MsgTechTeam: Tech Team
+-- > MsgTechHead: Head of Tech Team
+--
+-- @example.hs
+-- > data UserRole = URSalesTeam | URSalesHead | URTechTeam | URTechHead
+-- >
+-- > instance PathPiece UserDepartment where
+-- >   toPathPiece = \case
+-- >     URSalesTeam -> "sales-team"
+-- >     URSalesHead -> "sales-head"
+-- >     URTechTeam -> "tech-team"
+-- >     URTechHead -> "tech-head"
+-- >   fromPathPiece = \case
+-- >     "sales-team" -> Just URSalesTeam
+-- >     "sales-head" -> Just URSalesHead
+-- >     "tech-team" -> Just URTechTeam
+-- >     "tech-head" -> Just URTechHead
+-- >     _ -> Nothing
+-- >
+-- > userRoleOptions ::
+-- >   (MonadHandler m, RenderMessage (HandlerSite m) msg) => m (OptionList UserRole)
+-- > userRoleOptions = optionsFromList' userRoles toMsg
+-- >   where
+-- >   userRoles = [URSalesTeam, URSalesHead, URTechTeam, URTechHead]
+-- >   toMsg = \case
+-- >     URSalesTeam -> MsgSalesTeam
+-- >     URSalesHead -> MsgSalesHead
+-- >     URTechTeam -> MsgTechTeam
+-- >     URTechHead -> MsgTechHead
+--
+-- userRoleOptions, will produce an OptionList with the following attributes:
+--
+-- > +----------------+----------------+--------------------+
+-- > | Internal Value | External Value | User-facing Value  |
+-- > +----------------+----------------+--------------------+
+-- > | URSalesTeam    | sales-team     | Sales Team         |
+-- > +----------------+----------------+--------------------+
+-- > | URSalesHead    | sales-head     | Head of Sales Team |
+-- > +----------------+----------------+--------------------+
+-- > | URTechTeam     | tech-team      | Tech Team          |
+-- > +----------------+----------------+--------------------+
+-- > | URTechHead     | tech-head      | Head of Tech Team  |
+-- > +----------------+----------------+--------------------+
+
 optionsFromList' ::
      MonadHandler m
   => RenderMessage (HandlerSite m) msg
@@ -25,7 +79,15 @@ optionsFromList' lst toDisplay = do
     , optionExternalValue = toPathPiece v
     }
 
--- | Creates an 'OptionList' from an 'Enum'
+-- | Creates an `OptionList` from an `Enum`.
+--
+-- @since 1.7.7
+--
+-- optionsEnum' == optionsFromList' [minBound..maxBound]
+--
+-- Creates an `OptionList` containing every constructor of `a`, so that these
+-- constructors do not need to be typed out. Bounded and Enum instances must
+-- exist for `a` to use this.
 optionsEnum' ::
      MonadHandler m
   => RenderMessage (HandlerSite m) msg

--- a/yesod-form/Yesod/Form/Option.hs
+++ b/yesod-form/Yesod/Form/Option.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Yesod.Form.Option where
+
+import Yesod.Core
+import Yesod.Form.Fields
+
+-- | Creates an 'OptionList' from a 'List', using the 'PathPiece' instance for
+-- the external value and a custom function for the user-facing value.
+-- NB: We choose PathPiece as the most suitable class for generating External
+-- Values. The motivation is to avoid Show/Read instances which could leak
+-- an internal representation to forms, query params, javascript etc.
+optionsFromList' ::
+     MonadHandler m
+  => RenderMessage (HandlerSite m) msg
+  => PathPiece a
+  => [a]
+  -> (a -> msg)
+  -> m (OptionList a)
+optionsFromList' lst toDisplay = do
+  mr <- getMessageRender
+  pure $ mkOptionList $ flip map lst $ \v -> Option
+    { optionDisplay = mr $ toDisplay v
+    , optionInternalValue = v
+    , optionExternalValue = toPathPiece v
+    }
+
+-- | Creates an 'OptionList' from an 'Enum'
+optionsEnum' ::
+     MonadHandler m
+  => RenderMessage (HandlerSite m) msg
+  => PathPiece a
+  => Enum a
+  => Bounded a
+  => (a -> msg)
+  -> m (OptionList a)
+optionsEnum' = optionsFromList' [minBound..maxBound]

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            yesod-form
-version:         1.7.1
+version:         1.7.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -46,6 +46,7 @@ library
       build-depends: network-uri >= 2.6
 
     exposed-modules: Yesod.Form
+                     Yesod.Form.Option
                      Yesod.Form.Types
                      Yesod.Form.Functions
                      Yesod.Form.Bootstrap3


### PR DESCRIPTION
The 2 new functions are:
- optionsFromList': creates an OptionList from a List, using the PathPiece instance for the external value and a custom function for the user-facing value.
- optionsEnum': creates an OptionList from an enumeration.

Also bump the version and update the changelog.

Before submitting your PR, check that you've:

- [X] Bumped the version number
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)

After submitting your PR:

- [X] Update the Changelog.md file with a link to your PR
- [] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
