### PR TITLE
Use crypton instead of cryptonite

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -18,3 +18,4 @@ packages:
 extra-deps:
 - attoparsec-aeson-2.1.0.0
 - crypton-1.0.0
+- crypton-conduit-0.2.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,3 +17,4 @@ packages:
 
 extra-deps:
 - attoparsec-aeson-2.1.0.0
+- crypton-1.0.0

--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-auth
 
+## 1.6.11.4
+
+* Use crypton instead of cryptonite [#1838](https://github.com/yesodweb/yesod/pull/1838)
+
 ## 1.6.11.3
 
 * Add Romanian translation [#1809](https://github.com/yesodweb/yesod/pull/1809)

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >=1.10
 name:            yesod-auth
-version:         1.6.11.3
+version:         1.6.11.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin
@@ -35,7 +35,7 @@ library
                    , conduit                 >= 1.3
                    , conduit-extra
                    , containers
-                   , cryptonite
+                   , crypton
                    , data-default
                    , email-validate          >= 1.0
                    , file-embed

--- a/yesod-static/ChangeLog.md
+++ b/yesod-static/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-static
 
+## 1.6.1.1
+
+* Use crypton instead of cryptonite [#1838](https://github.com/yesodweb/yesod/pull/1838)
+
 ## 1.6.1.0
 
 * Support reproducible embedded file order [#1684](https://github.com/yesodweb/yesod/issues/1684#issuecomment-652562514)

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -1,5 +1,5 @@
 name:            yesod-static
-version:         1.6.1.0
+version:         1.6.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -35,8 +35,8 @@ library
                    , bytestring            >= 0.9.1.4
                    , conduit               >= 1.3
                    , containers            >= 0.2
-                   , cryptonite            >= 0.11
-                   , cryptonite-conduit    >= 0.1
+                   , crypton               >= 1.0
+                   , crypton-conduit       >= 0.2.3
                    , css-text              >= 0.1.2
                    , data-default
                    , directory             >= 1.0
@@ -98,8 +98,8 @@ test-suite tests
                    , bytestring
                    , conduit
                    , containers
-                   , cryptonite
-                   , cryptonite-conduit
+                   , crypton
+                   , crypton-conduit
                    , data-default
                    , directory
                    , file-embed


### PR DESCRIPTION
Cryptonite has been archived on GitHub, and it has been forked to crypton. See

* https://github.com/commercialhaskell/stackage/issues/7474

Tested using

    nice cabal build yesod-static yesod-auth -c 'cryptonite<0' -w ghc-9.6.5 -c 'clientsession>=0.9.3.0' -c 'cprng-aes<0'

This depends on

* https://github.com/yesodweb/clientsession/pull/40

Before submitting your PR, check that you've:

- [X] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
