### PR TITLE
yesod-core: Dispatch builds with 'wai-extra >= 3.0.7' again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,16 +15,17 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         args:
-        - "--resolver lts-22"
-        - "--resolver lts-20"
-        - "--resolver lts-18"
-        - "--resolver lts-16"
+        - "--resolver lts-23"
+        - "--resolver lts-22 --stack-yaml stack-lts-22.yaml"
+        - "--resolver lts-20 --stack-yaml stack-lts-22.yaml"
+        - "--resolver lts-18 --stack-yaml stack-lts-22.yaml"
+        - "--resolver lts-16 --stack-yaml stack-lts-22.yaml"
         exclude:
           # llvm too new on macos-latest for ghc 8
           - os: macos-latest
-            args: "--resolver lts-18"
+            args: "--resolver lts-18 --stack-yaml stack-lts-22.yaml"
           - os: macos-latest
-            args: "--resolver lts-16"
+            args: "--resolver lts-16 --stack-yaml stack-lts-22.yaml"
 
     steps:
       - name: Clone project

--- a/stack-lts-22.yaml
+++ b/stack-lts-22.yaml
@@ -1,0 +1,21 @@
+resolver: lts-22.43
+packages:
+- ./yesod-core
+- ./yesod-static
+- ./yesod-persistent
+- ./yesod-newsfeed
+- ./yesod-form
+- ./yesod-form-multi
+- ./yesod-auth
+- ./yesod-auth-oauth
+- ./yesod-sitemap
+- ./yesod-test
+- ./yesod-bin
+- ./yesod
+- ./yesod-eventsource
+- ./yesod-websockets
+
+extra-deps:
+  - attoparsec-aeson-2.1.0.0
+  - crypton-1.0.0
+  - crypton-conduit-0.2.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.3
+resolver: lts-23.10
 packages:
 - ./yesod-core
 - ./yesod-static
@@ -15,7 +15,4 @@ packages:
 - ./yesod-eventsource
 - ./yesod-websockets
 
-extra-deps:
-- attoparsec-aeson-2.1.0.0
-- crypton-1.0.0
-- crypton-conduit-0.2.3
+extra-deps: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,17 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: attoparsec-aeson-2.1.0.0@sha256:fa83aba43bfa58490de8f274d19b9d58b6403a207b12cac5f93922102b084c52,1154
-    pantry-tree:
-      sha256: 294c3a8a19a7ddad58097e18c624c6b34894b3c4a4cc490759cb31d842db242a
-      size: 114
-  original:
-    hackage: attoparsec-aeson-2.1.0.0
+packages: []
 snapshots:
 - completed:
-    sha256: 694573e96dca34db5636edb1fe6c96bb233ca0f9fb96c1ead1671cdfa9bd73e9
-    size: 585603
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/3.yaml
-  original: lts-18.3
+    sha256: 889b6bffaf21cd509a7c6017703281e77c2f6df0a0908a11c85fa97fcbf11d4e
+    size: 680573
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/23/10.yaml
+  original: lts-23.10

--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 1.6.27.0
 
-* Build with `wai-extra-3.1.17` [#1861](https://github.com/yesodweb/yesod/pull/1860)
+* Build with `wai-extra-3.1.17` [#1861](https://github.com/yesodweb/yesod/pull/1861)
 
 ## 1.6.26.0
 

--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.27.0
+
+* Build with `wai-extra-3.1.17` [#1861](https://github.com/yesodweb/yesod/pull/1860)
+
 ## 1.6.26.0
 
 * Always apply jsAttributes to julius script blocks of body [#1836](https://github.com/yesodweb/yesod/pull/1836)

--- a/yesod-core/src/Yesod/Core/Dispatch.hs
+++ b/yesod-core/src/Yesod/Core/Dispatch.hs
@@ -1,8 +1,9 @@
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 module Yesod.Core.Dispatch
     ( -- * Quasi-quoted routing
       parseRoutes
@@ -63,6 +64,9 @@ import qualified Data.ByteString as S
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Char8 as S8
 import Data.ByteString.Builder (byteString, toLazyByteString)
+#if !MIN_VERSION_wai_extra(3,1,14)
+import Data.Default (def)
+#endif
 import Network.HTTP.Types (status301, status307)
 import Yesod.Routes.Parse
 import Yesod.Core.Types
@@ -78,7 +82,12 @@ import Yesod.Core.Internal.Util (getCurrentMaxExpiresRFC1123)
 import Network.Wai.Middleware.Autohead
 import Network.Wai.Middleware.AcceptOverride
 import Network.Wai.Middleware.RequestLogger
-import Network.Wai.Middleware.Gzip
+import Network.Wai.Middleware.Gzip (
+    gzip,
+#if MIN_VERSION_wai_extra(3,1,14)
+    defaultGzipSettings,
+#endif
+ )
 import Network.Wai.Middleware.MethodOverride
 
 import qualified Network.Wai.Handler.Warp
@@ -244,7 +253,12 @@ serverValue = S8.pack $ concat
 -- Since 1.2.0
 mkDefaultMiddlewares :: Logger -> IO W.Middleware
 mkDefaultMiddlewares logger = do
-    logWare <- mkRequestLogger def
+    logWare <- mkRequestLogger
+#if MIN_VERSION_wai_extra(3,1,8)
+        defaultRequestLoggerSettings
+#else
+        def
+#endif
         { destination = Network.Wai.Middleware.RequestLogger.Logger $ loggerSet logger
         , outputFormat = Apache FromSocket
         }
@@ -254,7 +268,14 @@ mkDefaultMiddlewares logger = do
 --
 -- Since 1.2.12
 defaultMiddlewaresNoLogging :: W.Middleware
-defaultMiddlewaresNoLogging = acceptOverride . autohead . gzip def . methodOverride
+defaultMiddlewaresNoLogging = acceptOverride . autohead . gzip gzipSettings . methodOverride
+  where
+    gzipSettings =
+#if MIN_VERSION_wai_extra(3,1,14)
+        defaultGzipSettings
+#else
+        def
+#endif
 
 -- | Deprecated synonym for 'warp'.
 warpDebug :: YesodDispatch site => Int -> site -> IO ()

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.26.0
+version:         1.6.27.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -39,6 +39,7 @@ library
                    , conduit-extra
                    , containers            >= 0.2
                    , cookie                >= 0.4.3    && < 0.6
+                   , data-default
                    , deepseq               >= 1.3
                    , entropy
                    , fast-logger           >= 2.2


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Sorry for the breakage, this should make it build with any wai-extra from 3.0.7 onwards again.