### PR TITLE
Add Stack dependency caching to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,14 +31,18 @@ jobs:
       - name: Clone project
         uses: actions/checkout@v4
 
-# Getting weird OS X errors...
-#      - name: Cache dependencies
-#        uses: actions/cache@v1
-#        with:
-#          path: ~/.stack
-#          key: ${{ runner.os }}-${{ matrix.resolver }}-${{ hashFiles('stack.yaml') }}
-#          restore-keys: |
-#            ${{ runner.os }}-${{ matrix.resolver }}-
+      - name: Cache Stack dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.stack
+          key: stack-${{ runner.os }}-${{ matrix.args }}-${{ hashFiles('**/*.cabal', 'stack.yaml', 'stack-lts-22.yaml') }}
+          restore-keys: |
+            stack-${{ runner.os }}-${{ matrix.args }}-
+            stack-${{ runner.os }}-
+
+      - name: Remove Stack lock files
+        shell: bash
+        run: rm -rf ~/.stack/setup-exe-cache ~/.stack/pantry/pantry.sqlite3.pantry-write-lock
 
       - name: Install stack if needed
         shell: bash


### PR DESCRIPTION
Replace the commented-out actions/cache@v1 with actions/cache@v4. Caches ~/.stack (GHC installations and snapshot packages) keyed by OS, resolver args, and hashes of cabal/stack config files. Includes a cleanup step to remove lock files that previously caused macOS issues with cache@v1.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
