### PR TITLE
Fix parseRoutes brace-token comment, document TH-stage split requirement

### DIFF
--- a/yesod-core/docs/split-route-compilation.md
+++ b/yesod-core/docs/split-route-compilation.md
@@ -190,6 +190,33 @@ like `data MySub a`), `mkYesodSubDispatchInstance "(MyClass a) => MySub a"
 resourcesMySub` generates the `YesodSubDispatch` and nested instances in one
 splice.
 
+## When the subsite split is required, not optional
+
+Everything above presents the Data/Dispatch split as an organizational choice.
+It stops being optional once a *parameterized* subsite mounts a *different*
+subsite inside its own route tree — a subsite leaf nested under a
+`ResourceParent`, not just a further nested route group of the same subsite.
+
+`mkYesodSubData` generates the subsite's route datatype and its `resources*` value
+(a `[ResourceTree String]`) in one splice. Turning that value into dispatch
+code — `mkYesodSubDispatch`, `mkNestedSubDispatchInstance` — is a *second*
+splice. GHC's stage restriction won't let a top-level splice consume a name
+that a different splice produced earlier in the same module; that name has to
+come from an already-compiled module instead. `mkYesodSubDispatchInstance`
+gets around this by generating the `YesodSubDispatch` and nested instances in
+one splice, which is why it can keep a parameterized subsite's own dispatch in
+a single module —
+but it only covers that one subsite's own nested route groups. A mounted child
+subsite needs its own `mkYesodSubData` and its own `YesodSubDispatch`
+instance, and the parent's `resources*` value then has to cross a module
+boundary to reach the splice that dispatches into it.
+
+`yesod-core`'s test suite has a worked example of exactly this shape:
+`YesodCoreTest.ParameterizedSubDispatchRuntime.Data` generates a parameterized
+subsite (`BigSub a`) that mounts a second, unparameterized subsite (`ChildSub`)
+as a leaf, and `YesodCoreTest.ParameterizedSubDispatchRuntime` is the separate,
+already-compiled module that dispatches both.
+
 ## Linking to nested routes
 
 A nested fragment constructor isn't a `Route App` on its own — its parent may
@@ -254,3 +281,12 @@ fallthrough.
   `OVERLAPPABLE`, so a *more specific* hand-written instance wins, but a
   hand-written instance with the identical head is still a duplicate-instance
   error.
+* **`GHC stage restriction: 'resourcesFoo' is used in a top-level splice,
+  quasi-quote, or annotation, and must be imported, not defined locally`** —
+  a `mkYesodSubData`-generated `resources*` value is being consumed by another
+  splice (`mkYesodSubDispatch`, `mkNestedSubDispatchInstance`) in the same
+  module. Move the consuming splice to a separate, already-compiled module
+  that imports the `resources*` binding (see [When the subsite split is
+  required, not optional](#when-the-subsite-split-is-required-not-optional)),
+  or, if the subsite mounts no child subsite, replace both splices with a
+  single `mkYesodSubDispatchInstance` call.

--- a/yesod-core/test/YesodCoreTest/ParameterizedSubDispatchRuntime.hs
+++ b/yesod-core/test/YesodCoreTest/ParameterizedSubDispatchRuntime.hs
@@ -49,8 +49,18 @@ instance ParamSubsiteClass ConcreteSub App where
     type AssocType ConcreteSub = Text
     getSubsiteValue _ _ = "concrete"
 
--- | parseRoutes can only embed a single-token subsite type, so we alias the
--- fully-applied subsites here.
+-- | 'parseRoutes' can embed a subsite type directly via the @{...}@ brace
+-- syntax, and a brace token isn't limited to a single identifier: it accepts
+-- any fully-applied type expression, e.g. @{ParamSubsite ConcreteSub}@ —
+-- 'parseTypeTree' (in "Yesod.Routes.Parse") parses what's inside the braces
+-- the same way it parses any other route-piece type. So 'ConcreteParamSub'
+-- below isn't strictly needed; it's kept because the alias is reused in
+-- several type signatures further down, which reads better than repeating
+-- the braced application everywhere. 'ConcreteBigSub', on the other hand,
+-- *is* needed: its underlying type is the bare unit type @()@, and
+-- 'parseTypeTree' can't parse @()@ as a token on its own (it has no leading
+-- identifier to anchor on), so it has to be hidden behind an alias before it
+-- can appear in a route.
 type ConcreteParamSub = ParamSubsite ConcreteSub
 type ConcreteBigSub = BigSub ()
 


### PR DESCRIPTION
## What

- Corrects an inaccurate comment in `YesodCoreTest/ParameterizedSubDispatchRuntime.hs` claiming that `parseRoutes`'s `{...}` brace token only accepts single-token subsite types. It actually accepts any fully-applied type expression (e.g. `{ParamSubsite ConcreteSub}`), verified against `Yesod.Routes.Parse.parseTypeTree`.
- Documents a previously-unstated GHC TH stage-restriction constraint in `docs/split-route-compilation.md`: splitting a subsite's Data module (`mkYesodSubData`) from its Dispatch module (`mkYesodSubDispatch`) into separately-compiled modules becomes mandatory — not just organizational — once a parameterized subsite mounts a *different* subsite as a leaf in its own route tree. Adds a matching Troubleshooting entry quoting the actual GHC error text.

## Why

While working with parameterized subsites, I'd been declaring `type` synonyms just so `{...}` would have a single identifier to point at. Discovering that brace tokens actually accept any fully-applied type expression directly was a nice simplification — turns out a synonym is only needed when the target type can't be written as a bare applied expression (e.g. it involves a unit type like `()`). Working through that also surfaced that the existing comment didn't reflect this, and that the related Data/Dispatch split requirement wasn't documented anywhere, even though `yesod-core`'s own test suite already has a worked example of exactly this shape.

## Testing

No code changes — comment and documentation only. Verified via `stack build yesod-core` (exit 0) that the touched files still compile cleanly.
