### PR TITLE
Add comment re: `ContentBuilder`'s default forcing behavior

### DIFF
--- a/yesod-core/src/Yesod/Core/Types.hs
+++ b/yesod-core/src/Yesod/Core/Types.hs
@@ -298,9 +298,17 @@ data PageContent url = PageContent
     }
 
 data Content = ContentBuilder !BB.Builder !(Maybe Int) -- ^ The content and optional content length.
+             --
+             -- Note that, despite @Builder@'s laziness, this is entirely forced
+             -- into memory by default in order to catch imprecise exceptions
+             -- before beginning to respond. If you are confident you don't have
+             -- imprecise exceptions, you may disable this by wrapping the
+             -- `ToContent` data in `DontFullyEvaluate`.
              | ContentSource !(ConduitT () (Flush BB.Builder) (ResourceT IO) ())
              | ContentFile !FilePath !(Maybe FilePart)
              | ContentDontEvaluate !Content
+             -- ^ Used internally to wrap @ContentBuilder@s to disable forcing
+             -- them. No effect on other @Content@.
 
 data TypedContent = TypedContent !ContentType !Content
 


### PR DESCRIPTION
There was a comment introduced by
https://github.com/yesodweb/yesod/commit/f91ff4fde2ee1dcfb8e8ebc48ce75477936c34bd but it's since been removed.

<img width="1474" height="502" alt="image" src="https://github.com/user-attachments/assets/65fa8993-4e91-420e-a585-01212e75939c" />
