### PR TITLE
Compatibility of yesod-static with crypton-1.1.

### DIFF
--- a/stack-lts-22.yaml
+++ b/stack-lts-22.yaml
@@ -19,6 +19,7 @@ extra-deps:
   - attoparsec-aeson-2.1.0.0
   - crypton-1.0.0
   - crypton-conduit-0.2.3
+  - ram-0.22.0
   - encoding-0.10.2
   # th-compat entered Stackage after lts-18; needed for the CI legs that
   # reuse this file with --resolver lts-16 / lts-18

--- a/yesod-static/Yesod/Static.hs
+++ b/yesod-static/Yesod/Static.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE PackageImports #-}
 ---------------------------------------------------------
 --
 -- | Serve static files from a Yesod app.
@@ -79,7 +80,11 @@ import Crypto.Hash.Conduit (hashFile, sinkHash)
 import Crypto.Hash (MD5, Digest)
 import Control.Monad.Trans.State
 
-import qualified Data.ByteArray as ByteArray
+#if MIN_VERSION_crypton(1,1,0)
+import qualified "ram" Data.ByteArray as ByteArray
+#else
+import qualified "memory" Data.ByteArray as ByteArray
+#endif
 import qualified Data.ByteString.Base64
 import qualified Data.ByteString.Char8 as S8
 import qualified Data.ByteString.Lazy as L

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -46,6 +46,7 @@ library
                    , hjsmin
                    , http-types            >= 0.7
                    , memory
+                   , ram                   >= 0.21 && < 0.22
                    , mime-types            >= 0.1
                    , process
                    , template-haskell

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -108,6 +108,7 @@ test-suite tests
                    , hjsmin
                    , http-types
                    , memory
+                   , ram
                    , mime-types
                    , process
                    , template-haskell

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -46,7 +46,7 @@ library
                    , hjsmin
                    , http-types            >= 0.7
                    , memory
-                   , ram                   >= 0.21 && < 0.22
+                   , ram                   >= 0.21 && < 0.23
                    , mime-types            >= 0.1
                    , process
                    , template-haskell

--- a/yesod-static/yesod-static.cabal
+++ b/yesod-static/yesod-static.cabal
@@ -1,5 +1,5 @@
 name:            yesod-static
-version:         1.6.1.3
+version:         1.6.1.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
The `crypton` package [has switched]((https://github.com/kazu-yamamoto/crypton/commit/7912865682ad497edc04dae00ed215d8948ada30)) from `memory` to its fork [`ram`](https://hackage-content.haskell.org/package/ram-0.21.1). `yesod-static` still imported `Data.ByteArray` from `memory` though, leading to a confusing error about a missing instance of `ByteArrayAccess (Digest MD5)`, because `ByteArrayAccess` came [from `memory`](https://hackage.haskell.org/package/memory-0.17.0/docs/Data-ByteArray.html#t:ByteArrayAccess) but `crypton` only defines an instance of [the `ram` version](https://hackage-content.haskell.org/package/ram-0.21.1/docs/Data-ByteArray.html#t:ByteArrayAccess) of `ByteArrayAccess`.

Note: I haven't checked the `ram` package very closely to see whether the switch is actually a good idea. An alternative would be to define the instances elsewhere. But the argument of `ram` is that `memory` is now unsupported, so switching to another package is perhaps unavoidable in the long term.

Haven't bumped any versions or changelog, not sure that's applicable for a change like this?