### PR TITLE
lots of CPP and cleanup of 'Data.Monoid/Semigroup' stuff

### DIFF
--- a/demo/lite/lite.hs
+++ b/demo/lite/lite.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 import Yesod.Core
 import Data.Aeson
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Data.Text (Text, pack)
 
 people :: [(Text, Int)]

--- a/demo/lite/lite.hs
+++ b/demo/lite/lite.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 import Yesod.Core
 import Data.Aeson
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text, pack)
 
 people :: [(Text, Int)]

--- a/demo/streaming/streaming.hs
+++ b/demo/streaming/streaming.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -6,7 +7,9 @@
 import Data.Conduit
 import qualified Data.Conduit.Binary as CB
 import Control.Concurrent.Lifted (threadDelay)
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import qualified Data.Text as T
 import Control.Monad (forM_)
 

--- a/demo/streaming/streaming.hs
+++ b/demo/streaming/streaming.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -7,9 +6,6 @@
 import Data.Conduit
 import qualified Data.Conduit.Binary as CB
 import Control.Concurrent.Lifted (threadDelay)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import qualified Data.Text as T
 import Control.Monad (forM_)
 

--- a/yesod-auth/ChangeLog.md
+++ b/yesod-auth/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-auth
 
+## 1.6.12.1
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.6.12.0
 
 * Add `afterPasswordRouteHandler` [#1863](https://github.com/yesodweb/yesod/pull/1863)

--- a/yesod-auth/Yesod/Auth.hs
+++ b/yesod-auth/Yesod/Auth.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/yesod-auth/Yesod/Auth/GoogleEmail2.hs
+++ b/yesod-auth/Yesod/Auth/GoogleEmail2.hs
@@ -89,7 +89,6 @@ import           Data.Aeson.Types            (FromJSON (parseJSON), parseEither,
 import           Data.Conduit
 import           Data.Conduit.Attoparsec     (sinkParser)
 import           Data.Maybe                  (fromMaybe)
-import           Data.Monoid                 (mappend)
 import           Data.Text                   (Text)
 import qualified Data.Text                   as T
 import           Data.Text.Encoding          (decodeUtf8, encodeUtf8)
@@ -189,7 +188,7 @@ authPlugin storeToken clientID clientSecret =
         return $ decodeUtf8
                $ toByteString
                $ fromByteString "https://accounts.google.com/o/oauth2/auth"
-                    `Data.Monoid.mappend` renderQueryText True qs
+                    `mappend` renderQueryText True qs
 
     login tm = do
         [whamlet|<a href=@{tm forwardUrl}>_{Msg.LoginGoogle}|]

--- a/yesod-auth/Yesod/Auth/Message.hs
+++ b/yesod-auth/Yesod/Auth/Message.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Yesod.Auth.Message
     ( AuthMessage (..)
@@ -23,8 +24,10 @@ module Yesod.Auth.Message
     , romanianMessage
     ) where
 
-import           Data.Monoid (mappend, (<>))
-import           Data.Text   (Text)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
+import Data.Text (Text)
 
 data AuthMessage =
       NoOpenID
@@ -92,9 +95,7 @@ englishMessage RegisterLong = "Register a new account"
 englishMessage EnterEmail = "Enter your e-mail address below, and a confirmation e-mail will be sent to you."
 englishMessage ConfirmationEmailSentTitle = "Confirmation e-mail sent"
 englishMessage (ConfirmationEmailSent email) =
-    "A confirmation e-mail has been sent to " `Data.Monoid.mappend`
-    email `mappend`
-    "."
+    "A confirmation e-mail has been sent to " `mappend` email `mappend` "."
 englishMessage AddressVerified = "Email address verified, please set a new password"
 englishMessage EmailVerifiedChangePass = "Email address verified, please set a new password"
 englishMessage EmailVerified = "Email address verified"
@@ -885,7 +886,7 @@ romanianMessage RegisterLong = "Înregistrați un cont nou"
 romanianMessage EnterEmail = "Introduceți adresa dvs. de e-mail pentru a primi un e-mail de confirmare."
 romanianMessage ConfirmationEmailSentTitle = "Un mesaj de confirmare a fost trimis la adresa dvs. de e-mail"
 romanianMessage (ConfirmationEmailSent email) =
-    "Un mesaj de confirmare a fost trimis la " `Data.Monoid.mappend` email `mappend` "."
+    "Un mesaj de confirmare a fost trimis la " `mappend` email `mappend` "."
 romanianMessage AddressVerified = "Adresa de e-mail a fost verificată, vă rugăm să setați o parolă nouă"
 romanianMessage EmailVerifiedChangePass = "Adresa de e-mail a fost verificată, vă rugăm să setați o parolă nouă"
 romanianMessage EmailVerified = "Adresa de e-mail a fost verificată"

--- a/yesod-auth/Yesod/Auth/Message.hs
+++ b/yesod-auth/Yesod/Auth/Message.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Yesod.Auth.Message
     ( AuthMessage (..)
@@ -24,9 +23,6 @@ module Yesod.Auth.Message
     , romanianMessage
     ) where
 
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Data.Text (Text)
 
 data AuthMessage =

--- a/yesod-auth/Yesod/Auth/OpenId.hs
+++ b/yesod-auth/Yesod/Auth/OpenId.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/yesod-auth/Yesod/Auth/Util/PasswordStore.hs
+++ b/yesod-auth/Yesod/Auth/Util/PasswordStore.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |

--- a/yesod-auth/Yesod/Auth/Util/PasswordStore.hs
+++ b/yesod-auth/Yesod/Auth/Util/PasswordStore.hs
@@ -455,12 +455,3 @@ genSaltRandom gen = (salt, newgen)
               where (a, g') = randomR ('\NUL', '\255') g
           salt   = makeSalt $ B.pack $ map fst (rands gen 16)
           newgen = snd $ last (rands gen 16)
-
-#if !MIN_VERSION_base(4, 6, 0)
--- | Strict version of 'modifySTRef'
-modifySTRef' :: STRef s a -> (a -> a) -> ST s ()
-modifySTRef' ref f = do
-    x <- readSTRef ref
-    let x' = f x
-    x' `seq` writeSTRef ref x'
-#endif

--- a/yesod-auth/yesod-auth.cabal
+++ b/yesod-auth/yesod-auth.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >=1.10
 name:            yesod-auth
-version:         1.6.12.0
+version:         1.6.12.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman, Patrick Brisbin
@@ -21,7 +21,7 @@ flag network-uri
 
 library
     default-language: Haskell2010
-    build-depends:   base                    >= 4.10      && < 5
+    build-depends:   base                    >= 4.11      && < 5
                    , aeson                   >= 0.7
                    , attoparsec-aeson        >= 2.1
                    , authenticate            >= 1.3.4

--- a/yesod-bin/ChangeLog.md
+++ b/yesod-bin/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-bin
 
+## 1.6.2.4
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.6.2.3
 
 * Support optparse-applicative-0.18 [#1829](https://github.com/yesodweb/yesod/pull/1829)

--- a/yesod-bin/Devel.hs
+++ b/yesod-bin/Devel.hs
@@ -30,14 +30,13 @@ import           Data.Time                             (getCurrentTime)
 import qualified Distribution.Package                  as D
 import qualified Distribution.PackageDescription       as D
 #if MIN_VERSION_Cabal(3,8,0)
-import qualified Distribution.Simple.PackageDescription as D
-#endif
-#if MIN_VERSION_Cabal(2, 2, 0)
-import qualified Distribution.PackageDescription.Parsec as D
+import qualified Distribution.Simple.PackageDescription as D (readGenericPackageDescription)
+#elif MIN_VERSION_Cabal(2, 2, 0)
+import qualified Distribution.PackageDescription.Parsec as D (readGenericPackageDescription)
 #else
-import qualified Distribution.PackageDescription.Parse as D
+import qualified Distribution.PackageDescription.Parse as D (readGenericPackageDescription)
 #endif
-import qualified Distribution.Simple.Utils             as D
+import qualified Distribution.Simple.Utils             as D (tryFindPackageDesc)
 import qualified Distribution.Verbosity                as D
 import           Network.HTTP.Client                   (newManager)
 import           Network.HTTP.Client                   (managerSetProxy,
@@ -309,7 +308,7 @@ devel opts passThroughArgs = do
 
     let pd = D.packageDescription gpd
         D.PackageIdentifier packageNameWrapped _version = D.package pd
-#if MIN_VERSION_Cabal(2, 0, 0)
+#if MIN_VERSION_Cabal(1, 22, 0)
         packageName = D.unPackageName packageNameWrapped
 #else
         D.PackageName packageName = packageNameWrapped

--- a/yesod-bin/HsFile.hs
+++ b/yesod-bin/HsFile.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 module HsFile (mkHsFile) where
+
 import Text.ProjectTemplate (createTemplate)
 import Conduit
 import qualified Data.ByteString as BS

--- a/yesod-bin/Keter.hs
+++ b/yesod-bin/Keter.hs
@@ -19,7 +19,9 @@ import System.Process
 import Control.Monad
 import System.Directory hiding (findFiles)
 import Data.Maybe (mapMaybe,isJust,maybeToList)
-import Data.Monoid
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import System.FilePath ((</>))
 import qualified Codec.Archive.Tar as Tar
 import Control.Exception
@@ -94,7 +96,7 @@ keter cabal noBuild noCopyTo buildArgs = do
             useStack = inStackExec || isJust mStackYaml || stackQueryRunSuccess
 
         if useStack
-            then do let stackYaml = maybeToList $ fmap ("--stack-yaml="<>) mStackYaml
+            then do let stackYaml = maybeToList $ fmap ("--stack-yaml=" <>) mStackYaml
                         localBinPath = cwd' </> "dist/bin"
                     run "stack" $ stackYaml <> ["clean"]
                     createDirectoryIfMissing True localBinPath

--- a/yesod-bin/Keter.hs
+++ b/yesod-bin/Keter.hs
@@ -19,9 +19,6 @@ import System.Process
 import Control.Monad
 import System.Directory hiding (findFiles)
 import Data.Maybe (mapMaybe,isJust,maybeToList)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import System.FilePath ((</>))
 import qualified Codec.Archive.Tar as Tar
 import Control.Exception

--- a/yesod-bin/Options.hs
+++ b/yesod-bin/Options.hs
@@ -14,7 +14,9 @@ import           Data.List                 (foldl')
 import           Data.List.Split           (splitOn)
 import qualified Data.Map                  as M
 import           Data.Maybe                (mapMaybe)
-import           Data.Monoid
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup ((<>))
+#endif
 import           Options.Applicative
 import           Options.Applicative.Types
 import           System.Directory

--- a/yesod-bin/Options.hs
+++ b/yesod-bin/Options.hs
@@ -14,9 +14,6 @@ import           Data.List                 (foldl')
 import           Data.List.Split           (splitOn)
 import qualified Data.Map                  as M
 import           Data.Maybe                (mapMaybe)
-#if !MIN_VERSION_base(4,11,0)
-import           Data.Semigroup ((<>))
-#endif
 import           Options.Applicative
 import           Options.Applicative.Types
 import           System.Directory

--- a/yesod-bin/main.hs
+++ b/yesod-bin/main.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Main (main) where
 
-#if !MIN_VERSION_base(4,11,0)
-import           Data.Semigroup ((<>))
-#endif
 import           Data.Version           (showVersion)
 import           Options.Applicative
 import           System.Exit            (exitFailure)

--- a/yesod-bin/main.hs
+++ b/yesod-bin/main.hs
@@ -3,7 +3,9 @@
 
 module Main (main) where
 
-import           Data.Monoid
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup ((<>))
+#endif
 import           Data.Version           (showVersion)
 import           Options.Applicative
 import           System.Exit            (exitFailure)

--- a/yesod-bin/yesod-bin.cabal
+++ b/yesod-bin/yesod-bin.cabal
@@ -1,5 +1,5 @@
 name:            yesod-bin
-version:         1.6.2.3
+version:         1.6.2.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -25,7 +25,7 @@ executable             yesod
     if os(openbsd)
         ld-options:      -Wl,-zwxneeded
 
-    build-depends:     base               >= 4.10         && < 5
+    build-depends:     base               >= 4.11         && < 5
                      , Cabal              >= 1.18
                      , bytestring         >= 0.9.1.4
                      , conduit            >= 1.3

--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-core
 
+## 1.6.27.1
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.6.27.0
 
 * Build with `wai-extra-3.1.17` [#1861](https://github.com/yesodweb/yesod/pull/1861)

--- a/yesod-core/bench/widget.hs
+++ b/yesod-core/bench/widget.hs
@@ -9,7 +9,6 @@ import Gauge.Main
 import Text.Hamlet
 import qualified Data.ByteString.Lazy as L
 import qualified Text.Blaze.Html.Renderer.Utf8 as Utf8
-import Data.Monoid (mconcat)
 import Text.Blaze.Html5 (table, tr, td)
 import Text.Blaze.Html (toHtml)
 import Data.Int
@@ -64,6 +63,6 @@ bigTableWidget rows = fmap (L.length . Utf8.renderHtml . ($ render)) (run [whaml
     -}
 
 bigTableBlaze :: Show a => [[a]] -> Int64
-bigTableBlaze t = L.length $ Utf8.renderHtml $ table $ Data.Monoid.mconcat $ map row t
+bigTableBlaze t = L.length $ Utf8.renderHtml $ table $ concatMap row t
   where
-    row r = tr $ mconcat $ map (td . toHtml . show) r
+    row r = tr $ concatMap (td . toHtml . show) r

--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -1,8 +1,6 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
 module Yesod.Core.Class.Yesod where
@@ -28,9 +26,6 @@ import           Data.List                          (foldl', nub)
 import qualified Data.Map                           as Map
 import           Data.Maybe                         (catMaybes)
 import           Data.Monoid                        (Last (..))
-#if !MIN_VERSION_base(4,11,0)
-import           Data.Semigroup                     ((<>))
-#endif
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T
 import qualified Data.Text.Encoding                 as TE

--- a/yesod-core/src/Yesod/Core/Class/Yesod.hs
+++ b/yesod-core/src/Yesod/Core/Class/Yesod.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -26,7 +27,10 @@ import Data.Aeson (object, (.=))
 import           Data.List                          (foldl', nub)
 import qualified Data.Map                           as Map
 import           Data.Maybe                         (catMaybes)
-import           Data.Monoid
+import           Data.Monoid                        (Last (..))
+#if !MIN_VERSION_base(4,11,0)
+import           Data.Semigroup                     ((<>))
+#endif
 import           Data.Text                          (Text)
 import qualified Data.Text                          as T
 import qualified Data.Text.Encoding                 as TE

--- a/yesod-core/src/Yesod/Core/Internal/LiteApp.hs
+++ b/yesod-core/src/Yesod/Core/Internal/LiteApp.hs
@@ -1,12 +1,8 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Yesod.Core.Internal.LiteApp where
 
-#if !(MIN_VERSION_base(4,11,0))
-import Data.Semigroup (Semigroup(..))
-#endif
 import Yesod.Routes.Class
 import Yesod.Core.Class.Yesod
 import Yesod.Core.Class.Dispatch
@@ -50,9 +46,6 @@ instance Semigroup LiteApp where
 
 instance Monoid LiteApp where
     mempty = LiteApp $ \_ _ -> Nothing
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
 
 type LiteHandler = HandlerFor LiteApp
 type LiteWidget = WidgetFor LiteApp

--- a/yesod-core/src/Yesod/Core/Internal/Request.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Request.hs
@@ -51,9 +51,12 @@ import qualified Data.Word8 as Word8
 limitRequestBody :: Word64 -> W.Request -> IO W.Request
 limitRequestBody maxLen req = do
     ref <- newIORef maxLen
-    return req
-        { W.requestBody = do
+    let bd = do
+#if MIN_VERSION_wai(3,2,2)
+            bs <- W.getRequestBodyChunk req
+#else
             bs <- W.requestBody req
+#endif
             remaining <- readIORef ref
             let len = fromIntegral $ S8.length bs
                 remaining' = remaining - len
@@ -62,7 +65,11 @@ limitRequestBody maxLen req = do
                 else do
                     writeIORef ref remaining'
                     return bs
-        }
+#if MIN_VERSION_wai(3,2,4)
+    return $ W.setRequestBodyChunks bd req
+#else
+    return req { W.requestBody = bd }
+#endif
 
 tooLargeResponse :: Word64 -> Word64 -> W.Response
 tooLargeResponse maxLen bodyLen = W.responseLBS

--- a/yesod-core/src/Yesod/Core/Internal/Response.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Response.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Yesod.Core.Internal.Response where
 

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
@@ -289,7 +290,11 @@ runFakeHandler fakeSessionMap logger site handler = liftIO $ do
                      typePlain
                      (toContent ("runFakeHandler: errHandler" :: S8.ByteString))
                      (reqSession req)
+#if MIN_VERSION_wai(3,2,4)
+      fakeWaiRequest = setRequestBodyChunks (pure mempty) Request
+#else
       fakeWaiRequest = Request
+#endif
           { requestMethod  = "POST"
           , httpVersion    = H.http11
           , rawPathInfo    = "/runFakeHandler/pathInfo"
@@ -300,7 +305,9 @@ runFakeHandler fakeSessionMap logger site handler = liftIO $ do
           , remoteHost     = error "runFakeHandler-remoteHost"
           , pathInfo       = ["runFakeHandler", "pathInfo"]
           , queryString    = []
+#if !MIN_VERSION_wai(3,2,4)
           , requestBody    = return mempty
+#endif
           , vault          = mempty
           , requestBodyLength = KnownLength 0
           , requestHeaderRange = Nothing

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}

--- a/yesod-core/src/Yesod/Core/Internal/Run.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Run.hs
@@ -290,29 +290,12 @@ runFakeHandler fakeSessionMap logger site handler = liftIO $ do
                      typePlain
                      (toContent ("runFakeHandler: errHandler" :: S8.ByteString))
                      (reqSession req)
-#if MIN_VERSION_wai(3,2,4)
-      fakeWaiRequest = setRequestBodyChunks (pure mempty) Request
-#else
-      fakeWaiRequest = Request
-#endif
+      fakeWaiRequest = defaultRequest
           { requestMethod  = "POST"
           , httpVersion    = H.http11
           , rawPathInfo    = "/runFakeHandler/pathInfo"
-          , rawQueryString = ""
-          , requestHeaderHost = Nothing
-          , requestHeaders = []
-          , isSecure       = False
           , remoteHost     = error "runFakeHandler-remoteHost"
           , pathInfo       = ["runFakeHandler", "pathInfo"]
-          , queryString    = []
-#if !MIN_VERSION_wai(3,2,4)
-          , requestBody    = return mempty
-#endif
-          , vault          = mempty
-          , requestBodyLength = KnownLength 0
-          , requestHeaderRange = Nothing
-          , requestHeaderReferer = Nothing
-          , requestHeaderUserAgent = Nothing
           }
       fakeRequest =
         YesodRequest

--- a/yesod-core/src/Yesod/Core/Internal/Util.hs
+++ b/yesod-core/src/Yesod/Core/Internal/Util.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Yesod.Core.Internal.Util
     ( putTime
     , getTime

--- a/yesod-core/src/Yesod/Core/Json.hs
+++ b/yesod-core/src/Yesod/Core/Json.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Yesod.Core.Json

--- a/yesod-core/src/Yesod/Core/Types.hs
+++ b/yesod-core/src/Yesod/Core/Types.hs
@@ -30,7 +30,9 @@ import           Data.IORef                         (IORef, modifyIORef')
 import           Data.Map                           (Map, unionWith)
 import qualified Data.Map                           as Map
 import           Data.Monoid                        (Endo (..), Last (..))
+#if !MIN_VERSION_base(4,11,0)
 import           Data.Semigroup                     (Semigroup(..))
+#endif
 import           Data.Serialize                     (Serialize (..),
                                                      putByteString)
 import           Data.String                        (IsString (fromString))
@@ -398,13 +400,9 @@ newtype Title = Title { unTitle :: Html }
 newtype Description = Description { unDescription :: Text }
 
 newtype Head url = Head (HtmlUrl url)
-    deriving Monoid
-instance Semigroup (Head url) where
-  (<>) = mappend
+    deriving (Semigroup, Monoid)
 newtype Body url = Body (HtmlUrl url)
-    deriving Monoid
-instance Semigroup (Body url) where
-  (<>) = mappend
+    deriving (Semigroup, Monoid)
 
 type CssBuilderUrl a = (a -> [(Text, Text)] -> Text) -> TBuilder.Builder
 

--- a/yesod-core/src/Yesod/Core/Types.hs
+++ b/yesod-core/src/Yesod/Core/Types.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -6,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -30,9 +28,6 @@ import           Data.IORef                         (IORef, modifyIORef')
 import           Data.Map                           (Map, unionWith)
 import qualified Data.Map                           as Map
 import           Data.Monoid                        (Endo (..), Last (..))
-#if !MIN_VERSION_base(4,11,0)
-import           Data.Semigroup                     (Semigroup(..))
-#endif
 import           Data.Serialize                     (Serialize (..),
                                                      putByteString)
 import           Data.String                        (IsString (fromString))
@@ -264,9 +259,6 @@ data WidgetData site = WidgetData
 
 instance a ~ () => Monoid (WidgetFor site a) where
     mempty = return ()
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
 instance a ~ () => Semigroup (WidgetFor site a) where
     x <> y = x >> y
 
@@ -418,9 +410,6 @@ data GWData a = GWData
     }
 instance Monoid (GWData a) where
     mempty = GWData mempty mempty mempty mempty mempty mempty mempty mempty
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
 instance Semigroup (GWData a) where
     GWData a1 a2 a3 a4 a5 a6 a7 a8 <>
       GWData b1 b2 b3 b4 b5 b6 b7 b8 = GWData
@@ -525,9 +514,6 @@ instance MonadLoggerIO (HandlerFor site) where
 
 instance Monoid (UniqueList x) where
     mempty = UniqueList id
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
 instance Semigroup (UniqueList x) where
     UniqueList x <> UniqueList y = UniqueList $ x . y
 

--- a/yesod-core/src/Yesod/Core/Widget.hs
+++ b/yesod-core/src/Yesod/Core/Widget.hs
@@ -57,7 +57,7 @@ module Yesod.Core.Widget
     , asWidgetT
     ) where
 
-import Data.Monoid
+import Data.Monoid (Last (..))
 import qualified Text.Blaze.Html5 as H
 import Text.Hamlet
 import Text.Cassius

--- a/yesod-core/test/Hierarchy.hs
+++ b/yesod-core/test/Hierarchy.hs
@@ -128,11 +128,10 @@ do
         , mdsGetHandler = defaultGetHandler
         , mdsUnwrapper = return
         } resources
-    return
+    return $
+        InstanceD
 #if MIN_VERSION_template_haskell(2,11,0)
-        $ InstanceD Nothing
-#else
-        $ InstanceD
+            Nothing
 #endif
             []
             (ConT ''Dispatcher

--- a/yesod-core/test/RouteSpec.hs
+++ b/yesod-core/test/RouteSpec.hs
@@ -87,11 +87,10 @@ do
         , mdsGetHandler = defaultGetHandler
         , mdsUnwrapper = return
         } ress
-    return
+    return $
+        InstanceD
 #if MIN_VERSION_template_haskell(2,11,0)
-        $ InstanceD Nothing
-#else
-        $ InstanceD
+            Nothing
 #endif
             []
             (ConT ''Dispatcher

--- a/yesod-core/test/YesodCoreTest/CleanPath.hs
+++ b/yesod-core/test/YesodCoreTest/CleanPath.hs
@@ -26,7 +26,6 @@ import qualified Data.Text as TS
 import qualified Data.Text.Encoding as TE
 import Control.Arrow ((***))
 import Network.HTTP.Types (encodePath)
-import Data.Monoid (mappend)
 import Data.Text.Encoding (encodeUtf8Builder)
 
 data Subsite = Subsite
@@ -69,7 +68,7 @@ instance Yesod Y where
         corrected = filter (not . TS.null) s
 
     joinPath Y ar pieces' qs' =
-        encodeUtf8Builder ar `Data.Monoid.mappend` encodePath pieces qs
+        encodeUtf8Builder ar `mappend` encodePath pieces qs
       where
         pieces = if null pieces' then [""] else pieces'
         qs = map (TE.encodeUtf8 *** go) qs'

--- a/yesod-core/test/YesodCoreTest/CleanPath.hs
+++ b/yesod-core/test/YesodCoreTest/CleanPath.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/yesod-core/test/YesodCoreTest/Csrf.hs
+++ b/yesod-core/test/YesodCoreTest/Csrf.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -15,9 +14,6 @@ import Network.Wai.Test
 import Web.Cookie
 import qualified Data.Map as Map
 import Data.ByteString.Lazy (fromStrict)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 
 data App = App
 

--- a/yesod-core/test/YesodCoreTest/Csrf.hs
+++ b/yesod-core/test/YesodCoreTest/Csrf.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -14,7 +15,9 @@ import Network.Wai.Test
 import Web.Cookie
 import qualified Data.Map as Map
 import Data.ByteString.Lazy (fromStrict)
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 
 data App = App
 

--- a/yesod-core/test/YesodCoreTest/ErrorHandling.hs
+++ b/yesod-core/test/YesodCoreTest/ErrorHandling.hs
@@ -27,7 +27,6 @@ import Control.Exception (SomeException, try, AsyncException(..))
 import           UnliftIO.Exception(finally)
 import Network.HTTP.Types (Status, mkStatus)
 import Data.ByteString.Builder (Builder, toLazyByteString)
-import Data.Monoid (mconcat)
 import Data.Text (Text, pack)
 import Control.Monad (forM_)
 import qualified Network.Wai.Handler.Warp as Warp
@@ -125,7 +124,7 @@ getFileBadNameR :: Handler TypedContent
 getFileBadNameR = return $ TypedContent "ignored" $ ContentFile (error "filebadname") Nothing
 
 goodBuilderContent :: Builder
-goodBuilderContent = Data.Monoid.mconcat $ replicate 100 $ "This is a test\n"
+goodBuilderContent = mconcat $ replicate 100 $ "This is a test\n"
 
 getGoodBuilderR :: Handler TypedContent
 getGoodBuilderR = return $ TypedContent "text/plain" $ toContent goodBuilderContent

--- a/yesod-core/test/YesodCoreTest/InternalRequest.hs
+++ b/yesod-core/test/YesodCoreTest/InternalRequest.hs
@@ -6,7 +6,6 @@ import Data.List (nub)
 import Network.Wai as W
 import Yesod.Core.Internal (randomString, parseWaiRequest)
 import Test.Hspec
-import Data.Monoid (mempty)
 import Data.Map (singleton)
 import Yesod.Core
 import Data.Word (Word64)
@@ -58,7 +57,7 @@ tokenSpecs = describe "Yesod.Internal.Request.parseWaiRequest (reqToken)" $ do
 
 noDisabledToken :: Bool
 noDisabledToken = reqToken r == Nothing where
-  r = parseWaiRequest' defaultRequest Data.Monoid.mempty False 1000
+  r = parseWaiRequest' defaultRequest mempty False 1000
 
 ignoreDisabledToken :: Bool
 ignoreDisabledToken = reqToken r == Nothing where

--- a/yesod-core/test/YesodCoreTest/NoOverloadedStrings.hs
+++ b/yesod-core/test/YesodCoreTest/NoOverloadedStrings.hs
@@ -19,7 +19,6 @@ import YesodCoreTest.NoOverloadedStringsSub
 import Yesod.Core
 import Network.Wai
 import Network.Wai.Test
-import Data.Monoid (mempty)
 import qualified Data.Text as T
 import qualified Data.ByteString.Lazy.Char8 as L8
 
@@ -70,7 +69,7 @@ runner f = toWaiApp Y >>= runSession f
 case_sanity :: IO ()
 case_sanity = runner $ do
     res <- request defaultRequest
-    assertBody Data.Monoid.mempty res
+    assertBody mempty res
 
 case_subsite :: IO ()
 case_subsite = runner $ do

--- a/yesod-core/test/YesodCoreTest/SubSub.hs
+++ b/yesod-core/test/YesodCoreTest/SubSub.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module YesodCoreTest.SubSub where
 

--- a/yesod-core/test/YesodCoreTest/WaiSubsite.hs
+++ b/yesod-core/test/YesodCoreTest/WaiSubsite.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.27.0
+version:         1.6.27.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -25,7 +25,7 @@ library
     default-language: Haskell2010
     hs-source-dirs: src
 
-    build-depends:   base                  >= 4.10     && < 5
+    build-depends:   base                  >= 4.11     && < 5
                    , aeson                 >= 1.0
                    , attoparsec-aeson      >= 2.1
                    , auto-update
@@ -186,7 +186,7 @@ test-suite tests
     cpp-options:   -DTEST
     if os(windows)
         cpp-options: -DWINDOWS
-    build-depends:  base < 5
+    build-depends:  base >= 4.11 && < 5
                   , async
                   , bytestring
                   , clientsession

--- a/yesod-eventsource/Yesod/EventSource.hs
+++ b/yesod-eventsource/Yesod/EventSource.hs
@@ -12,7 +12,6 @@ module Yesod.EventSource
 import Blaze.ByteString.Builder (Builder)
 import Control.Monad (when)
 import Data.Functor ((<$>))
-import Data.Monoid (Monoid (..))
 import Yesod.Core
 import Data.Conduit
 import qualified Network.Wai as W
@@ -91,7 +90,7 @@ pollingEventSource initial act = do
       -- when we the connection should be closed.
       joinEvents (ev:evs) acc =
         case ES.eventToBuilder ev of
-          Just b  -> joinEvents evs (acc `Data.Monoid.mappend` b)
+          Just b  -> joinEvents evs (acc `mappend` b)
           Nothing -> (fst $ joinEvents [] acc, False)
       joinEvents [] acc = (acc, True)
 

--- a/yesod-form-multi/Yesod/Form/MultiInput.hs
+++ b/yesod-form-multi/Yesod/Form/MultiInput.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+#if !MIN_VERSION_shakespeare(2,0,18)
+{-# OPTIONS_GHC -Wno-orphans #-}
+#endif
 
 -- | A module providing a means of creating multiple input forms without
 -- the need to submit the form to generate a new input field unlike
@@ -35,13 +38,10 @@ import Yesod.Form.Fields (intField)
 import Yesod.Form.Functions
 import Yesod.Form.Types
 
-#ifdef MIN_VERSION_shakespeare(2,0,18)
-#if MIN_VERSION_shakespeare(2,0,18)
-#else
+#if !MIN_VERSION_shakespeare(2,0,18)
 import Text.Julius (ToJavascript (..))
 instance ToJavascript String where toJavascript = toJavascript . toJSON
 instance ToJavascript Text where toJavascript = toJavascript . toJSON
-#endif
 #endif
 
 -- | By default delete buttons have a @margin-left@ property of @0.75rem@.

--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-form
 
+## 1.7.9.1
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.7.9
 
 * Added `checkboxesField'` for creating checkbox in more correct way than original `checkboxesField`

--- a/yesod-form/Yesod/Form/Fields.hs
+++ b/yesod-form/Yesod/Form/Fields.hs
@@ -120,9 +120,6 @@ import Yesod.Persist.Core
 
 import Data.String (IsString)
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Monoid
-#endif
 
 import Data.Char (isHexDigit)
 

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -73,9 +73,6 @@ import Text.Blaze (Markup, toMarkup)
 #define toHtml toMarkup
 import Yesod.Core
 import Network.Wai (requestMethod)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Data.Maybe (listToMaybe, fromMaybe)
 import qualified Data.Map as Map
 import qualified Data.Text.Encoding as TE

--- a/yesod-form/Yesod/Form/Functions.hs
+++ b/yesod-form/Yesod/Form/Functions.hs
@@ -73,7 +73,9 @@ import Text.Blaze (Markup, toMarkup)
 #define toHtml toMarkup
 import Yesod.Core
 import Network.Wai (requestMethod)
-import Data.Monoid (mempty, (<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Data.Maybe (listToMaybe, fromMaybe)
 import qualified Data.Map as Map
 import qualified Data.Text.Encoding as TE
@@ -329,7 +331,7 @@ postHelper form env = do
     let tokenKey = defaultCsrfParamName
     let token =
             case reqToken req of
-                Nothing -> Data.Monoid.mempty
+                Nothing -> mempty
                 Just n -> [shamlet|<input type=hidden name=#{tokenKey} value=#{n}>|]
     m <- getYesod
     langs <- languages

--- a/yesod-form/Yesod/Form/I18n/Chinese.hs
+++ b/yesod-form/Yesod/Form/I18n/Chinese.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Chinese where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 chineseFormMessage :: FormMessage -> Text
-chineseFormMessage (MsgInvalidInteger t) = "无效的整数: " `Data.Monoid.mappend` t
+chineseFormMessage (MsgInvalidInteger t) = "无效的整数: " `mappend` t
 chineseFormMessage (MsgInvalidNumber t) = "无效的数字: " `mappend` t
 chineseFormMessage (MsgInvalidEntry t) = "无效的条目: " `mappend` t
 chineseFormMessage MsgInvalidTimeFormat = "无效的时间, 必须符合HH:MM[:SS]格式"

--- a/yesod-form/Yesod/Form/I18n/Croatian.hs
+++ b/yesod-form/Yesod/Form/I18n/Croatian.hs
@@ -3,7 +3,6 @@
 module Yesod.Form.I18n.Croatian where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 croatianFormMessage :: FormMessage -> Text

--- a/yesod-form/Yesod/Form/I18n/Czech.hs
+++ b/yesod-form/Yesod/Form/I18n/Czech.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Czech where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 czechFormMessage :: FormMessage -> Text
-czechFormMessage (MsgInvalidInteger t) = "Neplatné celé číslo: " `Data.Monoid.mappend` t
+czechFormMessage (MsgInvalidInteger t) = "Neplatné celé číslo: " `mappend` t
 czechFormMessage (MsgInvalidNumber t) = "Neplatné číslo: " `mappend` t
 czechFormMessage (MsgInvalidEntry t) = "Neplatná položka: " `mappend` t
 czechFormMessage MsgInvalidTimeFormat = "Neplatný čas, musí být ve formátu HH:MM[:SS]"

--- a/yesod-form/Yesod/Form/I18n/Dutch.hs
+++ b/yesod-form/Yesod/Form/I18n/Dutch.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Dutch where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 dutchFormMessage :: FormMessage -> Text
-dutchFormMessage (MsgInvalidInteger t) = "Ongeldig aantal: " `Data.Monoid.mappend` t
+dutchFormMessage (MsgInvalidInteger t) = "Ongeldig aantal: " `mappend` t
 dutchFormMessage (MsgInvalidNumber t)  = "Ongeldig getal: " `mappend` t
 dutchFormMessage (MsgInvalidEntry t)   = "Ongeldige invoer: " `mappend` t
 dutchFormMessage MsgInvalidTimeFormat  = "Ongeldige tijd, het juiste formaat is (UU:MM[:SS])"

--- a/yesod-form/Yesod/Form/I18n/English.hs
+++ b/yesod-form/Yesod/Form/I18n/English.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.English where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 englishFormMessage :: FormMessage -> Text
-englishFormMessage (MsgInvalidInteger t) = "Invalid integer: " `Data.Monoid.mappend` t
+englishFormMessage (MsgInvalidInteger t) = "Invalid integer: " `mappend` t
 englishFormMessage (MsgInvalidNumber t) = "Invalid number: " `mappend` t
 englishFormMessage (MsgInvalidEntry t) = "Invalid entry: " `mappend` t
 englishFormMessage MsgInvalidTimeFormat = "Invalid time, must be in HH:MM[:SS] format"

--- a/yesod-form/Yesod/Form/I18n/French.hs
+++ b/yesod-form/Yesod/Form/I18n/French.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.French (frenchFormMessage) where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 frenchFormMessage :: FormMessage -> Text
-frenchFormMessage (MsgInvalidInteger t) = "Entier invalide : " `Data.Monoid.mappend` t
+frenchFormMessage (MsgInvalidInteger t) = "Entier invalide : " `mappend` t
 frenchFormMessage (MsgInvalidNumber t) = "Nombre invalide : " `mappend` t
 frenchFormMessage (MsgInvalidEntry t) = "Entrée invalide : " `mappend` t
 frenchFormMessage MsgInvalidTimeFormat = "Heure invalide (elle doit être au format HH:MM ou HH:MM:SS"

--- a/yesod-form/Yesod/Form/I18n/German.hs
+++ b/yesod-form/Yesod/Form/I18n/German.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.German where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 germanFormMessage :: FormMessage -> Text
-germanFormMessage (MsgInvalidInteger t) = "Ungültige Ganzzahl: " `Data.Monoid.mappend` t
+germanFormMessage (MsgInvalidInteger t) = "Ungültige Ganzzahl: " `mappend` t
 germanFormMessage (MsgInvalidNumber t) = "Ungültige Zahl: " `mappend` t
 germanFormMessage (MsgInvalidEntry t) = "Ungültiger Eintrag: " `mappend` t
 germanFormMessage MsgInvalidTimeFormat = "Ungültiges Zeitformat, HH:MM[:SS] Format erwartet"

--- a/yesod-form/Yesod/Form/I18n/Japanese.hs
+++ b/yesod-form/Yesod/Form/I18n/Japanese.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Japanese where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 japaneseFormMessage :: FormMessage -> Text
-japaneseFormMessage (MsgInvalidInteger t) = "無効な整数です: " `Data.Monoid.mappend` t
+japaneseFormMessage (MsgInvalidInteger t) = "無効な整数です: " `mappend` t
 japaneseFormMessage (MsgInvalidNumber t) = "無効な数値です: " `mappend` t
 japaneseFormMessage (MsgInvalidEntry t) = "無効な入力です: " `mappend` t
 japaneseFormMessage MsgInvalidTimeFormat = "無効な時刻です。HH:MM[:SS]フォーマットで入力してください"

--- a/yesod-form/Yesod/Form/I18n/Korean.hs
+++ b/yesod-form/Yesod/Form/I18n/Korean.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Korean where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 koreanFormMessage :: FormMessage -> Text
-koreanFormMessage (MsgInvalidInteger t) = "잘못된 정수입니다: " `Data.Monoid.mappend` t
+koreanFormMessage (MsgInvalidInteger t) = "잘못된 정수입니다: " `mappend` t
 koreanFormMessage (MsgInvalidNumber t) = "잘못된 숫자입니다: " `mappend` t
 koreanFormMessage (MsgInvalidEntry t) = "잘못된 입력입니다: " `mappend` t
 koreanFormMessage MsgInvalidTimeFormat = "잘못된 시간입니다. HH:MM[:SS] 형태로 입력하세요"

--- a/yesod-form/Yesod/Form/I18n/Norwegian.hs
+++ b/yesod-form/Yesod/Form/I18n/Norwegian.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Norwegian where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 norwegianBokmålFormMessage :: FormMessage -> Text
-norwegianBokmålFormMessage (MsgInvalidInteger t) = "Ugyldig antall: " `Data.Monoid.mappend` t
+norwegianBokmålFormMessage (MsgInvalidInteger t) = "Ugyldig antall: " `mappend` t
 norwegianBokmålFormMessage (MsgInvalidNumber t) = "Ugyldig nummer: " `mappend` t
 norwegianBokmålFormMessage (MsgInvalidEntry t) = "Ugyldig oppføring: " `mappend` t
 norwegianBokmålFormMessage MsgInvalidTimeFormat = "Ugyldig klokkeslett, må være i formatet HH:MM[:SS]"

--- a/yesod-form/Yesod/Form/I18n/Portuguese.hs
+++ b/yesod-form/Yesod/Form/I18n/Portuguese.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Portuguese where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 portugueseFormMessage :: FormMessage -> Text
-portugueseFormMessage (MsgInvalidInteger t) = "Número inteiro inválido: " `Data.Monoid.mappend` t
+portugueseFormMessage (MsgInvalidInteger t) = "Número inteiro inválido: " `mappend` t
 portugueseFormMessage (MsgInvalidNumber t) = "Número inválido: " `mappend` t
 portugueseFormMessage (MsgInvalidEntry t) = "Entrada inválida: " `mappend` t
 portugueseFormMessage MsgInvalidTimeFormat = "Hora inválida, deve estar no formato HH:MM[:SS]"

--- a/yesod-form/Yesod/Form/I18n/Romanian.hs
+++ b/yesod-form/Yesod/Form/I18n/Romanian.hs
@@ -3,14 +3,13 @@
 module Yesod.Form.I18n.Romanian where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 -- | Romanian translation
 --
 -- @since 1.7.5
 romanianFormMessage :: FormMessage -> Text
-romanianFormMessage (MsgInvalidInteger t) = "Număr întreg nevalid: " `Data.Monoid.mappend` t
+romanianFormMessage (MsgInvalidInteger t) = "Număr întreg nevalid: " `mappend` t
 romanianFormMessage (MsgInvalidNumber t) = "Număr nevalid: " `mappend` t
 romanianFormMessage (MsgInvalidEntry t) = "Valoare nevalidă: " `mappend` t
 romanianFormMessage MsgInvalidTimeFormat = "Oră nevalidă. Formatul necesar este HH:MM[:SS]"

--- a/yesod-form/Yesod/Form/I18n/Russian.hs
+++ b/yesod-form/Yesod/Form/I18n/Russian.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Russian where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 russianFormMessage :: FormMessage -> Text
-russianFormMessage (MsgInvalidInteger t) = "Неверно записано целое число: " `Data.Monoid.mappend` t
+russianFormMessage (MsgInvalidInteger t) = "Неверно записано целое число: " `mappend` t
 russianFormMessage (MsgInvalidNumber t) = "Неверный формат числа: " `mappend` t
 russianFormMessage (MsgInvalidEntry t) = "Неверный выбор: " `mappend` t
 russianFormMessage MsgInvalidTimeFormat = "Неверно указано время, используйте формат ЧЧ:ММ[:СС]"

--- a/yesod-form/Yesod/Form/I18n/Spanish.hs
+++ b/yesod-form/Yesod/Form/I18n/Spanish.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Spanish where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 spanishFormMessage :: FormMessage -> Text
-spanishFormMessage (MsgInvalidInteger t) = "Número entero inválido: " `Data.Monoid.mappend` t
+spanishFormMessage (MsgInvalidInteger t) = "Número entero inválido: " `mappend` t
 spanishFormMessage (MsgInvalidNumber t) = "Número inválido: " `mappend` t
 spanishFormMessage (MsgInvalidEntry t) = "Entrada inválida: " `mappend` t
 spanishFormMessage MsgInvalidTimeFormat = "Hora inválida, debe tener el formato HH:MM[:SS]"

--- a/yesod-form/Yesod/Form/I18n/Swedish.hs
+++ b/yesod-form/Yesod/Form/I18n/Swedish.hs
@@ -3,11 +3,10 @@
 module Yesod.Form.I18n.Swedish where
 
 import Yesod.Form.Types (FormMessage (..))
-import Data.Monoid (mappend)
 import Data.Text (Text)
 
 swedishFormMessage :: FormMessage -> Text
-swedishFormMessage (MsgInvalidInteger t) = "Ogiltigt antal: " `Data.Monoid.mappend` t
+swedishFormMessage (MsgInvalidInteger t) = "Ogiltigt antal: " `mappend` t
 swedishFormMessage (MsgInvalidNumber t) = "Ogiltigt nummer: " `mappend` t
 swedishFormMessage (MsgInvalidEntry t) = "Invalid entry: " `mappend` t
 swedishFormMessage MsgInvalidTimeFormat = "Ogiltigt klockslag, måste vara på formatet HH:MM[:SS]"

--- a/yesod-form/Yesod/Form/Jquery.hs
+++ b/yesod-form/Yesod/Form/Jquery.hs
@@ -21,11 +21,10 @@ import Data.Time (Day)
 import Data.Default
 import Text.Julius (rawJS)
 import Data.Text (Text, pack, unpack)
-import Data.Monoid (mconcat)
 
 -- | Gets the Google hosted jQuery UI 1.8 CSS file with the given theme.
 googleHostedJqueryUiCss :: Text -> Text
-googleHostedJqueryUiCss theme = Data.Monoid.mconcat
+googleHostedJqueryUiCss theme = mconcat
     [ "//ajax.googleapis.com/ajax/libs/jqueryui/1.8/themes/"
     , theme
     , "/jquery-ui.css"

--- a/yesod-form/Yesod/Form/MassInput.hs
+++ b/yesod-form/Yesod/Form/MassInput.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/yesod-form/Yesod/Form/Nic.hs
+++ b/yesod-form/Yesod/Form/Nic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/yesod-form/Yesod/Form/Types.hs
+++ b/yesod-form/Yesod/Form/Types.hs
@@ -26,7 +26,6 @@ module Yesod.Form.Types
 import Control.Monad.Trans.RWS (RWST)
 import Control.Monad.Trans.Writer (WriterT)
 import Data.Text (Text)
-import Data.Monoid (Monoid (..))
 import Text.Blaze (Markup, ToMarkup (toMarkup), ToValue (toValue))
 #define Html Markup
 #define ToHtml ToMarkup
@@ -37,7 +36,9 @@ import Control.Monad.Trans.Class
 import Data.String (IsString (..))
 import Yesod.Core
 import qualified Data.Map as Map
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup, (<>))
+#endif
 import Data.Traversable
 import Data.Foldable
 
@@ -63,7 +64,7 @@ instance Control.Applicative.Applicative FormResult where
     (FormFailure x) <*> _ = FormFailure x
     _ <*> (FormFailure y) = FormFailure y
     _ <*> _ = FormMissing
-instance Data.Monoid.Monoid m => Monoid (FormResult m) where
+instance Monoid m => Monoid (FormResult m) where
     mempty = pure mempty
     mappend x y = mappend <$> x <*> y
 instance Semigroup m => Semigroup (FormResult m) where

--- a/yesod-form/Yesod/Form/Types.hs
+++ b/yesod-form/Yesod/Form/Types.hs
@@ -36,9 +36,6 @@ import Control.Monad.Trans.Class
 import Data.String (IsString (..))
 import Yesod.Core
 import qualified Data.Map as Map
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup (Semigroup, (<>))
-#endif
 import Data.Traversable
 import Data.Foldable
 
@@ -106,9 +103,6 @@ instance ToValue Enctype where
     toValue Multipart = "multipart/form-data"
 instance Monoid Enctype where
     mempty = UrlEncoded
-#if !(MIN_VERSION_base(4,11,0))
-    mappend = (<>)
-#endif
 instance Semigroup Enctype where
     UrlEncoded <> UrlEncoded = UrlEncoded
     _          <> _          = Multipart

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            yesod-form
-version:         1.7.9
+version:         1.7.9.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -20,7 +20,7 @@ flag network-uri
 
 library
     default-language: Haskell2010
-    build-depends:   base                  >= 4.10     && < 5
+    build-depends:   base                  >= 4.11     && < 5
                    , aeson
                    , attoparsec            >= 0.10
                    , blaze-builder         >= 0.2.1.4

--- a/yesod-newsfeed/Yesod/AtomFeed.hs
+++ b/yesod-newsfeed/Yesod/AtomFeed.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/yesod-newsfeed/Yesod/RssFeed.hs
+++ b/yesod-newsfeed/Yesod/RssFeed.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/yesod-persistent/test/Yesod/PersistSpec.hs
+++ b/yesod-persistent/test/Yesod/PersistSpec.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyDataDecls #-}

--- a/yesod-static/ChangeLog.md
+++ b/yesod-static/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-static
 
+## 1.6.1.2
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.6.1.1
 
 * Use crypton instead of cryptonite [#1838](https://github.com/yesodweb/yesod/pull/1838)

--- a/yesod-static/Yesod/EmbeddedStatic.hs
+++ b/yesod-static/Yesod/EmbeddedStatic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/yesod-static/Yesod/EmbeddedStatic/Css/Util.hs
+++ b/yesod-static/Yesod/EmbeddedStatic/Css/Util.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -10,9 +9,6 @@ module Yesod.EmbeddedStatic.Css.Util where
 import Control.Applicative
 import Control.Monad (void, foldM)
 import Data.Hashable (Hashable)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Network.Mime (MimeType, defaultMimeLookup)
 import Text.CSS.Parse (parseBlocks)
 import Language.Haskell.TH (litE, stringL)
@@ -76,8 +72,7 @@ parseBackgroundImage n v = (n, case P.parseOnly parseUrl v of
 
 parseCssWith :: (T.Text -> T.Text -> EithUrl) -> T.Text -> Either String Css
 parseCssWith urlParser contents =
-    let mparsed = parseBlocks contents in
-    case mparsed of
+    case parseBlocks contents of
         Left err -> Left err
         Right blocks -> Right [ (t, map (uncurry urlParser) b) | (t,b) <- blocks ]
 

--- a/yesod-static/Yesod/EmbeddedStatic/Css/Util.hs
+++ b/yesod-static/Yesod/EmbeddedStatic/Css/Util.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -9,7 +10,9 @@ module Yesod.EmbeddedStatic.Css.Util where
 import Control.Applicative
 import Control.Monad (void, foldM)
 import Data.Hashable (Hashable)
-import Data.Monoid
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Network.Mime (MimeType, defaultMimeLookup)
 import Text.CSS.Parse (parseBlocks)
 import Language.Haskell.TH (litE, stringL)

--- a/yesod-static/Yesod/EmbeddedStatic/Internal.hs
+++ b/yesod-static/Yesod/EmbeddedStatic/Internal.hs
@@ -41,16 +41,6 @@ import qualified WaiAppStatic.Storage.Embedded as Static
 import Yesod.Static (base64md5)
 import Yesod.EmbeddedStatic.Types
 
-#if !MIN_VERSION_base(4,6,0)
--- copied from base
-atomicModifyIORef' :: IORef a -> (a -> (a,b)) -> IO b
-atomicModifyIORef' ref f = do
-    b <- atomicModifyIORef ref
-            (\x -> let (a, b) = f x
-                    in (a, a `seq` b))
-    b `seq` return b
-#endif
-
 -- | The subsite for the embedded static file server.
 data EmbeddedStatic = EmbeddedStatic {
     stApp :: !Application

--- a/yesod-static/Yesod/EmbeddedStatic/Internal.hs
+++ b/yesod-static/Yesod/EmbeddedStatic/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -1,5 +1,5 @@
 name:            yesod-static
-version:         1.6.1.1
+version:         1.6.1.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -27,7 +27,7 @@ extra-source-files:
 
 library
     default-language: Haskell2010
-    build-depends:   base                  >= 4.10     && < 5
+    build-depends:   base                  >= 4.11     && < 5
                    , async
                    , attoparsec            >= 0.10
                    , base64-bytestring     >= 0.1.0.1

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod-test
 
+## 1.6.23.1
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.6.23
 
 * Add `MonadFail` to `SIO` so tests can fail on pattern match failure. [#1874](https://github.com/yesodweb/yesod/pull/1874)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -268,9 +268,6 @@ import qualified Blaze.ByteString.Builder as Builder
 import Data.Time.Clock (getCurrentTime)
 import Control.Applicative ((<$>))
 import Text.Show.Pretty (ppShow)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import GHC.Stack (HasCallStack)
 import Data.ByteArray.Encoding (convertToBase, Base(..))
 import Network.HTTP.Types.Header (hContentType)

--- a/yesod-test/Yesod/Test.hs
+++ b/yesod-test/Yesod/Test.hs
@@ -268,16 +268,10 @@ import qualified Blaze.ByteString.Builder as Builder
 import Data.Time.Clock (getCurrentTime)
 import Control.Applicative ((<$>))
 import Text.Show.Pretty (ppShow)
-import Data.Monoid (mempty)
-#if MIN_VERSION_base(4,9,0)
-import GHC.Stack (HasCallStack)
-#elif MIN_VERSION_base(4,8,1)
-import GHC.Stack (CallStack)
-type HasCallStack = (?callStack :: CallStack)
-#else
-import GHC.Exts (Constraint)
-type HasCallStack = (() :: Constraint)
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
 #endif
+import GHC.Stack (HasCallStack)
 import Data.ByteArray.Encoding (convertToBase, Base(..))
 import Network.HTTP.Types.Header (hContentType)
 import Data.Aeson (eitherDecode')
@@ -1427,7 +1421,7 @@ getLocation = do
   where decodePath b = let (x, y) = BS8.break (=='?') b
                        in (H.decodePathSegments x, unJust <$> H.parseQueryText y)
         unJust (a, Just b) = (a, b)
-        unJust (a, Nothing) = (a, Data.Monoid.mempty)
+        unJust (a, Nothing) = (a, mempty)
 
 -- | Sets the HTTP method used by the request.
 --

--- a/yesod-test/Yesod/Test/Internal.hs
+++ b/yesod-test/Yesod/Test/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This module exposes functions that are used internally by yesod-test.
@@ -18,7 +19,9 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as DTLE
 import qualified Yesod.Core.Content as Content
-import Data.Semigroup (Semigroup(..))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 
 -- | Helper function to get the first 1024 characters of the body, assuming it is UTF-8.
 -- This function is used to preview the body in case of an assertion failure.

--- a/yesod-test/Yesod/Test/Internal.hs
+++ b/yesod-test/Yesod/Test/Internal.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | This module exposes functions that are used internally by yesod-test.
@@ -19,9 +18,6 @@ import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Encoding as DTLE
 import qualified Yesod.Core.Content as Content
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 
 -- | Helper function to get the first 1024 characters of the body, assuming it is UTF-8.
 -- This function is used to preview the body in case of an assertion failure.

--- a/yesod-test/Yesod/Test/Internal/SIO.hs
+++ b/yesod-test/Yesod/Test/Internal/SIO.hs
@@ -1,14 +1,8 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TypeFamilies #-}
 
 -- | The 'SIO' type is used by "Yesod.Test" to provide exception-safe
 -- environment between requests and assertions.
@@ -24,7 +18,9 @@ import Conduit (MonadThrow)
 import qualified Control.Monad.State.Class as MS
 import Yesod.Core
 import Data.IORef
+#if MIN_VERSION_base(4,13,0)
 import GHC.Stack (HasCallStack)
+#endif
 
 -- | State + IO
 --
@@ -32,10 +28,12 @@ import GHC.Stack (HasCallStack)
 newtype SIO s a = SIO (ReaderT (IORef s) IO a)
   deriving (Functor, Applicative, Monad, MonadIO, MonadThrow, MonadUnliftIO)
 
+#if MIN_VERSION_base(4,13,0)
 -- | @since 1.6.23
 instance MonadFail (SIO s) where
   fail :: HasCallStack => String -> SIO s a
   fail = error
+#endif
 
 instance MS.MonadState s (SIO s)
   where

--- a/yesod-test/Yesod/Test/TransversingCSS.hs
+++ b/yesod-test/Yesod/Test/TransversingCSS.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 {- |

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -30,7 +30,9 @@ import Yesod.Test.TransversingCSS
 import Text.XML
 import Data.Text (Text, pack)
 import Data.Char (toUpper)
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Control.Applicative
 import Network.Wai (pathInfo, rawQueryString, requestHeaders)
 import Network.Wai.Test (SResponse(simpleBody))

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -30,9 +29,6 @@ import Yesod.Test.TransversingCSS
 import Text.XML
 import Data.Text (Text, pack)
 import Data.Char (toUpper)
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Control.Applicative
 import Network.Wai (pathInfo, rawQueryString, requestHeaders)
 import Network.Wai.Test (SResponse(simpleBody))

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.23
+version:            1.6.23.1
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>
@@ -24,7 +24,7 @@ library
   build-depends:
       aeson             >= 1.0     && < 2.3
     , attoparsec        >= 0.10    && < 0.15
-    , base              >= 4.10    && < 5
+    , base              >= 4.11    && < 5
     , blaze-builder     >= 0.3.1   && < 0.5
     , blaze-html        >= 0.5     && < 0.10
     , blaze-markup      >= 0.6     && < 0.9

--- a/yesod-websockets/README.md
+++ b/yesod-websockets/README.md
@@ -1,5 +1,5 @@
 
-## REQUIRED PACKAGES
+## REQUIREMENTS FOR THE EXAMPLES
 
 The example, chat.hs, requires `stm-lifted` and `conduit-combinators`
 which are not dependencies of `yesod-websockets`. Installing the extra
@@ -7,6 +7,9 @@ packages needed for the chat.hs example can be installed with the
 command:
 
     $ cabal install stm-lifted conduit-combinators
+
+The oldest GHC you can use for all examples (`chat.hs`, `chat-with-*.hs`, etc.)
+as of writing this is the one bundled with `base-4.11`, namely `GHC 8.4`.
 
 
 ## TIMEOUTS

--- a/yesod-websockets/chat-with-multiple-channels.hs
+++ b/yesod-websockets/chat-with-multiple-channels.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,7 +13,9 @@ import Control.Monad.Trans.Reader
 import Control.Concurrent (threadDelay)
 import Data.Time
 import Conduit
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Control.Concurrent.STM.Lifted
 import Data.Text (Text)
 import qualified Data.Map as M

--- a/yesod-websockets/chat-with-multiple-channels.hs
+++ b/yesod-websockets/chat-with-multiple-channels.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -13,9 +12,6 @@ import Control.Monad.Trans.Reader
 import Control.Concurrent (threadDelay)
 import Data.Time
 import Conduit
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Control.Concurrent.STM.Lifted
 import Data.Text (Text)
 import qualified Data.Map as M

--- a/yesod-websockets/chat-with-timeout-control.hs
+++ b/yesod-websockets/chat-with-timeout-control.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -13,9 +12,6 @@ import Control.Monad.Trans.Reader
 import Control.Concurrent (threadDelay)
 import Data.Time
 import Conduit
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Control.Concurrent.STM.Lifted
 import Data.Text (Text)
 import UnliftIO.Exception (try, SomeException)

--- a/yesod-websockets/chat-with-timeout-control.hs
+++ b/yesod-websockets/chat-with-timeout-control.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,7 +13,9 @@ import Control.Monad.Trans.Reader
 import Control.Concurrent (threadDelay)
 import Data.Time
 import Conduit
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Control.Concurrent.STM.Lifted
 import Data.Text (Text)
 import UnliftIO.Exception (try, SomeException)

--- a/yesod-websockets/chat.hs
+++ b/yesod-websockets/chat.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -13,9 +12,6 @@ import Control.Monad.Trans.Reader
 import Control.Concurrent (threadDelay)
 import Data.Time
 import Conduit
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup ((<>))
-#endif
 import Control.Concurrent.STM.Lifted
 import Data.Text (Text)
 import UnliftIO.Exception (try, SomeException)

--- a/yesod-websockets/chat.hs
+++ b/yesod-websockets/chat.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,7 +13,9 @@ import Control.Monad.Trans.Reader
 import Control.Concurrent (threadDelay)
 import Data.Time
 import Conduit
-import Data.Monoid ((<>))
+#if !MIN_VERSION_base(4,11,0)
+import Data.Semigroup ((<>))
+#endif
 import Control.Concurrent.STM.Lifted
 import Data.Text (Text)
 import UnliftIO.Exception (try, SomeException)

--- a/yesod/ChangeLog.md
+++ b/yesod/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for yesod
 
+## 1.6.2.2
+
+* Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+
 ## 1.6.2.1
 
 * Support `template-haskell-2.19.0.0` [#1769](https://github.com/yesodweb/yesod/pull/1769)

--- a/yesod/Yesod.hs
+++ b/yesod/Yesod.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
-
 -- | This module simply re-exports from other modules for your convenience.
 module Yesod
     ( -- * Re-exports from yesod-core

--- a/yesod/Yesod/Default/Config.hs
+++ b/yesod/Yesod/Default/Config.hs
@@ -195,7 +195,7 @@ loadConfig (ConfigSettings env parseExtra getFile getObject) = do
             _ -> fail "Expected map"
 
     let host    = fromString $ T.unpack $ fromMaybe "*" $ lookupScalar "host"    m
-    mport <- parseMonad (\x -> x .: "port") m
+    mport <- parseEitherM (\x -> x .: "port") m
     let approot' = fromMaybe "" $ lookupScalar "approot" m
 
     -- Handle the DISPLAY_PORT environment variable for yesod devel
@@ -208,7 +208,7 @@ loadConfig (ConfigSettings env parseExtra getFile getObject) = do
                     Nothing -> return approot'
                     Just p -> return $ prefix `T.append` T.pack (':' : p)
 
-    extra <- parseMonad (parseExtra env) m
+    extra <- parseEitherM (parseExtra env) m
 
     -- set some default arguments
     let port' = fromMaybe 80 mport
@@ -244,5 +244,9 @@ withYamlEnvironment fp env f = do
         Left err ->
           fail $ "Invalid YAML file: " ++ show fp ++ " " ++ prettyPrintParseException err
         Right (Object obj)
-            | Just v <- M.lookup (fromString $ show env) obj -> parseMonad f v
+            | Just v <- M.lookup (fromString $ show env) obj -> parseEitherM f v
         _ -> fail $ "Could not find environment: " ++ show env
+
+-- | Replacement for `parseMonad`
+parseEitherM :: (a -> Parser b) -> a -> IO b
+parseEitherM p = either fail pure . parseEither p

--- a/yesod/Yesod/Default/Config2.hs
+++ b/yesod/Yesod/Default/Config2.hs
@@ -29,7 +29,9 @@ module Yesod.Default.Config2
 
 import Data.Yaml.Config
 
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup
+#endif
 import Data.Aeson
 import System.Environment (getEnvironment)
 import Network.Wai (Application)

--- a/yesod/Yesod/Default/Config2.hs
+++ b/yesod/Yesod/Default/Config2.hs
@@ -29,9 +29,6 @@ module Yesod.Default.Config2
 
 import Data.Yaml.Config
 
-#if !MIN_VERSION_base(4,11,0)
-import Data.Semigroup
-#endif
 import Data.Aeson
 import System.Environment (getEnvironment)
 import Network.Wai (Application)

--- a/yesod/Yesod/Default/Util.hs
+++ b/yesod/Yesod/Default/Util.hs
@@ -23,7 +23,10 @@ import Yesod.Core -- purposely using complete import so that Haddock will see ad
 import Control.Monad (when, unless)
 import Conduit
 import System.Directory (doesFileExist, createDirectoryIfMissing)
-import Language.Haskell.TH.Syntax hiding (makeRelativeToProject)
+import Language.Haskell.TH.Syntax
+#if MIN_VERSION_template_haskell(2,19,0)
+    hiding (makeRelativeToProject)
+#endif
 import Text.Lucius (luciusFile, luciusFileReload)
 import Text.Julius (juliusFile, juliusFileReload)
 import Text.Cassius (cassiusFile, cassiusFileReload)

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -1,5 +1,5 @@
 name:            yesod
-version:         1.6.2.1
+version:         1.6.2.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -18,7 +18,7 @@ library
     if os(windows)
         cpp-options: -DWINDOWS
 
-    build-depends:   base                      >= 4.10     && < 5
+    build-depends:   base                      >= 4.11     && < 5
                    , aeson
                    , bytestring
                    , conduit                   >= 1.3

--- a/yesod/yesod.cabal
+++ b/yesod/yesod.cabal
@@ -25,7 +25,7 @@ library
                    , data-default-class
                    , directory
                    , fast-logger
-                   , file-embed
+                   , file-embed                >= 0.0.10
                    , monad-logger
                    , shakespeare
                    , streaming-commons


### PR DESCRIPTION
Mostly found all the imports of 'Data.Monoid' and 'Data.Semigroup' and removed as much as I can without breaking it.
Used CPP for backwards compatibility where needed.

Thought about using CPP to avoid deprecation warning of 'parseMonad', but defining a helper function seemed way more straightforward.