### PR TITLE
 Add some CSS level 3 structural pseudo-classes

### DIFF
--- a/yesod-test/Yesod/Test/CssQuery.hs
+++ b/yesod-test/Yesod/Test/CssQuery.hs
@@ -54,7 +54,7 @@ data Selector
   | ByAttrContains Text Text
   | ByAttrStarts Text Text
   | ByAttrEnds Text Text
-  | Asterisk  -- TODO: This needs to be deep.
+  | Asterisk
   deriving (Show, Eq)
 
 
@@ -78,14 +78,14 @@ parseQuery = parseOnly cssQuery
 
 -- Below this line is the Parsec parser for css queries.
 cssQuery :: Parser [[SelectorGroup]]
-cssQuery = many (char ' ') >> sepBy rules (char ',' >> many (char ' '))
+cssQuery = (many (char ' ') >> sepBy rules (char ',' >> many (char ' ')))
 
 rules :: Parser [SelectorGroup]
 rules = many $ directChildren <|> deepChildren
 
 directChildren :: Parser SelectorGroup
 directChildren =
-    string "> " >> (many (char ' ')) >> DirectChildren <$> pOptionalTrailingSpace parseSelectorTypes
+    string "> " >> many (char ' ') >> DirectChildren <$> pOptionalTrailingSpace parseSelectorTypes
 
 deepChildren :: Parser SelectorGroup
 deepChildren = pOptionalTrailingSpace $ DeepChildren <$> parseSelectorTypes

--- a/yesod-test/Yesod/Test/TransversingCSS.hs
+++ b/yesod-test/Yesod/Test/TransversingCSS.hs
@@ -117,3 +117,21 @@ selector c (ByAttrEnds n v) =
     case attribute (Name n Nothing Nothing) c of
         t:_ -> v `T.isSuffixOf` t
         [] -> False
+selector c (ByPseudoClass FirstChild) = null $ precedingSibling c
+selector c (ByPseudoClass LastChild) = null $ followingSibling c
+selector c (ByPseudoClass (NthChild anpb)) = let i = index1 c in
+  case anpb of
+    Repetition 0 b -> i == b 
+    Repetition a b | a <= 0 -> i <= b 
+    Repetition a b -> i >= b && (i + b) `mod` a == 0
+    Position p -> i == p
+    Odd -> odd i
+    Even -> even i
+
+-- | Returns the index of the node at a cursor amongst its siblings, starting at 1.
+index1 :: Cursor -> Int
+index1 = (+ 1) . index 
+
+-- | Returns the index of the node at a cursor amongst its siblings, starting at 0.
+index :: Cursor -> Int
+index = length . precedingSibling

--- a/yesod-test/Yesod/Test/TransversingCSS.hs
+++ b/yesod-test/Yesod/Test/TransversingCSS.hs
@@ -89,7 +89,7 @@ runQuery html query = concatMap (runGroup html) query
 runGroup :: Cursor -> [SelectorGroup] -> [Cursor]
 runGroup c [] = [c]
 runGroup c (DirectChildren s:gs) = concatMap (flip runGroup gs) $ c $/ selectors s
-runGroup c (DeepChildren s:gs) = concatMap (flip runGroup gs) $ c $// selectors s
+runGroup c (DeepChildren s:gs) = concatMap (flip runGroup gs) $ c $.// selectors s
 
 selectors :: [SelectorType] -> Cursor -> [Cursor]
 selectors cs c
@@ -125,7 +125,9 @@ selector c (ByAttrEnds n v) =
     case attribute (Name n Nothing Nothing) c of
         t:_ -> v `T.isSuffixOf` t
         [] -> False
