### PR TITLE
Update yesod-test.cabal

### DIFF
--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,10 @@
 # ChangeLog for yesod-test
 
+
+## 1.6.22
+
+- Add upper bounds to all build dependencies to comply with Hackage upload requirements. [#1873](https://github.com/yesodweb/yesod/pull/1873)
+
 ## 1.6.21
 
 * Add `browseBody` to yesod-test. [#1872](https://github.com/yesodweb/yesod/pull/1872)

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.21
+version:            1.6.22
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>
@@ -22,35 +22,35 @@ extra-source-files:
 library
   default-language: Haskell2010
   build-depends:
-      aeson
-    , attoparsec        >=0.10
-    , base              >=4.10   && <5
-    , blaze-builder
-    , blaze-html        >=0.5
-    , blaze-markup
-    , bytestring        >=0.9
-    , case-insensitive  >=0.2
-    , conduit
-    , containers
-    , cookie
-    , directory
-    , hspec-core        >=2      && <3
-    , html-conduit      >=0.1
-    , http-types        >=0.7
-    , HUnit             >=1.2
-    , memory
-    , mtl               >=2.0.0
-    , network           >=2.2
-    , pretty-show       >=1.6
-    , process
-    , text
-    , time
-    , transformers      >=0.2.2
-    , wai               >=3.0
-    , wai-extra
-    , xml-conduit       >=1.0
-    , xml-types         >=0.3
-    , yesod-core        >=1.6.17
+      aeson             >= 1.0     && < 2.3
+    , attoparsec        >= 0.10    && < 0.15
+    , base              >= 4.10    && < 5
+    , blaze-builder     >= 0.3.1   && < 0.5
+    , blaze-html        >= 0.5     && < 0.10
+    , blaze-markup      >= 0.6     && < 0.9
+    , bytestring        >= 0.9     && < 0.13
+    , case-insensitive  >= 0.2     && < 1.3
+    , conduit           >= 1.3     && < 1.4
+    , containers        >= 0.5     && < 0.8
+    , cookie            >= 0.4     && < 0.6
+    , directory         >= 1.2     && < 1.4
+    , hspec-core        >= 2       && < 3
+    , html-conduit      >= 0.1     && < 1.4
+    , http-types        >= 0.7     && < 0.13
+    , HUnit             >= 1.2     && < 1.7
+    , memory            >= 0.14    && < 0.19
+    , mtl               >= 2.0.0   && < 2.4
+    , network           >= 2.2     && < 3.3
+    , pretty-show       >= 1.6     && < 1.11
+    , process           >= 1.6     && < 1.7
+    , text              >= 1.2     && < 2.2
+    , time              >= 1.5     && < 1.13
+    , transformers      >= 0.2.2   && < 0.7
+    , wai               >= 3.0     && < 3.3
+    , wai-extra         >= 3.0     && < 3.2
+    , xml-conduit       >= 1.0     && < 1.10
+    , xml-types         >= 0.3     && < 0.4
+    , yesod-core        >= 1.6.17  && < 1.7
 
   exposed-modules:
     Yesod.Test
@@ -87,4 +87,4 @@ test-suite test
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/yesod.git
+  location: https://github.com/yesodweb/yesod.git


### PR DESCRIPTION
This fixes the following errors that occur when running `cabal check`.

```
The following errors are likely to affect your build negatively:
Error: [git-protocol] Cloning over git:// might lead to an arbitrary
code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
These warnings may cause trouble when distributing the package:
Warning: [missing-upper-bounds] On library, these packages miss upper
bounds:
- aeson
- attoparsec
- blaze-builder
- blaze-html
- blaze-markup
- bytestring
- case-insensitive
- conduit
- containers
- cookie
- directory
- html-conduit
- http-types
- HUnit
- memory
- mtl
- network
- pretty-show
- process
- text
- time
- transformers
- wai
- wai-extra
- xml-conduit
- xml-types
- yesod-core
Please add them. There is more information at https://pvp.haskell.org/
Error: Hackage would reject this package.
```

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] ~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~
- [ ] ~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs~

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
