### PR TITLE
Update haddock on assertEq to specify the expected and actual value ordering

### DIFF
--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -546,7 +546,11 @@ htmlQuery = htmlQuery' yedResponse []
 -- In case they are not equal, the error message includes the two values.
 --
 -- @since 1.5.2
-assertEq :: (HasCallStack, Eq a, Show a) => String -> a -> a -> YesodExample site ()
+assertEq :: (HasCallStack, Eq a, Show a)
+  => String -- ^ The message prefix
+  -> a      -- ^ The expected value
+  -> a      -- ^ The actual value
+  -> YesodExample site ()
 assertEq m a b =
   liftIO $ HUnit.assertEqual msg a b
   where msg = "Assertion: " ++ m ++ "\n"
@@ -857,7 +861,7 @@ addGetParam name value = modifySIO $ \rbd -> rbd
 -- parameter and no other parameters.
 --
 -- @since 1.6.16
--- 
+--
 -- ==== __Examples__
 --
 -- > {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [X] Bumped the version number
(Documentation updates don't need a version number bump)
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
(Just improving documentation to match the docs for the underlying [HUnit](https://hackage.haskell.org/package/HUnit-1.6.2.0/docs/Test-HUnit-Base.html#v:assertEqual) implementation.)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs
N/A

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
