### PR TITLE
Break yesod-form/yesod-test test dependency cycle

### DIFF
--- a/yesod-form/ChangeLog.md
+++ b/yesod-form/ChangeLog.md
@@ -1,5 +1,13 @@
 # ChangeLog for yesod-form
 
+## 1.7.10.1
+
+* Move the `runFormPRG` integration tests to yesod-test's test suite,
+  removing yesod-form's test-suite dependency on yesod-test. That
+  dependency created a package-level cycle
+  (yesod-test → yesod-form → yesod-test) which broke the Stackage
+  build plan. [#1928](https://github.com/yesodweb/yesod/issues/1928)
+
 ## 1.7.10
 
 * Add `runFormPRG`, a `runFormPost` variant for the

--- a/yesod-form/test/main.hs
+++ b/yesod-form/test/main.hs
@@ -6,11 +6,8 @@ import Data.Text (pack)
 import Yesod.Form.Fields (parseTime)
 import Yesod.Form.Types
 
-import qualified PRGSpec
-
 main :: IO ()
 main = hspec $ do
-    PRGSpec.spec
     describe "parseTime" $ mapM_ (\(s, e) -> it s $ parseTime (pack s) `shouldBe` e)
         [ ("01:00:00", Right $ TimeOfDay 1 0 0)
         , ("1:00", Right $ TimeOfDay 1 0 0)

--- a/yesod-form/yesod-form.cabal
+++ b/yesod-form/yesod-form.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            yesod-form
-version:         1.7.10
+version:         1.7.10.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -77,18 +77,11 @@ test-suite test
     type: exitcode-stdio-1.0
     main-is: main.hs
     hs-source-dirs: test
-    other-modules: PRGSpec
     build-depends:          base
                           , yesod-form
                           , time
                           , hspec
                           , text
-                          , bytestring
-                          , clientsession
-                          , containers
-                          , wai-extra
-                          , yesod-core            >= 1.6
-                          , yesod-test            >= 1.6
 
 source-repository head
   type:     git

--- a/yesod-test/ChangeLog.md
+++ b/yesod-test/ChangeLog.md
@@ -1,5 +1,12 @@
 # ChangeLog for yesod-test
 
+## 1.7.0.3
+
+* Adopt the `runFormPRG` integration tests from yesod-form's test
+  suite, whose yesod-test dependency created a package-level cycle
+  that broke the Stackage build plan. No library changes.
+  [#1928](https://github.com/yesodweb/yesod/issues/1928)
+
 ## 1.7.0.2
 
 * Support `yesod-core` 1.7

--- a/yesod-test/test/PRGSpec.hs
+++ b/yesod-test/test/PRGSpec.hs
@@ -6,7 +6,12 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE ViewPatterns          #-}
 
--- | Integration tests for 'runFormPRG'.
+-- | Integration tests for yesod-form's 'runFormPRG'.
+--
+-- These live in yesod-test rather than yesod-form: a yesod-test
+-- dependency in yesod-form's test suite creates a package-level
+-- dependency cycle that Stackage's build planner rejects, see
+-- <https://github.com/yesodweb/yesod/issues/1928>.
 module PRGSpec (spec) where
 
 import qualified Data.ByteString.Lazy as BL

--- a/yesod-test/test/main.hs
+++ b/yesod-test/test/main.hs
@@ -48,6 +48,8 @@ import qualified Data.ByteString.Char8 as B8
 import Yesod.Test.Internal (contentTypeHeaderIsUtf8)
 import Data.Foldable (traverse_)
 
+import qualified PRGSpec
+
 parseQuery_ :: Text -> [[SelectorGroup]]
 parseQuery_ = either error id . parseQuery
 
@@ -69,6 +71,7 @@ mkYesod "RoutedApp" [parseRoutes|
 
 main :: IO ()
 main = hspec $ do
+    PRGSpec.spec
     describe "CSS selector parsing" $ do
         it "elements" $ parseQuery_ "strong" @?= [[DeepChildren [ByTagName "strong"]]]
         it "child elements" $ parseQuery_ "strong > i" @?= [[DeepChildren [ByTagName "strong"], DirectChildren [ByTagName "i"]]]

--- a/yesod-test/yesod-test.cabal
+++ b/yesod-test/yesod-test.cabal
@@ -1,5 +1,5 @@
 name:               yesod-test
-version:            1.7.0.2
+version:            1.7.0.3
 license:            MIT
 license-file:       LICENSE
 author:             Nubis <nubis@woobiz.com.ar>
@@ -66,9 +66,11 @@ test-suite test
   type:             exitcode-stdio-1.0
   main-is:          main.hs
   hs-source-dirs:   test
+  other-modules:    PRGSpec
   build-depends:
       base
     , bytestring
+    , clientsession
     , containers
     , cookie
     , hspec


### PR DESCRIPTION
Fixes #1928.

yesod-form-1.7.10 made its test suite depend on yesod-test for the `runFormPRG` integration tests. Cabal accepts this because its solver works per-component, but Stackage checks for cycles at the package level with test suites enabled, and yesod-test's own test suite already depended on yesod-form — hence the cycle reported by the Stackage curator.

This PR:

* Moves the `runFormPRG` integration tests to yesod-test's test suite, which already depended on yesod-form, so no new dependency edge is introduced. A module comment explains why they live there.
* Restores yesod-form's test suite to its pre-1.7.10 dependencies.
* Bumps yesod-form to 1.7.10.1. The fix needs a new Hackage upload, since a metadata revision cannot remove a dependency.
* Bumps yesod-test to 1.7.0.3, which merely carries the relocated tests along and is not urgent to release.