### PR TITLE
Add attributes directly to resource parent

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -3,6 +3,7 @@
 ## UNRELEASED (major version bump)
 
 * Add the ability to focus on a nested route structure during code generation, allowing datatypes and dispatches to be generated in separate modules. [#1887](https://github.com/yesodweb/yesod/pull/1887)
+* Extend `ResourceParent` to include route attributes. Replace `frParentPieces` with `frParentDetails` to refer to a parent's attributes. [1911](https://github.com/yesodweb/yesod/pull/1911)
 
 ## 1.6.29.1
 

--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -3,7 +3,7 @@
 ## UNRELEASED (major version bump)
 
 * Add the ability to focus on a nested route structure during code generation, allowing datatypes and dispatches to be generated in separate modules. [#1887](https://github.com/yesodweb/yesod/pull/1887)
-* Extend `ResourceParent` to include route attributes. Replace `frParentPieces` with `frParentDetails` to refer to a parent's attributes. [1911](https://github.com/yesodweb/yesod/pull/1911)
+* Extend `ResourceParent` to include route attributes. Replace `frParentPieces` with `frParentDetails` to gather a parent's pieces and attributes. [1911](https://github.com/yesodweb/yesod/pull/1911)
 
 ## 1.6.29.1
 

--- a/yesod-core/src/Yesod/Core/Internal/TH.hs
+++ b/yesod-core/src/Yesod/Core/Internal/TH.hs
@@ -350,7 +350,7 @@ mkYesodSubDispatchInstance nameStr resS = do
     -- Find nested routes and generate YesodSubDispatchNested instances
     let findNested :: [ResourceTree a] -> [String]
         findNested [] = []
-        findNested (ResourceParent n _ _ _ : rest) = n : findNested rest
+        findNested (ResourceParent n _ _ _ _ : rest) = n : findNested rest
         findNested (_ : rest) = findNested rest
         nestedNames = findNested res
 

--- a/yesod-core/src/Yesod/Routes/Overlap.hs
+++ b/yesod-core/src/Yesod/Routes/Overlap.hs
@@ -24,7 +24,7 @@ flatten =
         , fHasSuffix = hasSuffix $ ResourceLeaf r
         , fCheck = check && resourceCheck r
         }
-    go names pieces check (ResourceParent newname check' newpieces children) =
+    go names pieces check (ResourceParent newname check' _attrs newpieces children) =
         concatMap (go names' pieces' (check && check')) children
       where
         names' = names . (newname:)

--- a/yesod-core/src/Yesod/Routes/Parse.hs
+++ b/yesod-core/src/Yesod/Routes/Parse.hs
@@ -107,7 +107,7 @@ resourcesFromString =
                                 (p, Nothing, c) -> (p, c)
                                 -- FIXME: Give better error message
                                 _ -> error "Invalid resource line: bad overlap"
-                     in ((ResourceParent constr check pieces children' :), otherLines'')
+                     in ((ResourceParent constr check (Set.fromList attrs) pieces children' :), otherLines'')
                 (pattern:constr:rest) ->
                     let (pieces, mmulti, check) = piecesFromStringCheck pattern
                         (attrs, rest') = takeAttrs rest
@@ -154,7 +154,7 @@ addAttrs attrs =
     map goTree
   where
     goTree (ResourceLeaf res) = ResourceLeaf (goRes res)
-    goTree (ResourceParent w x y z) = ResourceParent w x y (map goTree z)
+    goTree (ResourceParent v w x y z) = ResourceParent v w x y (map goTree z)
 
     goRes res =
         res { resourceAttrs = noDupes ++ resourceAttrs res }

--- a/yesod-core/src/Yesod/Routes/TH/Dispatch.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Dispatch.hs
@@ -227,7 +227,7 @@ mkDispatchClause phase preDyns parentCons tyargs MkDispatchSettings {..} resourc
         addPat x y = conPCompat '(:) [x, y]
 
     go :: DispatchPhase -> NestedRouteSettings -> SDC -> ResourceTree a -> Q ([String], [Clause])
-    go goPhase nrs sdc (ResourceParent name _check pieces children) = do
+    go goPhase nrs sdc (ResourceParent name _check _attrs pieces children) = do
         let mtargetName = nrsTargetName nrs
         let mtargetMatch =
                 fmap (name ==) mtargetName
@@ -613,7 +613,7 @@ mkNestedDispatchInstance routeOpts target master cxt tyargs unwrapper res = do
     childInstances <-
         fmap mconcat $ forM subres $ \childRes -> do
             case childRes of
-                ResourceParent name _ _ _ -> do
+                ResourceParent name _ _ _ _ -> do
                     instanceExists <- fmap (fromMaybe False) . runMaybeT $ do
                         tyname <- MaybeT $ lookupTypeName name
                         nameAppliedT <- Trans.lift $ case tyargs of
@@ -729,7 +729,7 @@ mkNestedSubDispatchInstance routeOpts target cxt tyargs unwrapper res = do
     childInstances <-
         fmap mconcat $ forM subres $ \childRes -> do
             case childRes of
-                ResourceParent name _ _ _ -> do
+                ResourceParent name _ _ _ _ -> do
                     instanceExists <- fmap (fromMaybe False) . runMaybeT $ do
                         tyname <- MaybeT $ lookupTypeName name
                         nameAppliedT <- Trans.lift $ case tyargs of
@@ -840,7 +840,7 @@ genNestedDispatchClauses config routeOpts _parentDepth parentDynsP toParentE yre
                                 `AppE` reqExp'
                 return [Match (foldr consPat (VarP restPath) pats) (NormalB $ ConE 'Just `AppE` subsiteExp) []]
 
-    genClauseForResource (ResourceParent name _check pieces _children) = do
+    genClauseForResource (ResourceParent name _check _attrs pieces _children) = do
         (pats, dynVars) <- genPiecePats pieces
 
         -- Build the parent args tuple for the nested call

--- a/yesod-core/src/Yesod/Routes/TH/Internal.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Internal.hs
@@ -65,7 +65,7 @@ findNestedRoute target (res : ress) =
     case res of
         ResourceLeaf _ ->
             findNestedRoute target ress
-        ResourceParent name _overlap pieces children -> do
+        ResourceParent name _overlap _attrs pieces children -> do
             if name == target
                 then Just (pieces, children)
                 else

--- a/yesod-core/src/Yesod/Routes/TH/ParseRoute.hs
+++ b/yesod-core/src/Yesod/Routes/TH/ParseRoute.hs
@@ -74,7 +74,7 @@ mkParseRouteInstanceOpts routeOpts origTyargs cxt typ unfocusedRess = do
                     case res of
                         ResourceLeaf _ ->
                             acc
-                        ResourceParent name _ _ children ->
+                        ResourceParent name _ _ _ children ->
                             if name == target
                             then children
                             else focusTarget children <> acc
@@ -121,7 +121,7 @@ generateParseRouteClause routeOpts resourceTree =
                     expr <- liftQ [e| fmap $(pure route) ( parseRoute $(pure tupExp) ) |]
                     pure $ Clause [pat] (NormalB expr) []
 
-        ResourceParent name _check pieces _children -> do
+        ResourceParent name _check _attrs pieces _children -> do
             recordNameIfNotInstance name
 
             (pats, dyns) <- handlePieces pieces

--- a/yesod-core/src/Yesod/Routes/TH/RenderRoute.hs
+++ b/yesod-core/src/Yesod/Routes/TH/RenderRoute.hs
@@ -277,7 +277,7 @@ mkRouteConsOpts opts cxt origTyargs master resourceTrees = do
                 Subsite { subsiteType = typ } -> [ConT ''Route `AppT` typ]
                 _ -> []
 
-    mkRouteCon prePieces (ResourceParent name _check pieces children) = do
+    mkRouteCon prePieces (ResourceParent name _check _attrs pieces children) = do
         -- Accumulate pieces for children: combine parent pieces with this route's pieces
         let accumulatedPieces = prePieces <> pieces
         (cons, decs) <- mkRouteConsOpts' accumulatedPieces children
@@ -373,7 +373,7 @@ mkRenderRouteClauses =
     isDynamic Dynamic{} = True
     isDynamic _ = False
 
-    go (ResourceParent name _check pieces _children) = do
+    go (ResourceParent name _check _attrs pieces _children) = do
         let cnt = length $ filter isDynamic pieces
         dyns <- replicateM cnt $ newName "dyn"
         child <- newName "child"
@@ -471,7 +471,7 @@ mkRenderRouteNestedClauses parentArgsNames resources = do
     isDynamic Dynamic{} = True
     isDynamic _ = False
 
-    go (ResourceParent name _check pieces _children) = do
+    go (ResourceParent name _check _attrs pieces _children) = do
         let cnt = length $ filter isDynamic pieces
         dyns <- replicateM cnt $ newName "dyn"
         child <- newName "child"
@@ -677,7 +677,7 @@ mkToParentRouteInstances routeOpts cxt origTyargs ress = do
   where
     go _ (ResourceLeaf _) =
         pure []
-    go (accPieces, parentConstructors) (ResourceParent name _check pieces children) = do
+    go (accPieces, parentConstructors) (ResourceParent name _check _attrs pieces children) = do
         -- Extract dynamic types from accumulated parent pieces
         let accDynTypes = [t | Dynamic t <- accPieces]
         accDynVars <- mapM (\_ -> newName "parent") accDynTypes
@@ -863,7 +863,7 @@ mkRenderRouteNestedInstanceOpts routeOpts cxt tyargs typ prepieces target ress =
                 Subsite { subsiteType = subtyp } -> [ConT ''Route `AppT` subtyp]
                 _ -> []
 
-    mkRouteCon' prePieces (ResourceParent name _check pieces children) = do
+    mkRouteCon' prePieces (ResourceParent name _check _attrs pieces children) = do
         -- For nested parents within the focused route, recursively generate
         let accumulatedPieces = prePieces <> pieces
         (cons, decs) <- mkRouteConsOpts' accumulatedPieces children

--- a/yesod-core/src/Yesod/Routes/TH/RouteAttrs.hs
+++ b/yesod-core/src/Yesod/Routes/TH/RouteAttrs.hs
@@ -45,9 +45,9 @@ goTree mtarget front (ResourceLeaf res) =
             return $ toList $ goRes front res
         Just _ ->
             return []
-goTree (Just target) front (ResourceParent name _check _pieces trees)
+goTree (Just target) front (ResourceParent name _check _attrs _pieces trees)
     | target /= name = concat <$> mapM (goTree (Just target) front) trees
-goTree mtarget front (ResourceParent name _check pieces trees) = do
+goTree mtarget front (ResourceParent name _check _attrs pieces trees) = do
     doesTypeExist <- lookupTypeName name
     doesNestedInstanceExist <-
         case doesTypeExist of

--- a/yesod-core/src/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Types.hs
@@ -18,19 +18,20 @@ module Yesod.Routes.TH.Types
     ) where
 
 import Language.Haskell.TH.Syntax
+import Data.Set (Set)
 
 data ResourceTree typ
     = ResourceLeaf (Resource typ)
-    | ResourceParent String CheckOverlap [Piece typ] [ResourceTree typ]
+    | ResourceParent String CheckOverlap (Set String) [Piece typ] [ResourceTree typ]
     deriving (Lift, Show, Functor)
 
 resourceTreePieces :: ResourceTree typ -> [Piece typ]
 resourceTreePieces (ResourceLeaf r) = resourcePieces r
-resourceTreePieces (ResourceParent _ _ x _) = x
+resourceTreePieces (ResourceParent _ _ _ x _) = x
 
 resourceTreeName :: ResourceTree typ -> String
 resourceTreeName (ResourceLeaf r) = resourceName r
-resourceTreeName (ResourceParent x _ _ _) = x
+resourceTreeName (ResourceParent x _ _ _ _) = x
 
 data Resource typ = Resource
     { resourceName :: String
@@ -82,5 +83,5 @@ flatten =
     concatMap (go id True)
   where
     go front check' (ResourceLeaf (Resource a b c _ check)) = [FlatResource (front []) a b c (check' && check)]
-    go front check' (ResourceParent name check pieces children) =
+    go front check' (ResourceParent name check _attrs pieces children) =
         concatMap (go (front . ((name, pieces):)) (check && check')) children

--- a/yesod-core/src/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Types.hs
@@ -72,6 +72,7 @@ resourceMulti _ = Nothing
 
 data FlatResource a = FlatResource
     { frParentPieces :: [(String, [Piece a])]
+    , frParentAttrs :: [(String, Set String)]
     , frName :: String
     , frPieces :: [Piece a]
     , frDispatch :: Dispatch a
@@ -80,8 +81,9 @@ data FlatResource a = FlatResource
 
 flatten :: [ResourceTree a] -> [FlatResource a]
 flatten =
-    concatMap (go id True)
+    concatMap (go id id True)
   where
-    go front check' (ResourceLeaf (Resource a b c _ check)) = [FlatResource (front []) a b c (check' && check)]
-    go front check' (ResourceParent name check _attrs pieces children) =
-        concatMap (go (front . ((name, pieces):)) (check && check')) children
+    go pp pa check' (ResourceLeaf (Resource a b c _ check)) =
+        [FlatResource (pp []) (pa []) a b c (check' && check)]
+    go pp pa check' (ResourceParent name check attrs pieces children) =
+        concatMap (go (pp . ((name, pieces):)) (pa . ((name, attrs):)) (check && check')) children

--- a/yesod-core/src/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Types.hs
@@ -19,6 +19,8 @@ module Yesod.Routes.TH.Types
 
 import Language.Haskell.TH.Syntax
 import Data.Set (Set)
+-- Provides Lift instance for Set in older versions of GHC
+import Instances.TH.Lift ()
 
 data ResourceTree typ
     = ResourceLeaf (Resource typ)

--- a/yesod-core/src/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Types.hs
@@ -73,6 +73,7 @@ resourceMulti _ = Nothing
 data FlatResource a = FlatResource
     { frParentPieces :: [(String, [Piece a])]
     , frParentAttrs :: [(String, Set String)]
+    -- ^ @since TODO
     , frName :: String
     , frPieces :: [Piece a]
     , frDispatch :: Dispatch a

--- a/yesod-core/src/Yesod/Routes/TH/Types.hs
+++ b/yesod-core/src/Yesod/Routes/TH/Types.hs
@@ -10,6 +10,7 @@ module Yesod.Routes.TH.Types
     , Dispatch (..)
     , CheckOverlap
     , FlatResource (..)
+    , ParentDetails (..)
       -- ** Helper functions
     , resourceMulti
     , resourceTreePieces
@@ -72,10 +73,14 @@ resourceMulti :: Resource typ -> Maybe typ
 resourceMulti Resource { resourceDispatch = Methods (Just t) _ } = Just t
 resourceMulti _ = Nothing
 
+data ParentDetails a = ParentDetails
+    { pdName :: String
+    , pdPieces :: [Piece a]
+    , pdAttrs :: Set String
+    } deriving (Show)
+
 data FlatResource a = FlatResource
-    { frParentPieces :: [(String, [Piece a])]
-    , frParentAttrs :: [(String, Set String)]
-    -- ^ @since TODO
+    { frParentDetails :: [ParentDetails a]
     , frName :: String
     , frPieces :: [Piece a]
     , frDispatch :: Dispatch a
@@ -84,9 +89,9 @@ data FlatResource a = FlatResource
 
 flatten :: [ResourceTree a] -> [FlatResource a]
 flatten =
-    concatMap (go id id True)
+    concatMap (go id True)
   where
-    go pp pa check' (ResourceLeaf (Resource a b c _ check)) =
-        [FlatResource (pp []) (pa []) a b c (check' && check)]
-    go pp pa check' (ResourceParent name check attrs pieces children) =
-        concatMap (go (pp . ((name, pieces):)) (pa . ((name, attrs):)) (check && check')) children
+    go front check' (ResourceLeaf (Resource a b c _ check)) =
+        [FlatResource (front []) a b c (check' && check)]
+    go front check' (ResourceParent name check attrs pieces children) =
+        concatMap (go (front . ((ParentDetails name pieces attrs):)) (check && check')) children

--- a/yesod-core/test/Route/RouteAttrSpec.hs
+++ b/yesod-core/test/Route/RouteAttrSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE ViewPatterns#-}
+
+module Route.RouteAttrSpec where
+
+import Yesod.Core
+import Test.Hspec
+import Yesod.Routes.TH.Types
+import Data.Set (Set)
+import qualified Data.Set as Set
+
+routeNoAttributes :: [ResourceTree String]
+routeNoAttributes = [parseRoutes|
+/one OneR:
+  /two TwoR:
+    /three ThreeR:
+      /four FourR POST
+  |]
+
+routeWithAttributes :: [ResourceTree String]
+routeWithAttributes = [parseRoutes|
+/one OneR:
+  /two TwoR !x !z:
+    /three ThreeR !y:
+      /four FourR POST
+  |]
+
+spec :: Spec
+spec = do
+    describe "route attrs present" $ do
+        it "has no route attrs on parent" $ do
+            let parentAttrs = frParentAttrs <$> flatten routeNoAttributes
+            let attrs :: Set (String, Set String)
+                attrs = Set.fromList $ concat parentAttrs
+            attrs
+                `shouldBe`
+                    Set.fromList 
+                        [ ("OneR", Set.empty)
+                        , ("TwoR", Set.empty)
+                        , ("ThreeR", Set.empty)
+                        ]
+        it "has route attrs on parent" $ do
+            let parentAttrs = frParentAttrs <$> flatten routeWithAttributes
+            let attrs :: Set (String, Set String)
+                attrs = Set.fromList $ concat parentAttrs
+            attrs
+                `shouldBe`
+                    Set.fromList 
+                        [ ("OneR", Set.empty)
+                        , ("TwoR", Set.fromList ["x", "z"])
+                        , ("ThreeR", Set.singleton "y")
+                        ]

--- a/yesod-core/test/Route/RouteAttrSpec.hs
+++ b/yesod-core/test/Route/RouteAttrSpec.hs
@@ -1,18 +1,4 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeSynonymInstances #-}
-{-# LANGUAGE ViewPatterns#-}
 
 module Route.RouteAttrSpec where
 

--- a/yesod-core/test/Route/RouteAttrSpec.hs
+++ b/yesod-core/test/Route/RouteAttrSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Route.RouteAttrSpec where
+module Route.RouteAttrSpec (spec) where
 
 import Yesod.Core
 import Test.Hspec
@@ -28,10 +28,9 @@ spec :: Spec
 spec = do
     describe "route attrs present" $ do
         it "has no route attrs on parent" $ do
-            let parentAttrs = frParentAttrs <$> flatten routeNoAttributes
-            let attrs :: Set (String, Set String)
-                attrs = Set.fromList $ concat parentAttrs
-            attrs
+            let parentDetails = concat $ frParentDetails <$> flatten routeNoAttributes
+            let attrs = (\detail -> (pdName detail, pdAttrs detail)) <$> parentDetails
+            Set.fromList attrs
                 `shouldBe`
                     Set.fromList 
                         [ ("OneR", Set.empty)
@@ -39,10 +38,9 @@ spec = do
                         , ("ThreeR", Set.empty)
                         ]
         it "has route attrs on parent" $ do
-            let parentAttrs = frParentAttrs <$> flatten routeWithAttributes
-            let attrs :: Set (String, Set String)
-                attrs = Set.fromList $ concat parentAttrs
-            attrs
+            let parentDetails = concat $ frParentDetails <$> flatten routeWithAttributes
+            let attrs = (\detail -> (pdName detail, pdAttrs detail)) <$> parentDetails
+            Set.fromList attrs
                 `shouldBe`
                     Set.fromList 
                         [ ("OneR", Set.empty)

--- a/yesod-core/test/RouteSpec.hs
+++ b/yesod-core/test/RouteSpec.hs
@@ -24,6 +24,7 @@ import Hierarchy
 import qualified Data.Set as Set
 import qualified Route.FallthroughSpec as FallthroughSpec
 import qualified Route.RenderRouteSpec as RenderRouteSpec
+import qualified Route.RouteAttrSpec as RouteAttrSpec
 import qualified Data.Text as Text
 
 data MyApp = MyApp
@@ -67,6 +68,7 @@ do
         resParent = ResourceParent
             "ParentR"
             True
+            mempty
             [ Static "foo"
             , Dynamic "Text"
             ]
@@ -88,6 +90,7 @@ main :: IO ()
 main = hspec $ do
     describe "Route.FallthroughSpec" FallthroughSpec.spec
     describe "Route.RenderRouteSpec" RenderRouteSpec.spec
+    describe "Route.RouteAttrSpec" RouteAttrSpec.spec
     describe "RenderRoute instance" $ do
         it "renders root correctly" $ renderRoute RootR @?= ([], [])
         it "renders blog post correctly" $ renderRoute (BlogPostR $ Text.pack "foo") @?= (map Text.pack ["blog", "foo"], [])

--- a/yesod-core/test/YesodCoreTest/RenderRouteSpec.hs
+++ b/yesod-core/test/YesodCoreTest/RenderRouteSpec.hs
@@ -17,7 +17,7 @@ import Test.Hspec
 do
     let int = ConT ''Int
     (clauses, names) <- mkRenderRouteClauses
-        [ ResourceParent "FirstR" False [Static "first", Dynamic int]
+        [ ResourceParent "FirstR" False mempty [Static "first", Dynamic int]
             [ ResourceLeaf Resource
                 { resourceName = "BlahR"
                 , resourcePieces = [Static "blah"]
@@ -52,7 +52,7 @@ do
         parentName = mkName "parent"
     (clauses, names) <- mkRenderRouteNestedClauses
         [Left "hello", Right parentName]
-        [ ResourceParent "FirstR" False [Static "first", Dynamic int]
+        [ ResourceParent "FirstR" False mempty [Static "first", Dynamic int]
             [ ResourceLeaf Resource
                 { resourceName = "BlahR"
                 , resourcePieces = [Static "blah"]
@@ -150,7 +150,7 @@ data App = App
 do
     let int = ConT ''Int
     mkRenderRouteInstanceOpts defaultOpts [] [] (ConT (mkName "App"))
-            [ ResourceParent "FirstR" False [Static "first", Dynamic int]
+            [ ResourceParent "FirstR" False mempty [Static "first", Dynamic int]
                 [ ResourceLeaf Resource
                     { resourceName = "BlahR"
                     , resourcePieces = [Static "blah"]

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -137,6 +137,7 @@ test-suite test-routes
                    Yesod.Routes.TH.Internal
                    Route.FallthroughSpec
                    Route.RenderRouteSpec
+                   Route.RouteAttrSpec
 
     -- Workaround for: http://ghc.haskell.org/trac/ghc/ticket/8443
     other-extensions:      TemplateHaskell

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -178,6 +178,7 @@ test-suite test-routes
                  , template-haskell
                  , text
                  , th-abstraction
+                 , th-lift-instances
                  , time
                  , transformers
                  , unix-compat
@@ -306,6 +307,7 @@ test-suite tests
                   , wai-extra
                   , warp
                   , yesod-core
+                  , th-lift-instances
     ghc-options:     -Wall -threaded
     other-extensions: TemplateHaskell
 

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -56,6 +56,7 @@ library
                    , shakespeare           >= 2.0
                    , template-haskell      >= 2.13
                    , text                  >= 0.7
+                   , th-lift-instances     >= 0.1
                    , time                  >= 1.5
                    , transformers          >= 0.4
                    , unix-compat


### PR DESCRIPTION
Currently, `resourceAttrs` only end up in `ResourceLeaf`. However, if you want to know the attributes at a current `ResourceParent` level this isn't as useful.

In this PR, I add the attributes directly to `ResourceParent` so you can make decisions about attributes while processing a parent.

Use case, at work, we want to nest routes under another route. To do this, imagine the following route structure

```
/admin AdminR:
  -- lots of routes here
  /foo/bar FooBarR POST
  /foo//baz FooBazR POST
```

We have a bunch of existing type generation which handles this fine. However, if I want to introduce nesting e.g.

```
/admin AdminR:
  -- lots of routes here
  /foo AdminFooR !doNotInclude: 
    /bar FooBarR POST
    /baz FooBazR POST
```

I want to avoid adding `AdminFoo` to names because we've already generated names. However, this becomes a problem when you need multiple levels of nesting because you'll get two `["doNotInclude", "doNotInclude"]` but I can't know which route they are apart of.


Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddocks for new, public APIs

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