-selector _ Asterisk = True
+selector c Asterisk = case node c of
+  NodeElement _ -> True
+  _ -> False
 
 pseudoselector :: Cursor -> Selector -> PseudoSelector -> Bool
 pseudoselector c _ FirstChild = null $ precedingSibling c

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -72,17 +72,17 @@ mkYesod "RoutedApp" [parseRoutes|
 main :: IO ()
 main = hspec $ do
     describe "CSS selector parsing" $ do
-        it "elements" $ parseQuery_ "strong" @?= [[DeepChildren [ByTagName "strong"]]]
-        it "child elements" $ parseQuery_ "strong > i" @?= [[DeepChildren [ByTagName "strong"], DirectChildren [ByTagName "i"]]]
-        it "comma" $ parseQuery_ "strong.bar, #foo" @?= [[DeepChildren [ByTagName "strong", ByClass "bar"]], [DeepChildren [ById "foo"]]]
+        it "elements" $ parseQuery_ "strong" @?= [[DeepChildren [SimpleSelector (ByTagName "strong")]]]
+        it "child elements" $ parseQuery_ "strong > i" @?= [[DeepChildren [SimpleSelector (ByTagName "strong")], DirectChildren [SimpleSelector (ByTagName "i")]]]
+        it "comma" $ parseQuery_ "strong.bar, #foo" @?= [[DeepChildren [SimpleSelector (ByTagName "strong"), SimpleSelector (ByClass "bar")]], [DeepChildren [SimpleSelector (ById "foo")]]]
         describe "pseudo-classes" $ do
           it ":first-child, :last-child" $
-            parseQuery_ "p:first-child, p:last-child" @?= [[DeepChildren [ByTagName "p", ByPseudoClass FirstChild]], [DeepChildren [ByTagName "p", ByPseudoClass LastChild]]]
+            parseQuery_ "p:first-child, p:last-child" @?= [[DeepChildren [CompoundSelector (ByTagName "p") [FirstChild]]], [DeepChildren [CompoundSelector (ByTagName "p") [LastChild]]]]
           it ":nth-child" $ do
-            parseQuery_ ":nth-child(3n)" @?= [[DeepChildren [ByPseudoClass $ NthChild $ Repetition 3 0]]]
-            assertQueries [":nth-child(2n+1)", ":nth-child( 2n+1   )", ":nth-child(  2n +1)", ":nth-child(2n+   1 )"] [[DeepChildren [ByPseudoClass $ NthChild $ Repetition 2 1]]]
-            parseQuery_ "a > span:nth-child(2)" @?= [[DeepChildren [ByTagName "a"], DirectChildren [ByTagName "span", ByPseudoClass $ NthChild $ Position 2]]]
-            parseQuery_ "tr:nth-child(odd), tr:nth-child(even)" @?= [[DeepChildren [ByTagName "tr", ByPseudoClass $ NthChild Odd]], [DeepChildren [ByTagName "tr", ByPseudoClass $ NthChild Even]]]
+            assertQueries ["*:nth-child(3n)", ":nth-child(3n)"] [[DeepChildren [CompoundSelector Asterisk [NthChild $ Repetition 3 0]]]]
+            assertQueries [":nth-child(2n+1)", ":nth-child( 2n+1   )", ":nth-child(  2n +1)", ":nth-child(2n+   1 )"] [[DeepChildren [CompoundSelector Asterisk [NthChild $ Repetition 2 1]]]]
+            parseQuery_ "a > span:nth-child(2)" @?= [[DeepChildren [SimpleSelector (ByTagName "a")], DirectChildren [CompoundSelector (ByTagName "span") [NthChild $ Position 2]]]]
+            parseQuery_ "tr:nth-child(odd), tr:nth-child(even)" @?= [[DeepChildren [CompoundSelector (ByTagName "tr") [NthChild Odd]]], [DeepChildren [CompoundSelector (ByTagName "tr") [NthChild Even]]]]
     describe "find by selector" $ do
         it "XHTML" $
             let html = "<html><head><title>foo</title></head><body><p>Hello World</p></body></html>"

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -130,6 +130,8 @@ main = hspec $ do
             findBySelector_ html "p:nth-child(-n-1)" @?= []
             findBySelector_ html "p:nth-child(-n-0)" @?= []
             findBySelector_ html "p:nth-child(-n+3)" @?= ["<p>1</p>", "<p>2</p>", "<p>3</p>"]
+            let ps = ["<p>" <> show n <> "</p>" | n <- [1..10]] in
+              findBySelector_ html "*" @?= ["<html>" <> concat ps <> "</html>"] <> ps
         
     describe "HTML parsing" $ do
         it "XHTML" $

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.6.23.1
+version:            1.6.24
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>


### PR DESCRIPTION
This PR adds the following CSS level 3 structural pseudo-classes to `yesod-test`:

- `:first-child`
- `:last-child`
- `:nth-child` (with an implementation of the 'an + b' syntax)

[Reference material](https://www.w3.org/TR/selectors-3/#nth-child-pseudo)

These pseudo-classes facilitate easier matching of sequential elements and are particularly useful when inspecting lists or tables. 

---

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
