### PR TITLE
Remove exported internal functions

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,15 @@
 # ChangeLog for yesod-core
 
+## 1.6.30.0
+
+* Remove internal utility functions inadvertently exported from `Yesod.Core.Types` in 1.6.29.0 [#1908](https://github.com/yesodweb/yesod/pull/1908):
+  * `putTime`
+  * `getTime`
+  * `formatW3`
+  * `formatRFC1123`
+  * `formatRFC822`
+  * `getCurrentMaxExpiresRFC1123`
+
 ## 1.6.29.1
 
 * Fix compilation error for text >= 2.1.2 [#1905](https://github.com/yesodweb/yesod/pull/1905)

--- a/yesod-core/src/Yesod/Core/Types.hs
+++ b/yesod-core/src/Yesod/Core/Types.hs
@@ -15,7 +15,6 @@ module Yesod.Core.Types (
   , module Yesod.Core.Types.TypedContent
   , module Yesod.Core.Types.HandlerContents
 
-  , module Yesod.Core.Internal.Util
   , module Yesod.Routes.Class
   , module Yesod.Core.TypeCache
   ) where

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.6.29.1
+version:         1.6.30.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Fixes #1907

The PVP says removing these exports requires a major version bump, but it seems fine to bend the rules here with a minor version bump. Alternatively this PR could be bundled with a future major release.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)