### PR TITLE
yesod-test.cabal: switch to https url for git

### DIFF
--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -75,4 +75,4 @@ test-suite test
 
 source-repository head
   type: git
-  location: git://github.com/yesodweb/yesod.git
+  location: https://github.com/yesodweb/yesod.git


### PR DESCRIPTION
git:// is not widely supported, so better not to use.

IWBN to have a issues link too, but this minimal change seems good enough... so one can directly reach the github repo from the Hackage page

