### PR TITLE
Allow disabling of resources generation

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,8 +1,14 @@
 # ChangeLog for yesod-core
 
+<<<<<<< Updated upstream
 ## 1.6.27.1
 
 * Set `base >= 4.11` for less CPP and imports [#1876](https://github.com/yesodweb/yesod/pull/1876)
+=======
+## 1.6.28.0
+
+* Allow users to control generation of the `resourcesSite :: [ResourceTree String]` value. []()
+>>>>>>> Stashed changes
 
 ## 1.6.27.0
 

--- a/yesod-core/src/Yesod/Core/Dispatch.hs
+++ b/yesod-core/src/Yesod/Core/Dispatch.hs
@@ -28,6 +28,7 @@ module Yesod.Core.Dispatch
     , setEqDerived
     , setShowDerived
     , setReadDerived
+    , setCreateResources
       -- *** Helpers
     , defaultGen
     , getGetMaxExpires

--- a/yesod-core/src/Yesod/Routes/TH/RenderRoute.hs
+++ b/yesod-core/src/Yesod/Routes/TH/RenderRoute.hs
@@ -9,12 +9,14 @@ module Yesod.Routes.TH.RenderRoute
     , mkRouteCons
     , mkRouteConsOpts
     , mkRenderRouteClauses
+    , shouldCreateResources
 
     , RouteOpts
     , defaultOpts
     , setEqDerived
     , setShowDerived
     , setReadDerived
+    , setCreateResources
     ) where
 
 import Yesod.Routes.TH.Types
@@ -29,23 +31,28 @@ import Yesod.Routes.Class
 
 -- | General opts data type for generating yesod.
 --
--- Contains options for what instances are derived for the route. Use the setting
--- functions on `defaultOpts` to set specific fields.
+-- Contains options for customizing code generation for the router in
+-- 'mkYesodData', including what type class instances will be derived for
+-- the route datatype and whether or not to create the @resources ::
+-- [ResourceTree String]@ value. Use the setting functions on `defaultOpts`
+-- to set specific fields.
 --
 -- @since 1.6.25.0
 data RouteOpts = MkRouteOpts
     { roDerivedEq   :: Bool
     , roDerivedShow :: Bool
     , roDerivedRead :: Bool
+    , roCreateResources :: Bool
     }
 
 -- | Default options for generating routes.
 --
--- Defaults to all instances derived.
+-- Defaults to all instances derived and to create the @resourcesSite ::
+-- [ResourceTree String]@ term.
 --
 -- @since 1.6.25.0
 defaultOpts :: RouteOpts
-defaultOpts = MkRouteOpts True True True
+defaultOpts = MkRouteOpts True True True True
 
 -- |
 --
@@ -65,12 +72,34 @@ setShowDerived b rdo = rdo { roDerivedShow = b }
 setReadDerived :: Bool -> RouteOpts -> RouteOpts
 setReadDerived b rdo = rdo { roDerivedRead = b }
 
+-- | Determine whether or not to generate the @resourcesApp@ value.
+--
+-- Disabling this can be useful if you are creating the @routes ::
+-- [ResourceTree String]@ elsewhere in your module, and referring to it
+-- here. The @resourcesApp@ can become very large in large applications,
+-- and duplicating it can result in signifiacntly higher compile times.
+--
+-- @since 1.6.28.0
+setCreateResources :: Bool -> RouteOpts -> RouteOpts
+setCreateResources b rdo = rdo { roCreateResources = b }
+
+-- | Returns whether or not we should create the @resourcesSite ::
+-- [ResourceTree String]@ value during code generation.
+--
+-- @since 1.6.28.0
+shouldCreateResources :: RouteOpts -> Bool
+shouldCreateResources = roCreateResources
+
 -- |
 --
 -- @since 1.6.25.0
 instanceNamesFromOpts :: RouteOpts -> [Name]
-instanceNamesFromOpts (MkRouteOpts eq shw rd) = prependIf eq ''Eq $ prependIf shw ''Show $ prependIf rd ''Read []
+instanceNamesFromOpts (MkRouteOpts eq shw rd _) = prependIf eq ''Eq $ prependIf shw ''Show $ prependIf rd ''Read []
     where prependIf b = if b then (:) else const id
+
+-- |
+--
+-- @since 1.6.28.0
 
 -- | Generate the constructors of a route data type.
 mkRouteCons :: [ResourceTree Type] -> Q ([Con], [Dec])

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,9 @@
 name:            yesod-core
+<<<<<<< Updated upstream
 version:         1.6.27.1
+=======
+version:         1.6.28.0
+>>>>>>> Stashed changes
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This PR adds a setting to `RouteOpts` to allow users to control whether or not the code generation includes the `resourcesSite :: [ResourceTree String]` value.

In our web app, the generated TH code takes up about 40,000 lines. A good 1/3 of this is the `resourcesApp` value. But we already generate this in another file with `parseRouteFile`, so it is redundant.

On the timing impact: before this PR, our `P50(duration_s)` for compiling the module that only does `mkYesodData` is 6.456s. We have just under 2k routes. After, {i will fill in after running the test and collecting data}.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
