### PR TITLE
Always apply jsAttributes to scritps in body

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.26.0
+
+* Always apply jsAttributes to julius script blocks of body [#1836](https://github.com/yesodweb/yesod/pull/1836)
+
 ## 1.6.25.1
 
 * Export the options that were created in 1.6.25.0 [#1825](https://github.com/yesodweb/yesod/pull/1825)

--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -595,7 +595,7 @@ widgetToPageContent w = do
                 $maybe s <- jsLoc
                     <script src="#{s}" *{jsAttrs}>
                 $nothing
-                    <script>^{jelper j}
+                    <script *{jsAttrs}>^{jelper j}
         |]
 
         headAll = [hamlet|

--- a/yesod-core/test/YesodCoreTest.hs
+++ b/yesod-core/test/YesodCoreTest.hs
@@ -17,6 +17,7 @@ import YesodCoreTest.ParameterizedSite
 import YesodCoreTest.Breadcrumb
 import qualified YesodCoreTest.WaiSubsite as WaiSubsite
 import qualified YesodCoreTest.Redirect as Redirect
+import qualified YesodCoreTest.JsAttributes as JsAttributes
 import qualified YesodCoreTest.JsLoader as JsLoader
 import qualified YesodCoreTest.RequestBodySize as RequestBodySize
 import qualified YesodCoreTest.Json as Json
@@ -51,6 +52,7 @@ specs = do
       parameterizedSiteTest
       WaiSubsite.specs
       Redirect.specs
+      JsAttributes.specs
       JsLoader.specs
       RequestBodySize.specs
       Json.specs

--- a/yesod-core/test/YesodCoreTest/JsAttributes.hs
+++ b/yesod-core/test/YesodCoreTest/JsAttributes.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE QuasiQuotes, TypeFamilies, TemplateHaskell, MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
+module YesodCoreTest.JsAttributes
+    ( specs
+      -- To avoid unused warning
+    , Widget
+    , resourcesApp
+    ) where
+
+import Test.Hspec
+
+import Yesod.Core
+import Network.Wai.Test
+
+data App = App
+mkYesod "App" [parseRoutes|
+/ HeadR GET
+|]
+instance Yesod App where
+    jsAttributes _ = [("attr0", "a")]
+
+getHeadR :: Handler Html
+getHeadR = defaultLayout $ do
+    addScriptRemote "load.js"
+    toWidget [julius|/*body*/|]
+    toWidgetHead [julius|/*head*/|]
+
+specs :: Spec
+specs = describe "Test.JsAttributes" $ do
+    it "script in body gets attributes" $ runner App $ do
+      res <- request defaultRequest
+      assertBody "<!DOCTYPE html>\n<html><head><title></title><script>/*head*/</script></head><body><script src=\"load.js\"></script><script attr0=\"a\">/*body*/</script></body></html>" res
+
+runner :: YesodDispatch master => master -> Session () -> IO ()
+runner app f = toWaiApp app >>= runSession f
+

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -142,6 +142,7 @@ test-suite tests
 
     other-modules: YesodCoreTest
                    YesodCoreTest.Auth
+                   YesodCoreTest.Breadcrumb
                    YesodCoreTest.Cache
                    YesodCoreTest.CleanPath
                    YesodCoreTest.Header

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.25.1
+version:         1.6.26.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -151,6 +151,7 @@ test-suite tests
                    YesodCoreTest.ErrorHandling.CustomApp
                    YesodCoreTest.Exceptions
                    YesodCoreTest.InternalRequest
+                   YesodCoreTest.JsAttributes
                    YesodCoreTest.JsLoader
                    YesodCoreTest.JsLoaderSites.Bottom
                    YesodCoreTest.Json


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

Discussion over here https://github.com/yesodweb/yesod/issues/1835 but basically right now these jsAttributes only apply if you have cached the script to a location and are unusable otherwise.