### PR TITLE
yesod-newsfeed/yesod-sitemap: bump cabal-version to >=1.10

### DIFF
--- a/yesod-newsfeed/yesod-newsfeed.cabal
+++ b/yesod-newsfeed/yesod-newsfeed.cabal
@@ -7,7 +7,7 @@ maintainer:      Michael Snoyman <michael@snoyman.com>
 synopsis:        Helper functions and data types for producing News feeds.
 category:        Web, Yesod
 stability:       Stable
-cabal-version:   >= 1.8
+cabal-version:   >= 1.10
 build-type:      Simple
 homepage:        http://www.yesodweb.com/
 description:     API docs and the README are available at <http://www.stackage.org/package/yesod-newsfeed>
@@ -30,6 +30,7 @@ library
                    , Yesod.Feed
     other-modules:   Yesod.FeedTypes
     ghc-options:     -Wall
+    default-language: Haskell2010
 
 source-repository head
   type:     git

--- a/yesod-sitemap/yesod-sitemap.cabal
+++ b/yesod-sitemap/yesod-sitemap.cabal
@@ -7,7 +7,7 @@ maintainer:      Michael Snoyman <michael@snoyman.com>
 synopsis:        Generate XML sitemaps.
 category:        Web, Yesod
 stability:       Stable
-cabal-version:   >= 1.8
+cabal-version:   >= 1.10
 build-type:      Simple
 homepage:        http://www.yesodweb.com/
 description:     API docs and the README are available at <http://www.stackage.org/package/yesod-sitemap>
@@ -24,6 +24,7 @@ library
                    , yesod-core                >= 1.6      && < 1.8
     exposed-modules: Yesod.Sitemap
     ghc-options:     -Wall
+    default-language: Haskell2010
 
 source-repository head
   type:     git


### PR DESCRIPTION
## What

Bumps `cabal-version` from `>= 1.8` to `>= 1.10` in `yesod-newsfeed` and `yesod-sitemap`, and adds `default-language: Haskell2010` to each library stanza (required once `cabal-version >= 1.10`).

## Why

Hackage rejects new uploads of these two packages outright — the `cabal-version: >= 1.8` declaration fails the package-format check *before* authentication:

> Error: Invalid package — 'cabal-version' must be at least 1.10

This surfaced while cutting the current round of releases: the other 12 packages uploaded fine, but `yesod-newsfeed 1.7.0.1` and `yesod-sitemap 1.6.0.1` couldn't be packaged at all until this was fixed. (Those two are additionally blocked on Hackage maintainer access for the uploader, tracked separately — this PR is the prerequisite packaging fix so they're uploadable by anyone authorized.)

## Scope

Packaging metadata only; no code or dependency-bound changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)