### PR TITLE
Stop testing against stackage lts 11/12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,8 +20,6 @@ jobs:
         - "--resolver lts-18"
         - "--resolver lts-16"
         - "--resolver lts-14"
-        - "--resolver lts-12"
-        - "--resolver lts-11"
         # Bugs in GHC make it crash too often to be worth running
         exclude:
           - os: windows-latest
@@ -30,10 +28,6 @@ jobs:
             args: "--resolver lts-16"
           - os: macos-latest
             args: "--resolver lts-14"
-          - os: macos-latest
-            args: "--resolver lts-12"
-          - os: macos-latest
-            args: "--resolver lts-11"
 
     steps:
       - name: Clone project


### PR DESCRIPTION
since the requirement for attoparsec-aeson >= 2.1 was added this will no longer ever succeed

Before submitting your PR, check that you've:

After submitting your PR:

- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->


Since the MR that required attoparsec-aeson >= 2.1 https://github.com/yesodweb/yesod/pull/1818 then the older LTS that only have older aesons will never pass. This is confusing for any future MRs and seems like it should be removed it no one expects it to pass again.

Similarly there are two macos tests that fail as `stack` is not present, perhaps these should be removed until fixed also