### PR TITLE
yesod-core: compute max-expires per call instead of a 24h worker thread

### DIFF
--- a/yesod-core/ChangeLog.md
+++ b/yesod-core/ChangeLog.md
@@ -1,5 +1,14 @@
 # ChangeLog for yesod-core
 
+## 1.7.0.1
+
+* `getGetMaxExpires` now recomputes the max-expires timestamp on each call
+  instead of caching it behind a `mkAutoUpdate` worker on a 24-hour refresh
+  cycle. The worker, once started, lingered for up to a day after its last
+  use, so building a `YesodRunnerEnv` per request (as test harnesses do)
+  could pile up dormant worker threads. The value is a single `formatTime`,
+  so recomputing is cheap and thread-free. No API changes.
+
 ## 1.7.0.0
 
 * Split route compilation ([#1887](https://github.com/yesodweb/yesod/pull/1887), [guide](https://github.com/yesodweb/yesod/blob/master/yesod-core/docs/split-route-compilation.md)):

--- a/yesod-core/src/Yesod/Core/Dispatch.hs
+++ b/yesod-core/src/Yesod/Core/Dispatch.hs
@@ -104,7 +104,6 @@ import Yesod.Core.Class.Dispatch
 import Text.Read (readMaybe)
 import System.Environment (getEnvironment)
 import System.Entropy (getEntropy)
-import Control.AutoUpdate (mkAutoUpdate, defaultUpdateSettings, updateAction, updateFreq)
 import Yesod.Core.Internal.Util (getCurrentMaxExpiresRFC1123)
 import Yesod.Core.Class.Dispatch.ToParentRoute
 
@@ -340,9 +339,14 @@ warpEnv site = do
 -- | Default constructor for 'yreGetMaxExpires' field. Low level
 -- function for simple manual construction of 'YesodRunnerEnv'.
 --
+-- The returned action recomputes the value (a far-future RFC1123
+-- timestamp) on each call. It previously cached the value behind a
+-- @mkAutoUpdate@ worker thread on a 24-hour refresh cycle; that thread,
+-- once started, would linger for up to a day after its last use, so
+-- constructing a 'YesodRunnerEnv' per request (as test harnesses do) could
+-- pile up dormant worker threads. Recomputing is a single 'formatTime' and
+-- avoids the thread entirely; 'runFakeHandler' already does this.
+--
 -- @since 1.4.29
 getGetMaxExpires :: IO (IO Text)
-getGetMaxExpires = mkAutoUpdate defaultUpdateSettings
-  { updateAction = getCurrentMaxExpiresRFC1123
-  , updateFreq = 24 * 60 * 60 * 1000000 -- Update once per day
-  }
+getGetMaxExpires = pure getCurrentMaxExpiresRFC1123

--- a/yesod-core/yesod-core.cabal
+++ b/yesod-core/yesod-core.cabal
@@ -1,5 +1,5 @@
 name:            yesod-core
-version:         1.7.0.0
+version:         1.7.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
## Summary

`getGetMaxExpires` cached its value behind a `mkAutoUpdate` worker on a **24-hour** refresh cycle. Because the refresh interval is a full day, the worker thread lingers for up to 24h after its last use before it can notice it's idle and exit.

Constructing a `YesodRunnerEnv` per request — which test harnesses like [`hspec-yesod`](https://github.com/parsonsmatt/hspec-yesod) do — therefore accumulates dormant worker threads proportional to the request count. (The session date cacher and logger time cache don't have this problem: their `mkAutoUpdate` workers self-terminate quickly because their refresh intervals are seconds, which is also why `clientSessionDateCacher`'s "closer" is already a documented no-op.)

The cached value is just `formatTime` of `now + 1 year` — a single cheap call. Caching it behind a thread is a premature optimization; `runFakeHandler` already computes it inline. This PR recomputes it on each call and drops the worker entirely.

```haskell
getGetMaxExpires :: IO (IO Text)
getGetMaxExpires = pure getCurrentMaxExpiresRFC1123   -- was: mkAutoUpdate { ...updateFreq = 24h... }
```

## Compatibility

**No API changes** — patch release (`1.7.0.0` → `1.7.0.1`):

- `getGetMaxExpires :: IO (IO Text)` — signature unchanged.
- `yreGetMaxExpires` field — unchanged.
- Both `YesodRunnerEnv` construction sites (`mkYesodRunnerEnv`, `toWaiAppLogger`) and any direct caller benefit automatically.
- Only other change: dropped the now-unused `Control.AutoUpdate` import in `Dispatch.hs` (the dependency stays — `clientSessionDateCacher` still uses it).

Behavior change: the max-expires timestamp now advances continuously instead of jumping once per day. It's a far-future (`+1yr`) value used for cache/expiry headers, so this has no practical effect.

## Testing

`cabal build yesod-core` compiles clean. This unblocks per-request `YesodRunnerEnv` construction in test harnesses without leaking worker threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
