### PR TITLE
Add upper bound on wai-extra

### DIFF
--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -61,7 +61,7 @@ library
                    , unordered-containers  >= 0.2
                    , vector                >= 0.9      && < 0.14
                    , wai                   >= 3.2
-                   , wai-extra             >= 3.0.7
+                   , wai-extra             >= 3.0.7    && < 3.1.17
                    , wai-logger            >= 0.2
                    , warp                  >= 3.0.2
                    , word8


### PR DESCRIPTION
`wai-extra-3.1.17` has breaking changes.

cf https://github.com/yesodweb/yesod/issues/1854

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
